### PR TITLE
Implement flash_tlb function for TLB flashing

### DIFF
--- a/kernel/memory/page_operations.asm
+++ b/kernel/memory/page_operations.asm
@@ -6,6 +6,11 @@
 bits 64
 section .text
 
+global flash_tlb ; void flash_tlb(uint64_t addr);
+flash_tlb:
+    invlpg [rdi]
+    ret
+
 global set_cr3 ; rdi = addr
 set_cr3:
     mov cr3, rdi

--- a/kernel/memory/page_operations.h
+++ b/kernel/memory/page_operations.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 
 extern "C" {
+void flash_tlb(uint64_t addr);
+
 void set_cr3(uint64_t addr);
 
 uint64_t get_cr3();

--- a/kernel/memory/paging.cpp
+++ b/kernel/memory/paging.cpp
@@ -142,7 +142,7 @@ void setup_page_tables(linear_address addr, size_t num_pages)
 		return;
 	}
 
-	__asm__ volatile("invlpg (%0)" ::"r"(addr) : "memory");
+	flash_tlb(addr.data);
 }
 
 void clean_page_table(page_table_entry* table, int page_table_level)


### PR DESCRIPTION
Implemented a new function, flash_tlb, which flashes the Translation Lookaside Buffer (TLB) in memory/page_operations.h. Also, refactored the assembly volatile code into a standalone flash_tlb function in page_operations.asm for better readability and maintainability.