### PR TITLE
Add command line interface and commands

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -83,7 +83,8 @@ add_subdirectory(timers)
 add_subdirectory(task)
 add_subdirectory(hardware)
 add_subdirectory(file_system)
+add_subdirectory(command_line)
 
 # Define the main target and link it with the necessary libraries.
 add_executable(UchosKernel ${SOURCE_FILES})
-target_link_libraries(UchosKernel c c++ c++abi m UchosGraphics UchosMemory UchosInterrupt UchosTimers UchosTask UchosHardware UchosFileSystem)
+target_link_libraries(UchosKernel c c++ c++abi m UchosGraphics UchosMemory UchosInterrupt UchosTimers UchosTask UchosHardware UchosFileSystem UchosCommandLine)

--- a/kernel/command_line/CMakeLists.txt
+++ b/kernel/command_line/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(COMMAND_LINE_SOURCE_FILES
+        commands.cpp
+        controller.cpp
+)
+
+add_library(UchosCommandLine ${COMMAND_LINE_SOURCE_FILES})

--- a/kernel/command_line/commands.cpp
+++ b/kernel/command_line/commands.cpp
@@ -1,0 +1,7 @@
+#include "commands.hpp"
+#include "graphics/terminal.hpp"
+
+namespace command_line
+{
+void ls(terminal& term, const char* path) { term.print("ls"); }
+} // namespace command_line

--- a/kernel/command_line/commands.hpp
+++ b/kernel/command_line/commands.hpp
@@ -1,0 +1,19 @@
+/*
+ * @file command_line/commands.hpp
+ *
+ * @brief Command line commands
+ *
+ * This file contains the declarations of command line functions.
+ * Currently, these functions are implemented in the kernel space as a temporary
+ * measure until a more robust system call mechanism is developed for user space.
+ *
+ */
+
+#pragma once
+
+class terminal;
+
+namespace command_line
+{
+void ls(terminal& term, const char* path);
+} // namespace command_line

--- a/kernel/command_line/controller.cpp
+++ b/kernel/command_line/controller.cpp
@@ -9,6 +9,10 @@ controller::controller() { memset(histories_, '\0', sizeof(histories_)); }
 
 void controller::process_command(const char* command, terminal& term)
 {
+	memcpy(histories_[history_write_index_], command, strlen(command));
+	history_write_index_ == MAX_HISTORY - 1 ? history_write_index_
+											: history_write_index_++;
+
 	if (strcmp(command, "ls") == 0) {
 		ls(term, "/");
 	} else {

--- a/kernel/command_line/controller.cpp
+++ b/kernel/command_line/controller.cpp
@@ -1,0 +1,19 @@
+#include "controller.hpp"
+#include "../graphics/terminal.hpp"
+#include "commands.hpp"
+#include <cstring>
+
+namespace command_line
+{
+controller::controller() { memset(histories_, '\0', sizeof(histories_)); }
+
+void controller::process_command(const char* command, terminal& term)
+{
+	if (strcmp(command, "ls") == 0) {
+		ls(term, "/");
+	} else {
+		term.printf("Command not found: %s", command);
+	}
+}
+
+} // namespace command_line

--- a/kernel/command_line/controller.hpp
+++ b/kernel/command_line/controller.hpp
@@ -26,7 +26,8 @@ private:
 	static const int MAX_HISTORY_LENGTH = 100;
 
 	char histories_[MAX_HISTORY][MAX_HISTORY_LENGTH];
-	int history_index{ 0 };
+	int history_write_index_{ 0 };
+	int history_read_index_{ 0 };
 };
 
 } // namespace command_line

--- a/kernel/command_line/controller.hpp
+++ b/kernel/command_line/controller.hpp
@@ -1,0 +1,32 @@
+/*
+ * @file command_line/controller.hpp
+ *
+ * @brief Command line controller
+ *
+ * This file contains the definition of the `controller` class,
+ * which is responsible for handling and processing command line inputs.
+ *
+ */
+
+#pragma once
+
+#include "../graphics/terminal.hpp"
+
+namespace command_line
+{
+class controller
+{
+public:
+	controller();
+
+	void process_command(const char* command, terminal& term);
+
+private:
+	static const int MAX_HISTORY = 10;
+	static const int MAX_HISTORY_LENGTH = 100;
+
+	char histories_[MAX_HISTORY][MAX_HISTORY_LENGTH];
+	int history_index{ 0 };
+};
+
+} // namespace command_line

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -18,6 +18,12 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <memory>
+
+namespace command_line
+{
+class controller;
+} // namespace command_line
 
 class terminal
 {
@@ -46,6 +52,8 @@ public:
 
 	void clear();
 
+	void initialize_command_line();
+
 private:
 	static int adjusted_x(int x) { return x * kfont->width() + START_X; }
 	static int adjusted_y(int y)
@@ -67,6 +75,8 @@ private:
 	Color user_name_color_;
 	char user_name_[16];
 	bool cursor_visible_{ false };
+
+	std::unique_ptr<command_line::controller> cl_ctrl_;
 };
 
 extern terminal* main_terminal;

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -67,6 +67,8 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	file_system::initialize_fat(volume_image);
 
+	main_terminal->initialize_command_line();
+
 	initialize_pci();
 
 	usb::xhci::initialize();


### PR DESCRIPTION
Implemented a basic command line interface by creating a new directory 'command_line' which includes 'controller.cpp' and 'commands.cpp'. These files define the command line controller to handle and process command line inputs and define some commands, starting with a basic 'ls' command. Also updated 'terminal.cpp' in 'graphics' directory to take command line input and process through the controller. The CMakeLists files were updated to include these new additions.