### PR TITLE
Add system call functionality and handler

### DIFF
--- a/kernel/syscall/CMakeLists.txt
+++ b/kernel/syscall/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(SYSCALL_SOURCE_FILES
+        entry.asm
+        handler.cpp
         syscall.cpp
 )
 

--- a/kernel/syscall/entry.asm
+++ b/kernel/syscall/entry.asm
@@ -1,0 +1,28 @@
+; System V AMD64 Calling Convention
+; Registers(args): RDI, RSI, RDX, RCX, R8, R9
+
+bits 64
+section .text
+
+extern handle_syscall
+
+global syscall_entry
+syscall_entry:
+    push rbp
+    push rcx ; save RIP
+    push r11 ; save RFLAGS
+
+    mov rcx, r10 ; 4th argument
+    mov r9, rax ; save syscall number in 6th argument
+
+    mov rbp, rsp
+    and rsp, 0xfffffffffffffff0 ; align stack to 16 bytes
+
+    call handle_syscall
+
+    mov rsp, rbp ; restore stack pointer
+
+    pop r11 ; restore RFLAGS
+    pop rcx ; restore RIP
+    pop rbp
+    o64 sysret

--- a/kernel/syscall/entry.h
+++ b/kernel/syscall/entry.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern "C" {
+void syscall_entry(void);
+}

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -1,0 +1,35 @@
+#include "../graphics/terminal.hpp"
+#include "../types.hpp"
+#include "syscall.hpp"
+#include <cstdint>
+
+namespace syscall
+{
+
+error_t sys_write(uint64_t arg1)
+{
+	const char* s = reinterpret_cast<const char*>(arg1);
+	main_terminal->printf("%s\n", s);
+
+	return OK;
+}
+
+extern "C" int64_t handle_syscall(uint64_t arg1,
+								  uint64_t arg2,
+								  uint64_t arg3,
+								  uint64_t arg4,
+								  uint64_t arg5,
+								  uint64_t syscall_number)
+{
+	switch (syscall_number) {
+		case SYS_WRITE:
+			sys_write(arg1);
+			break;
+		default:
+			main_terminal->errorf("Unknown syscall number: %d\n", syscall_number);
+			break;
+	}
+
+	return 0;
+}
+} // namespace syscall

--- a/kernel/syscall/syscall.cpp
+++ b/kernel/syscall/syscall.cpp
@@ -1,29 +1,20 @@
 #include "syscall.hpp"
 #include "../asm_utils.h"
+#include "../graphics/terminal.hpp"
 #include "../memory/segment.hpp"
 #include "../msr.hpp"
+#include "entry.h"
 #include <cstdint>
 
 namespace syscall
 {
-
-int64_t syscall_handler(uint64_t arg1,
-						uint64_t arg2,
-						uint64_t arg3,
-						uint64_t arg4,
-						uint64_t arg5,
-						uint64_t arg6)
-{
-	return 0;
-}
-
 void initialize()
 {
 	// Enable syscall/sysret
 	write_msr(IA32_EFER, 0x0501U);
 
 	// Set syscall/sysret entry point
-	write_msr(IA32_LSTAR, reinterpret_cast<uint64_t>(syscall_handler));
+	write_msr(IA32_LSTAR, reinterpret_cast<uint64_t>(syscall_entry));
 
 	// Set syscall/sysret CS and SS
 	write_msr(IA32_STAR, (static_cast<uint64_t>(KERNEL_CS) << 32) |

--- a/kernel/syscall/syscall.hpp
+++ b/kernel/syscall/syscall.hpp
@@ -3,11 +3,20 @@
  *
  * @brief system call
  *
+ * This file defines the interface and necessary constants for system calls
+ * in the operating system. System calls are the primary mechanism for user mode
+ * processes to request services from the kernel.
+ *
  */
 
 #pragma once
 
+#include <cstdint>
+
+// system call number
+#define SYS_WRITE 1
+
 namespace syscall
 {
 void initialize();
-}
+} // namespace syscall


### PR DESCRIPTION
System call functionality is added via 'syscall' module. The module includes files like 'entry.asm' and 'handler.cpp' for system call entry and handling. Besides code changes, makefile `CMakeLists.txt` has also been updated to compile the new source files. The mechanism in place enables system calls from user mode processes to request services from the kernel. System call handling is defined in `handler.cpp`, starting with the `SYS_WRITE` call.