### PR TITLE
Added null check to TimerInterrupt in handler.cpp

### DIFF
--- a/kernel/interrupt/handler.cpp
+++ b/kernel/interrupt/handler.cpp
@@ -16,6 +16,11 @@ namespace
 
 __attribute__((interrupt)) void TimerInterrupt(InterruptFrame* frame)
 {
+	if (ktimer == nullptr) {
+		NotifyEndOfInterrupt();
+		return;
+	}
+
 	const bool need_switch_task = ktimer->increment_tick();
 	NotifyEndOfInterrupt();
 


### PR DESCRIPTION
This commit adds a null check for the 'ktimer' in the TimerInterrupt function of handler.cpp. If 'ktimer' is null, it will now trigger the NotifyEndOfInterrupt function and return, thus ensuring a more robust error handling.