### PR TITLE
Refactor memory segment descriptors and expand GDT

### DIFF
--- a/kernel/memory/segment.cpp
+++ b/kernel/memory/segment.cpp
@@ -2,10 +2,11 @@
 #include "../graphics/terminal.hpp"
 #include "segments_operations.h"
 #include <array>
+#include <cstdint>
 
 namespace
 {
-std::array<segment_descriptor, 3> gdt;
+std::array<segment_descriptor, 5> gdt;
 } // namespace
 
 void set_code_segment(segment_descriptor& desc,
@@ -35,8 +36,10 @@ void set_data_segment(segment_descriptor& desc,
 void setup_segments()
 {
 	gdt[0].data = 0;
-	set_code_segment(gdt[1], descriptor_type::kExecuteRead, 0);
-	set_data_segment(gdt[2], descriptor_type::kReadWrite, 0);
+	set_code_segment(gdt[1], descriptor_type::EXECUTE_READ, 0);
+	set_data_segment(gdt[2], descriptor_type::READ_WRITE, 0);
+	set_code_segment(gdt[3], descriptor_type::EXECUTE_READ, 3);
+	set_data_segment(gdt[4], descriptor_type::READ_WRITE, 3);
 
 	load_gdt(sizeof(gdt) - 1, reinterpret_cast<uint64_t>(&gdt));
 }

--- a/kernel/memory/segment.hpp
+++ b/kernel/memory/segment.hpp
@@ -1,15 +1,26 @@
+/*
+ * @file memory/segment.hpp
+ *
+ * @brief segmentation
+ *
+ * This file contains definitions and functions for managing
+ * memory segments, particularly for setting up and handling
+ * segment descriptors in a low-level system context.
+ *
+ */
+
 #pragma once
 
 #include <cstdint>
 
 enum descriptor_type {
-	kUpper8Bytes = 0,
-	kLDT = 2,
-	kTSSAvailable = 9,
-	kTSSBusy = 11,
-	kCallGate = 12,
-	kReadWrite = 2,
-	kExecuteRead = 10,
+	UPPER_8_BYTES = 0,
+	LDT = 2,
+	TSS_AVAILABLE = 9,
+	TSS_BUSY = 11,
+	CALL_GATE = 12,
+	READ_WRITE = 2,
+	EXECUTE_READ = 10,
 };
 
 union segment_descriptor {


### PR DESCRIPTION
The memory segment descriptors have been refactored for readability by renaming enumeration values to upper case. The Global Descriptor Table (GDT) size has been increased from 3 to 5 to accommodate additional segment definitions. These changes enhance code readability and expand our system's capability for managing memory segments.