### PR TITLE
Add convention comments to assembly files

### DIFF
--- a/kernel/asm_utils.asm
+++ b/kernel/asm_utils.asm
@@ -1,3 +1,8 @@
+; System V AMD64 Calling Convention
+; Registers(args): RDI, RSI, RDX, RCX, R8, R9
+; Caller-saved registers: RAX, RDI, RSI, RDX, RCX, R8, R9, R10, R11
+; Callee-saved registers: RBX, RBP, R12, R13, R14, R15
+
 bits 64
 section .text
 

--- a/kernel/interrupt/handler.asm
+++ b/kernel/interrupt/handler.asm
@@ -1,3 +1,8 @@
+; System V AMD64 Calling Convention
+; Registers(args): RDI, RSI, RDX, RCX, R8, R9
+; Caller-saved registers: RAX, RDI, RSI, RDX, RCX, R8, R9, R10, R11
+; Callee-saved registers: RBX, RBP, R12, R13, R14, R15
+
 bits 64
 section .text
 

--- a/kernel/memory/page_operations.asm
+++ b/kernel/memory/page_operations.asm
@@ -1,3 +1,8 @@
+; System V AMD64 Calling Convention
+; Registers(args): RDI, RSI, RDX, RCX, R8, R9
+; Caller-saved registers: RAX, RDI, RSI, RDX, RCX, R8, R9, R10, R11
+; Callee-saved registers: RBX, RBP, R12, R13, R14, R15
+
 bits 64
 section .text
 

--- a/kernel/syscall/entry.asm
+++ b/kernel/syscall/entry.asm
@@ -1,5 +1,7 @@
 ; System V AMD64 Calling Convention
 ; Registers(args): RDI, RSI, RDX, RCX, R8, R9
+; Caller-saved registers: RAX, RDI, RSI, RDX, RCX, R8, R9, R10, R11
+; Callee-saved registers: RBX, RBP, R12, R13, R14, R15
 
 bits 64
 section .text

--- a/kernel/task/context_switch.asm
+++ b/kernel/task/context_switch.asm
@@ -1,3 +1,8 @@
+; System V AMD64 Calling Convention
+; Registers(args): RDI, RSI, RDX, RCX, R8, R9
+; Caller-saved registers: RAX, RDI, RSI, RDX, RCX, R8, R9, R10, R11
+; Callee-saved registers: RBX, RBP, R12, R13, R14, R15
+
 bits 64
 section .text
 


### PR DESCRIPTION
This commit adds comments describing the System V AMD64 Calling Convention, including caller-saved and callee-saved registers, to multiple assembly files. This clarifies which registers are used and preserved across function calls, aiding in understanding and debugging of the assembly code.