### PR TITLE
Update sys_write syscall for better argument handling

### DIFF
--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -1,15 +1,25 @@
 #include "../graphics/terminal.hpp"
 #include "../types.hpp"
 #include "syscall.hpp"
+#include <cerrno>
 #include <cstdint>
 
 namespace syscall
 {
 
-error_t sys_write(uint64_t arg1)
+error_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 {
-	const char* s = reinterpret_cast<const char*>(arg1);
-	main_terminal->printf("%s\n", s);
+	const auto fd = arg1;
+	const auto* buf = reinterpret_cast<const char*>(arg2);
+	const auto count = arg3;
+
+	if (count > 1024) {
+		return E2BIG;
+	}
+
+	if (fd == 1) {
+		main_terminal->print(buf);
+	}
 
 	return OK;
 }
@@ -23,7 +33,7 @@ extern "C" int64_t handle_syscall(uint64_t arg1,
 {
 	switch (syscall_number) {
 		case SYS_WRITE:
-			sys_write(arg1);
+			sys_write(arg1, arg2, arg3);
 			break;
 		default:
 			main_terminal->errorf("Unknown syscall number: %d\n", syscall_number);


### PR DESCRIPTION
This commit updates the sys_write system call to handle three arguments instead of one. The modification not only refines the argument handling but also adds a limit check for the input size. The syscall now treats the first argument as a file descriptor and writes the content pointed by the second argument. If the count (third argument) is greater than 1024, it will return an error.