### PR TITLE
Add ELF support and argument parsing to file execution

### DIFF
--- a/kernel/command_line/controller.cpp
+++ b/kernel/command_line/controller.cpp
@@ -14,19 +14,34 @@ void controller::process_command(const char* command, terminal& term)
 	history_write_index_ == MAX_HISTORY - 1 ? history_write_index_
 											: history_write_index_++;
 
-	if (strcmp(command, "ls") == 0) {
-		ls(term, "/");
-	} else if (strcmp(command, "cat") == 0) {
-		cat(term, "KERNEL.ELF");
-	} else {
-		auto* entry = file_system::find_directory_entry(command, 0);
-		if (entry != nullptr) {
-			file_system::execute_file(*entry);
-			return;
-		}
-
-		term.printf("Command not found: %s", command);
+	const char* args = strchr(command, ' ');
+	int command_length = strlen(command);
+	if (args != nullptr) {
+		command_length = args - command;
+		++args;
 	}
+	char command_name[command_length + 1];
+	memcpy(command_name, command, command_length);
+	command_name[command_length] = '\0';
+
+	if (strcmp(command_name, "ls") == 0) {
+		ls(term, "/");
+		return;
+	}
+
+	if (strcmp(command_name, "cat") == 0) {
+		cat(term, "KERNEL.ELF");
+		return;
+	}
+
+	auto* entry = file_system::find_directory_entry(command_name, 0);
+	if (entry != nullptr) {
+		const int status = file_system::execute_file(*entry, args);
+		term.printf("Command exited with status %d", status);
+		return;
+	}
+
+	term.printf("Command not found: %s", command_name);
 }
 
 } // namespace command_line

--- a/kernel/file_system/elf.hpp
+++ b/kernel/file_system/elf.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+
+typedef uintptr_t elf64_addr_t;
+typedef uint64_t elf64_off_t;
+typedef uint16_t elf64_half_t;
+typedef uint32_t elf64_word_t;
+typedef int32_t elf64_sword_t;
+typedef uint64_t elf64_xword_t;
+typedef int64_t elf64_sxword_t;
+
+#define EI_NIDENT 16
+
+typedef struct {
+	unsigned char e_ident[EI_NIDENT];
+	elf64_half_t e_type;
+	elf64_half_t e_machine;
+	elf64_word_t e_version;
+	elf64_addr_t e_entry;
+	elf64_off_t e_phoff;
+	elf64_off_t e_shoff;
+	elf64_word_t e_flags;
+	elf64_half_t e_ehsize;
+	elf64_half_t e_phentsize;
+	elf64_half_t e_phnum;
+	elf64_half_t e_shentsize;
+	elf64_half_t e_shnum;
+	elf64_half_t e_shstrndx;
+} elf64_ehdr_t;
+
+typedef struct {
+	elf64_word_t p_type;
+	elf64_word_t p_flags;
+	elf64_off_t p_offset;
+	elf64_addr_t p_vaddr;
+	elf64_addr_t p_paddr;
+	elf64_xword_t p_filesz;
+	elf64_xword_t p_memsz;
+	elf64_xword_t p_align;
+} elf64_phdr_t;
+
+#define PT_NULL 0
+#define PT_LOAD 1
+#define PT_DYNAMIC 2
+#define PT_INTERP 3
+#define PT_NOTE 4
+#define PT_SHLIB 5
+#define PT_PHDR 6
+#define PT_TLS 7
+
+typedef struct {
+	elf64_sxword_t d_tag;
+	union {
+		elf64_xword_t d_val;
+		elf64_addr_t d_ptr;
+	} d_un;
+} elf64_dyn_t;
+
+#define DT_NULL 0
+#define DT_RELA 7
+#define DT_RELASZ 8
+#define DT_RELAENT 9
+
+typedef struct {
+	elf64_addr_t r_offset;
+	elf64_xword_t r_info;
+	elf64_sxword_t r_addend;
+} elf64_rela_t;
+
+#define ELF64_R_SYM(i) ((i) >> 32)
+#define ELF64_R_TYPE(i) ((i) & 0xffffffffL)
+#define ELF64_R_INFO(s, t) (((s) << 32) + ((t) & 0xffffffffL))
+
+#define R_X86_64_RELATIVE 8

--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -171,7 +171,7 @@ int execute_file(const directory_entry& entry, const char* args)
 		return 0;
 	}
 
-	char* command_name = nullptr;
+	char command_name[13];
 	read_dir_entry_name(entry, command_name);
 	auto argv = make_args(command_name, const_cast<char*>(args));
 

--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -1,13 +1,46 @@
 #include "fat.hpp"
-#include "cstring"
+#include "elf.hpp"
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 namespace file_system
 {
 bios_parameter_block* boot_volume_image;
 unsigned long bytes_per_cluster;
+
+std::vector<char*> make_args(char* command, char* args)
+{
+	std::vector<char*> argv;
+	argv.push_back(command);
+
+	char* p = args;
+	while (true) {
+		while (*p == ' ') {
+			++p;
+		}
+
+		if (*p == '\0') {
+			break;
+		}
+
+		argv.push_back(p);
+
+		while (*p != ' ' && *p != '\0') {
+			++p;
+		}
+
+		if (*p == '\0') {
+			break;
+		}
+
+		*p = '\0';
+		++p;
+	}
+
+	return argv;
+}
 
 void read_dir_entry_name(const directory_entry& entry, char* dest)
 {
@@ -109,7 +142,7 @@ directory_entry* find_directory_entry(const char* name, unsigned long cluster_id
 	return nullptr;
 }
 
-void execute_file(const directory_entry& entry)
+int execute_file(const directory_entry& entry, const char* args)
 {
 	auto cluster_id = entry.first_cluster();
 	auto remain_bytes = static_cast<unsigned long>(entry.file_size);
@@ -127,9 +160,25 @@ void execute_file(const directory_entry& entry)
 		cluster_id = next_cluster(cluster_id);
 	}
 
-	using func_t = void (*)();
-	auto f = reinterpret_cast<func_t>(file_buffer.data());
-	f();
-}
+	auto* elf_header = reinterpret_cast<elf64_ehdr_t*>(file_buffer.data());
+	if (memcmp(elf_header->e_ident,
+			   "\x7f"
+			   "ELF",
+			   4) != 0) {
+		using func_t = void (*)();
+		auto f = reinterpret_cast<func_t>(file_buffer.data());
+		f();
+		return 0;
+	}
 
+	char* command_name = nullptr;
+	read_dir_entry_name(entry, command_name);
+	auto argv = make_args(command_name, const_cast<char*>(args));
+
+	auto entry_addr = elf_header->e_entry;
+	entry_addr += reinterpret_cast<uintptr_t>(file_buffer.data());
+	using func_t = int (*)(int, char**);
+	auto f = reinterpret_cast<func_t>(entry_addr);
+	return f(argv.size(), argv.data());
+}
 } // namespace file_system

--- a/kernel/file_system/fat.hpp
+++ b/kernel/file_system/fat.hpp
@@ -96,7 +96,7 @@ unsigned long next_cluster(unsigned long cluster_id);
 
 directory_entry* find_directory_entry(const char* name, unsigned long cluster_id);
 
-void execute_file(const directory_entry& entry);
+int execute_file(const directory_entry& entry, const char* args);
 
 void read_dir_entry_name(const directory_entry& entry, char* dest);
 


### PR DESCRIPTION
Updated file execution in FAT file system to support Executable and Linkable Format (ELF). Added argument parsing functionality to the execute_file function. This update allows passing of arguments to the executed file and execution of ELF formatted files. Also enhanced command handling and added 'cat' command in `controller.cpp`.