### PR TITLE
Refine interrupt handling and memory segment initialization

### DIFF
--- a/kernel/interrupt/idt.cpp
+++ b/kernel/interrupt/idt.cpp
@@ -17,7 +17,6 @@ void set_idt_entry(idt_entry& entry,
 	entry.offset_middle = (offset >> 16) & 0xffffU;
 	entry.offset_high = offset >> 32;
 	entry.segment_selector = segment_selector;
-	entry.ist = 0;
 	entry.attr = attr;
 }
 
@@ -33,12 +32,12 @@ void initialize_interrupt()
 {
 	main_terminal->info("Initializing interrupt...");
 
-	auto set_entry = [](int irq, auto handler) {
+	auto set_entry = [](int irq, auto handler, uint16_t ist = 0) {
 		set_idt_entry(idt[irq], reinterpret_cast<uint64_t>(handler),
-					  type_attr{ gate_type::kInterruptGate, 0, 1 }, KERNEL_CS);
+					  type_attr{ ist, gate_type::kInterruptGate, 0, 1 }, KERNEL_CS);
 	};
 
-	set_entry(InterruptVector::kLocalApicTimer, on_timer_interrupt);
+	set_entry(InterruptVector::kLocalApicTimer, on_timer_interrupt, IST_FOR_TIMER);
 	set_entry(InterruptVector::kXHCI, on_xhci_interrupt);
 	set_entry(0, InterruptHandlerDE);
 	set_entry(1, InterruptHandlerDB);

--- a/kernel/interrupt/idt.hpp
+++ b/kernel/interrupt/idt.hpp
@@ -3,17 +3,24 @@
 #include <array>
 #include <cstdint>
 
-struct type_attr {
-	uint8_t type : 4;
-	uint8_t : 1;
-	uint8_t dpl : 2;
-	uint8_t present : 1;
+enum gate_type {
+	kTaskGate = 0x5,
+	kInterruptGate = 0xE,
+	kTrapGate = 0xF,
 };
+
+struct type_attr {
+	uint16_t interrupt_stack_table : 3;
+	uint16_t : 5;
+	uint16_t type : 4;
+	uint16_t : 1;
+	uint16_t dpl : 2;
+	uint16_t present : 1;
+} __attribute__((packed));
 
 struct idt_entry {
 	uint16_t offset_low;
 	uint16_t segment_selector;
-	uint8_t ist;
 	type_attr attr;
 	uint16_t offset_middle;
 	uint32_t offset_high;
@@ -27,10 +34,6 @@ struct idtr {
 	uint64_t base;
 } __attribute__((packed));
 
-enum gate_type {
-	kTaskGate = 0x5,
-	kInterruptGate = 0xE,
-	kTrapGate = 0xF,
-};
+const int IST_FOR_TIMER = 1;
 
 void initialize_interrupt();


### PR DESCRIPTION
This commit restructures and enhances interrupt and memory segment handling. It modifies IDT attributes and entries, introduces a new gate type enum for the IDT and adjusts the TSS initialization process. This includes splitting the initialization of TSS into separate functions for memory allocation, assigning TSS, and stack allocation. Furthermore, specified interrupt stack tables for kernel level entries were added. This enhances the system's resilience to different interrupt events as it provides more granularity in handling interruptions.