### PR TITLE
Implement directory view in command shell

### DIFF
--- a/kernel/command_line/commands.cpp
+++ b/kernel/command_line/commands.cpp
@@ -1,7 +1,37 @@
 #include "commands.hpp"
-#include "graphics/terminal.hpp"
+#include "../file_system/fat.hpp"
+#include "../graphics/terminal.hpp"
 
 namespace command_line
 {
-void ls(terminal& term, const char* path) { term.print("ls"); }
+void ls(terminal& term, const char* path)
+{
+	const auto entries_per_cluster =
+			file_system::bytes_per_cluster / sizeof(file_system::directory_entry);
+
+	while (file_system::boot_volume_image->root_cluster !=
+		   file_system::END_OF_CLUSTERCHAIN) {
+		auto* dir_entry = file_system::get_sector<file_system::directory_entry>(
+				file_system::boot_volume_image->root_cluster);
+
+		for (int i = 0; i < entries_per_cluster; i++) {
+			if (dir_entry[i].name[0] == 0x00) {
+				return;
+			}
+
+			if (dir_entry[i].name[0] == 0xE5) {
+				continue;
+			}
+
+			if (dir_entry[i].attribute == file_system::entry_attribute::LONG_NAME) {
+				continue;
+			}
+
+			char name[13];
+			file_system::read_dir_entry_name(dir_entry[i], name);
+
+			term.printf("%s\n", name);
+		}
+	}
+}
 } // namespace command_line

--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -1,4 +1,5 @@
 #include "fat.hpp"
+#include "cstring"
 #include <cstdint>
 
 namespace file_system
@@ -40,4 +41,27 @@ unsigned long next_cluster(unsigned long cluster_id)
 
 	return next;
 }
+
+void read_dir_entry_name(const directory_entry& entry, char* dest)
+{
+	char extention[5] = ".";
+
+	memcpy(dest, &entry.name[0], 8);
+	dest[8] = 0;
+
+	for (int i = 7; i >= 0 && dest[i] == 0x20; i--) {
+		dest[i] = 0;
+	}
+
+	memcpy(extention + 1, &entry.name[8], 3);
+	extention[4] = 0;
+	for (int i = 2; i >= 0 && extention[i + 1] == 0x20; i--) {
+		extention[i + 1] = 0;
+	}
+
+	if (extention[1] != 0) {
+		strcat(dest, extention);
+	}
+}
+
 } // namespace file_system

--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -60,7 +60,7 @@ void read_dir_entry_name(const directory_entry& entry, char* dest)
 	}
 
 	if (extention[1] != 0) {
-		strcat(dest, extention);
+		strlcat(dest, extention, 13);
 	}
 }
 

--- a/kernel/file_system/fat.hpp
+++ b/kernel/file_system/fat.hpp
@@ -94,6 +94,8 @@ T* get_sector(unsigned long cluster_id)
 
 unsigned long next_cluster(unsigned long cluster_id);
 
+void read_dir_entry_name(const directory_entry& entry, char* dest);
+
 void initialize_fat(void* volume_image);
 
 } // namespace file_system

--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -68,8 +68,6 @@ void terminal::error(const char* s)
 
 void terminal::input_key(uint8_t c)
 {
-	const uint8_t delete_key = 0x08;
-
 	if (c == '\n') {
 		char command[100];
 		memcpy(command, buffer_[cursor_y_], sizeof(buffer_[cursor_y_]));
@@ -87,6 +85,8 @@ void terminal::input_key(uint8_t c)
 
 		return;
 	}
+
+	const uint8_t delete_key = 0x08;
 
 	if (c != delete_key) {
 		printf("%c", c);


### PR DESCRIPTION
Upgraded the 'ls' command in the shell to properly display directory entries. This update includes integration with the file system functions, specifically the "read_dir_entry_name" method, which was added to read the directory entry name. This functionality enhances usability, enabling users to see the files and directories in their system clearly.