### PR TITLE
Implement 'cat' command and improve file name handling

### DIFF
--- a/kernel/command_line/commands.cpp
+++ b/kernel/command_line/commands.cpp
@@ -9,10 +9,10 @@ void ls(terminal& term, const char* path)
 	const auto entries_per_cluster =
 			file_system::bytes_per_cluster / sizeof(file_system::directory_entry);
 
-	while (file_system::boot_volume_image->root_cluster !=
-		   file_system::END_OF_CLUSTERCHAIN) {
-		auto* dir_entry = file_system::get_sector<file_system::directory_entry>(
-				file_system::boot_volume_image->root_cluster);
+	uint32_t cluster_id = file_system::boot_volume_image->root_cluster;
+	while (cluster_id != file_system::END_OF_CLUSTERCHAIN) {
+		auto* dir_entry =
+				file_system::get_sector<file_system::directory_entry>(cluster_id);
 
 		for (int i = 0; i < entries_per_cluster; i++) {
 			if (dir_entry[i].name[0] == 0x00) {
@@ -32,6 +32,33 @@ void ls(terminal& term, const char* path)
 
 			term.printf("%s\n", name);
 		}
+
+		cluster_id = file_system::next_cluster(cluster_id);
+	}
+}
+
+void cat(terminal& term, const char* file_name)
+{
+	auto* entry = file_system::find_directory_entry(file_name, 0);
+	if (entry == nullptr) {
+		term.printf("File not found: %s\n", file_name);
+		return;
+	}
+
+	auto cluster_id = entry->first_cluster();
+	auto remain_bytes = entry->file_size;
+
+	while (cluster_id != file_system::END_OF_CLUSTERCHAIN) {
+		auto* p = file_system::get_sector<char>(cluster_id);
+
+		int i = 0;
+		for (; i < file_system::bytes_per_cluster && i < remain_bytes; i++) {
+			term.printf("%c", *p);
+			++p;
+		}
+
+		remain_bytes -= i;
+		cluster_id = file_system::next_cluster(cluster_id);
 	}
 }
 } // namespace command_line

--- a/kernel/command_line/commands.hpp
+++ b/kernel/command_line/commands.hpp
@@ -16,4 +16,6 @@ class terminal;
 namespace command_line
 {
 void ls(terminal& term, const char* path);
+
+void cat(terminal& term, const char* file_name);
 } // namespace command_line

--- a/kernel/command_line/controller.cpp
+++ b/kernel/command_line/controller.cpp
@@ -15,6 +15,8 @@ void controller::process_command(const char* command, terminal& term)
 
 	if (strcmp(command, "ls") == 0) {
 		ls(term, "/");
+	} else if (strcmp(command, "cat") == 0) {
+		cat(term, "KERNEL.ELF");
 	} else {
 		term.printf("Command not found: %s", command);
 	}

--- a/kernel/file_system/fat.hpp
+++ b/kernel/file_system/fat.hpp
@@ -94,6 +94,8 @@ T* get_sector(unsigned long cluster_id)
 
 unsigned long next_cluster(unsigned long cluster_id);
 
+directory_entry* find_directory_entry(const char* name, unsigned long cluster_id);
+
 void read_dir_entry_name(const directory_entry& entry, char* dest);
 
 void initialize_fat(void* volume_image);


### PR DESCRIPTION
Introduced the 'cat' command for reading and printing file contents. Additionally, refined the file name handling in 'fat.cpp' by replacing `strcat` with `strlcat` and added a feature to find directory entries. This not only extends the functionality of command line operations but also enhances the safety by avoiding potential buffer overflow.