### PR TITLE
Implement terminal cursor blinking functionality

### DIFF
--- a/kernel/graphics/font.hpp
+++ b/kernel/graphics/font.hpp
@@ -11,6 +11,7 @@ public:
 	const uint8_t* get_font(char c);
 	int width() const { return width_; }
 	int height() const { return height_; }
+	Point2D size() const { return { width_, height_ }; }
 
 private:
 	const uint8_t* font_data_;

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -8,7 +8,6 @@
  * operations such as printing strings, formatted text, handling user commands,
  * and displaying system messages. Also includes functionality to clear the
  * screen, scroll through the terminal history, and manage user input.
-
  *
  */
 
@@ -16,7 +15,8 @@
 
 #include "color.hpp"
 #include "font.hpp"
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 
 class terminal
 {
@@ -41,6 +41,8 @@ public:
 
 	void input_key(uint8_t c);
 
+	void cursor_blink();
+
 	void clear();
 
 private:
@@ -61,6 +63,7 @@ private:
 	Color font_color_;
 	Color user_name_color_;
 	char user_name_[16];
+	bool cursor_visible_{ false };
 };
 
 extern terminal* main_terminal;

--- a/kernel/interrupt/handler.cpp
+++ b/kernel/interrupt/handler.cpp
@@ -1,7 +1,9 @@
 #include "handler.hpp"
+#include "../system_event.hpp"
 #include "../system_event_queue.hpp"
 #include "../task/task_manager.hpp"
 #include "../timers/timer.hpp"
+#include <cstdint>
 
 namespace
 {
@@ -24,6 +26,6 @@ __attribute__((interrupt)) void TimerInterrupt(InterruptFrame* frame)
 
 __attribute__((interrupt)) void xhci_interrupt(InterruptFrame* frame)
 {
-	kevent_queue->queue(system_event{ system_event::XHCI });
+	kevent_queue->queue({ system_event::XHCI });
 	NotifyEndOfInterrupt();
 }

--- a/kernel/system_event.hpp
+++ b/kernel/system_event.hpp
@@ -14,8 +14,12 @@
 
 #include <cstdint>
 
+enum class action_type : uint8_t {
+	TERMINAL_CURSOR_BLINK,
+};
+
 struct system_event {
-	enum Type {
+	enum type : uint8_t {
 		EMPTY,
 		TIMER_TIMEOUT,
 		DRAW_SCREEN_TIMER,
@@ -30,6 +34,7 @@ struct system_event {
 			uint64_t timeout;
 			unsigned int period;
 			int periodical;
+			action_type action;
 		} timer;
 
 		struct {

--- a/kernel/system_event_queue.cpp
+++ b/kernel/system_event_queue.cpp
@@ -28,7 +28,7 @@ kernel_event_queue* kevent_queue;
 
 void initialize_system_event_queue() { kevent_queue = new kernel_event_queue(); }
 
-void handle_system_events()
+[[noreturn]] void handle_system_events()
 {
 	while (true) {
 		__asm__("cli");
@@ -40,7 +40,12 @@ void handle_system_events()
 		auto event = kevent_queue->dequeue();
 		switch (event.type_) {
 			case system_event::TIMER_TIMEOUT:
-				main_terminal->print("Timer timeout\n");
+				switch (event.args_.timer.action) {
+					case action_type::TERMINAL_CURSOR_BLINK:
+						main_terminal->cursor_blink();
+						break;
+				}
+
 				break;
 
 			case system_event::DRAW_SCREEN_TIMER:

--- a/kernel/system_event_queue.hpp
+++ b/kernel/system_event_queue.hpp
@@ -21,4 +21,4 @@ extern kernel_event_queue* kevent_queue;
 
 void initialize_system_event_queue();
 
-void handle_system_events();
+[[noreturn]] void handle_system_events();

--- a/kernel/timers/timer.hpp
+++ b/kernel/timers/timer.hpp
@@ -2,7 +2,6 @@
 
 #include "../system_event.hpp"
 #include <cstdint>
-#include <memory>
 #include <queue>
 #include <unordered_set>
 
@@ -13,6 +12,7 @@ inline bool operator<(const system_event& lhs, const system_event& rhs)
 
 static const int TIMER_FREQUENCY = 100;
 static const int SWITCH_TEXT_MILLISEC = 20;
+static const int CURSOR_BLINK_MILLISEC = 500;
 
 class kernel_timer
 {
@@ -26,9 +26,11 @@ public:
 		return static_cast<float>(tick) / TIMER_FREQUENCY;
 	}
 
-	uint64_t add_timer_event(unsigned long millisec);
+	uint64_t add_timer_event(unsigned long millisec, action_type type);
 
-	uint64_t add_periodic_timer_event(unsigned long millisec, uint64_t id = 0);
+	uint64_t add_periodic_timer_event(unsigned long millisec,
+									  action_type type,
+									  uint64_t id = 0);
 
 	void add_switch_task_event(unsigned long millisec);
 


### PR DESCRIPTION
The terminal cursor blinking feature has been enabled. This was achieved by making several changes in the system_event_queue, kernel_timer, and terminal classes. A new enumeration action_type was introduced to handle different timer action events. Changes also include ensuring that the cursor is correctly positioned and visible during screen updates and redraws.