### PR TITLE
"Enhance interrupt error handling and add hex printing"

### DIFF
--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -66,6 +66,21 @@ void terminal::error(const char* s)
 	print("\n");
 }
 
+void terminal::print_interrupt_hex(uint64_t value)
+{
+	print("0x");
+
+	for (int i = 0; i < 16; ++i) {
+		char buf[2] = { '0', '\0' };
+		int x = (value >> (4 * (15 - i))) & 0xfU;
+		char c = x < 10 ? '0' + x : 'a' + x - 10;
+		buf[0] = c;
+		print(buf);
+	}
+	
+	print("\n");
+}
+
 void terminal::input_key(uint8_t c)
 {
 	if (c == '\n') {

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -46,6 +46,8 @@ public:
 
 	void error(const char* s);
 
+	void print_interrupt_hex(uint64_t value);
+
 	void input_key(uint8_t c);
 
 	void cursor_blink();

--- a/kernel/interrupt/handler.hpp
+++ b/kernel/interrupt/handler.hpp
@@ -21,13 +21,24 @@ void xhci_interrupt(InterruptFrame* frame);
 			InterruptFrame* frame, uint64_t code)                                   \
 	{                                                                               \
 		main_terminal->print(#error_code);                                          \
+		main_terminal->print("\n");                                                 \
+		main_terminal->print("RIP : ");                                             \
+		main_terminal->print_interrupt_hex(frame->rip);                             \
+		main_terminal->print("RSP : ");                                             \
+		main_terminal->print_interrupt_hex(frame->rsp);                             \
+		main_terminal->print("CS : ");                                              \
+		main_terminal->print_interrupt_hex(frame->cs);                              \
+		main_terminal->print("SS : ");                                              \
+		main_terminal->print_interrupt_hex(frame->ss);                              \
+		main_terminal->print("RFLAGS : ");                                          \
+		main_terminal->print_interrupt_hex(frame->rflags);                          \
 		while (true)                                                                \
 			__asm__("hlt");                                                         \
 	}
 
 #define FaultHandlerNoError(error_code)                                             \
 	inline __attribute__((interrupt)) void InterruptHandler##error_code(            \
-			InterruptFrame* frame)                                                  \
+			InterruptFrame* frame, uint64_t code)                                   \
 	{                                                                               \
 		main_terminal->print(#error_code);                                          \
 		while (1)                                                                   \


### PR DESCRIPTION
This commit enhances and expands the interrupt error handling to include printouts of key registers. It also introduces a method for printing hexadecimal values cleanly. These additions improve troubleshooting capabilities by providing more detailed information in the event of system interruptions.