### PR TITLE
Add ipc handling and error definitions for tasks

### DIFF
--- a/kernel/task/CMakeLists.txt
+++ b/kernel/task/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TASK_SOURCE_FILES
         context_switch.asm
         task.cpp
+        ipc.cpp
 )
 
 add_library(UchosTask ${TASK_SOURCE_FILES})

--- a/kernel/task/ipc.cpp
+++ b/kernel/task/ipc.cpp
@@ -1,0 +1,22 @@
+#include "ipc.hpp"
+#include "../graphics/terminal.hpp"
+#include "../types.hpp"
+#include "task.hpp"
+
+error_t send_message(task_t dst_id, const message* m)
+{
+	if (dst_id == -1 || dst_id == CURRENT_TASK->id) {
+		main_terminal->errorf("invalid destination task id: %d", dst_id);
+		return ERR_INVALID_ARG;
+	}
+
+	task* dst = tasks[dst_id];
+	if (dst == nullptr) {
+		main_terminal->errorf("task %d is not found", dst_id);
+		return ERR_INVALID_TASK;
+	}
+	
+	dst->messages.push(*m);
+
+	return OK;
+}

--- a/kernel/task/ipc.hpp
+++ b/kernel/task/ipc.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../types.hpp"
+#include <cstdint>
+
+#define NOTIFY_KEY_INPUT 1
+
+struct message {
+	int32_t type;
+	task_t sender;
+
+	union {
+		struct {
+			uint8_t key_code;
+			uint8_t modifier;
+		} key_input;
+	} data;
+};
+
+error_t send_message(task_t dst, const message* m);

--- a/kernel/types.hpp
+++ b/kernel/types.hpp
@@ -12,3 +12,5 @@ using task_t = int;
 #define IS_ERR(err) (((long)(err)) < 0)
 #define OK 0
 #define ERR_NO_MEMORY -1
+#define ERR_INVALID_ARG -2
+#define ERR_INVALID_TASK -3


### PR DESCRIPTION
Implemented the Inter-Process Communication (IPC) system for task handling, together with error definitions related to invalid tasks and arguments in the types file. New IPC related files, 'ipc.hpp' and 'ipc.cpp', were also included in the build system. The IPC system allows tasks to send messages to each other, which enhances the communications between different tasks.