### PR TITLE
Replace print functions with kernel logging function

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(
 
 # Add compile options for both C and C++.
 add_compile_options(
-        -O0
+        -Og
         -Wall
         -g
         --target=x86_64-elf

--- a/kernel/elf.cpp
+++ b/kernel/elf.cpp
@@ -2,6 +2,7 @@
 #include "graphics/terminal.hpp"
 #include "memory/page.hpp"
 #include "memory/paging.hpp"
+#include "types.hpp"
 #include <cstdint>
 
 elf64_phdr_t* get_program_header(elf64_ehdr_t* elf_header)
@@ -56,7 +57,7 @@ void load_elf(elf64_ehdr_t* elf_header)
 
 	const auto first_load_addr = get_first_load_addr(elf_header);
 	if (first_load_addr < 0xffff'8000'0000'0000) {
-		main_terminal->printf("invalid load address: %p\n", first_load_addr);
+		printk(KERN_ERROR, "invalid load address: %p", first_load_addr);
 		return;
 	}
 

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -98,3 +98,5 @@ private:
 extern terminal* main_terminal;
 void initialize_terminal();
 void task_terminal();
+
+void printk(int level, const char* format, ...);

--- a/kernel/hardware/pci.cpp
+++ b/kernel/hardware/pci.cpp
@@ -1,6 +1,7 @@
 #include "pci.hpp"
 #include "../asm_utils.h"
 #include "../graphics/terminal.hpp"
+#include "types.hpp"
 
 namespace pci
 {
@@ -237,7 +238,7 @@ void configure_msi(const device& dev,
 	}
 
 	if (msix_cap_addr != 0) {
-		main_terminal->error("MSI-X is not supported");
+		printk(KERN_ERROR, "MSI-X is not supported");
 	}
 }
 

--- a/kernel/hardware/usb/device.cpp
+++ b/kernel/hardware/usb/device.cpp
@@ -71,7 +71,7 @@ void device::on_control_completed(const control_transfer_data& data)
 				return initialize_stage3(buf8, data.len);
 			}
 		default:
-			main_terminal->error("Device: on_control_completed: invalid stage");
+			printk(KERN_ERROR, "Device: on_control_completed: invalid stage");
 			return;
 	}
 }
@@ -82,7 +82,7 @@ void device::on_interrupt_completed(const interrupt_transfer_data& data)
 		return w->on_interrupt_completed(data.ep_id, data.buf, data.len);
 	}
 
-	main_terminal->error("Device: on_interrupt_completed: invalid endpoint");
+	printk(KERN_ERROR, "Device: on_interrupt_completed: invalid endpoint");
 }
 
 void device::initialize_stage1(const uint8_t* buf, int len)

--- a/kernel/hardware/usb/xhci/device_manager.cpp
+++ b/kernel/hardware/usb/xhci/device_manager.cpp
@@ -14,7 +14,7 @@ void device_manager::initialize(size_t max_slots)
 			reinterpret_cast<device**>(kmalloc(sizeof(device*) * (max_slots_ + 1),
 											   KMALLOC_UNINITIALIZED));
 	if (devices_ == nullptr) {
-		main_terminal->error("failed to allocate memory for devices");
+		printk(KERN_ERROR, "failed to allocate memory for devices");
 		return;
 	}
 
@@ -24,7 +24,7 @@ void device_manager::initialize(size_t max_slots)
 					KMALLOC_UNINITIALIZED, 64));
 	if (contexts_ == nullptr) {
 		kfree(devices_);
-		main_terminal->error("failed to allocate memory for device contexts");
+		printk(KERN_ERROR, "failed to allocate memory for device contexts");
 		return;
 	}
 
@@ -81,12 +81,12 @@ void device_manager::allocate_device(uint8_t slot_id,
 									 usb::xhci::doorbell_register* dbreg)
 {
 	if (slot_id > max_slots_) {
-		main_terminal->printf("slot_id %d is out of range\n", slot_id);
+		printk(KERN_ERROR, "slot_id %d is out of range", slot_id);
 		return;
 	}
 
 	if (devices_[slot_id] != nullptr) {
-		main_terminal->printf("slot_id %d is already allocated\n", slot_id);
+		printk(KERN_ERROR, "slot_id %d is already allocated", slot_id);
 		return;
 	}
 
@@ -98,7 +98,7 @@ void device_manager::allocate_device(uint8_t slot_id,
 void device_manager::load_dcbaa(uint8_t slot_id)
 {
 	if (slot_id > max_slots_) {
-		main_terminal->printf("slot_id %d is out of range\n", slot_id);
+		printk(KERN_ERROR, "slot_id %d is out of range", slot_id);
 		return;
 	}
 

--- a/kernel/hardware/usb/xhci/port.cpp
+++ b/kernel/hardware/usb/xhci/port.cpp
@@ -1,6 +1,7 @@
 #include "port.hpp"
 #include "../../../graphics/terminal.hpp"
 #include "registers.hpp"
+#include "types.hpp"
 #include "xhci.hpp"
 
 namespace usb::xhci
@@ -55,8 +56,8 @@ void reset_port(port& p)
 	const auto port_state = port_connection_states[p.number()];
 	if (port_state != port_connection_state::DISCONNECTED &&
 		port_state != port_connection_state::WAITING_ADDRESSED) {
-		main_terminal->printf("port %d is not disconnected or waiting addressed\n",
-							  p.number());
+		printk(KERN_ERROR, "port %d is not disconnected or waiting addressed",
+			   p.number());
 		return;
 	}
 

--- a/kernel/hardware/usb/xhci/ring.cpp
+++ b/kernel/hardware/usb/xhci/ring.cpp
@@ -15,7 +15,7 @@ void ring::initialize(size_t buf_size)
 	buffer_ = reinterpret_cast<trb*>(
 			kmalloc(sizeof(trb) * buffer_size_, KMALLOC_ZEROED, 64));
 	if (buffer_ == nullptr) {
-		main_terminal->error("failed to allocate memory for ring");
+		printk(KERN_ERROR, "failed to allocate memory for ring");
 		return;
 	}
 }
@@ -58,7 +58,7 @@ void event_ring::initialize(size_t buf_size,
 	buffer_ = reinterpret_cast<trb*>(
 			kmalloc(sizeof(trb) * buffer_size_, KMALLOC_ZEROED, 64));
 	if (buffer_ == nullptr) {
-		main_terminal->error("failed to allocate memory for event ring");
+		printk(KERN_ERROR, "failed to allocate memory for event ring");
 		return;
 	}
 
@@ -66,8 +66,7 @@ void event_ring::initialize(size_t buf_size,
 			kmalloc(sizeof(event_ring_segment_table_entry), KMALLOC_ZEROED, 64));
 	if (segment_table_ == nullptr) {
 		kfree(buffer_);
-		main_terminal->error(
-				"failed to allocate memory for event ring segment table");
+		printk(KERN_ERROR, "failed to allocate memory for event ring segment table");
 		return;
 	}
 

--- a/kernel/interrupt/idt.cpp
+++ b/kernel/interrupt/idt.cpp
@@ -3,6 +3,7 @@
 #include "../memory/segment.hpp"
 #include "handler.h"
 #include "handlers.hpp"
+#include "types.hpp"
 #include "vector.hpp"
 #include <array>
 
@@ -30,7 +31,7 @@ void load_idt(size_t size, uint64_t addr)
 
 void initialize_interrupt()
 {
-	main_terminal->info("Initializing interrupt...");
+	printk(KERN_INFO, "Initializing interrupt...");
 
 	auto set_entry = [](int irq, auto handler, uint16_t ist = 0) {
 		set_idt_entry(idt[irq], reinterpret_cast<uint64_t>(handler),
@@ -62,5 +63,5 @@ void initialize_interrupt()
 
 	__asm__("sti");
 
-	main_terminal->info("Interrupt initialized successfully.");
+	printk(KERN_INFO, "Interrupt initialized successfully.");
 }

--- a/kernel/memory/bootstrap_allocator.cpp
+++ b/kernel/memory/bootstrap_allocator.cpp
@@ -3,6 +3,7 @@
 #include "../graphics/terminal.hpp"
 #include "buddy_system.hpp"
 #include "page.hpp"
+#include "types.hpp"
 
 #include <sys/types.h>
 
@@ -41,7 +42,7 @@ void* bootstrap_allocator::allocate(size_t size)
 		}
 	}
 
-	main_terminal->printf("failed to allocate %u bytes\n", size);
+	printk(KERN_ERROR, "failed to allocate %u bytes", size);
 
 	return nullptr;
 }
@@ -78,9 +79,9 @@ void bootstrap_allocator::show_available_memory() const
 		}
 	}
 
-	main_terminal->printf("available memory: %u MiB / %u MiB\n",
-						  available_pages * PAGE_SIZE / 1024 / 1024,
-						  (end_index() - start_index()) * PAGE_SIZE / 1024 / 1024);
+	printk(KERN_INFO, "available memory: %u MiB / %u MiB",
+		   available_pages * PAGE_SIZE / 1024 / 1024,
+		   (end_index() - start_index()) * PAGE_SIZE / 1024 / 1024);
 }
 
 alignas(bootstrap_allocator) char bootstrap_allocator_buffer[sizeof(
@@ -89,7 +90,7 @@ bootstrap_allocator* boot_allocator;
 
 void initialize_bootstrap_allocator(const MemoryMap& mem_map)
 {
-	main_terminal->info("Initializing bootstrap allocator...");
+	printk(KERN_INFO, "Initializing bootstrap allocator...");
 	boot_allocator = new (bootstrap_allocator_buffer) bootstrap_allocator();
 
 	const auto mem_map_base = reinterpret_cast<uintptr_t>(mem_map.buffer);
@@ -109,7 +110,7 @@ void initialize_bootstrap_allocator(const MemoryMap& mem_map)
 
 	boot_allocator->show_available_memory();
 
-	main_terminal->info("Bootstrap allocator initialized successfully.");
+	printk(KERN_INFO, "Bootstrap allocator initialized successfully.");
 }
 
 extern "C" caddr_t program_break, program_break_end;
@@ -122,7 +123,7 @@ void initialize_heap()
 
 	auto* heap = boot_allocator->allocate(heap_size);
 	if (heap == nullptr) {
-		main_terminal->print("failed to allocate heap\n");
+		printk(KERN_ERROR, "failed to allocate heap");
 		return;
 	}
 
@@ -137,5 +138,5 @@ void disable_bootstrap_allocator()
 		boot_allocator = nullptr;
 	}
 
-	main_terminal->info("Bootstrap allocator disabled.");
+	printk(KERN_INFO, "Bootstrap allocator disabled.");
 }

--- a/kernel/memory/page.cpp
+++ b/kernel/memory/page.cpp
@@ -1,6 +1,7 @@
 #include "page.hpp"
 #include "../graphics/terminal.hpp"
 #include "bootstrap_allocator.hpp"
+#include "types.hpp"
 
 std::vector<page> pages;
 
@@ -43,7 +44,7 @@ void print_available_memory()
 		}
 	}
 
-	main_terminal->printf("available memory: %u MiB / %u MiB\n",
-						  available_pages * PAGE_SIZE / 1024 / 1024,
-						  pages.size() * PAGE_SIZE / 1024 / 1024);
+	printk(KERN_INFO, "available memory: %u MiB / %u MiB",
+		   available_pages * PAGE_SIZE / 1024 / 1024,
+		   pages.size() * PAGE_SIZE / 1024 / 1024);
 }

--- a/kernel/memory/paging.cpp
+++ b/kernel/memory/paging.cpp
@@ -50,13 +50,13 @@ void dump_page_table(page_table_entry* table,
 		dump_page_table(entry.get_next_level_table(), page_table_level - 1, addr);
 	}
 
-	main_terminal->printf("page_table_level=%d, index=%d entry=%p\n",
-						  page_table_level, page_table_index, entry.data);
+	printk(KERN_INFO, "page_table_level=%d, index=%d entry=%p", page_table_level,
+		   page_table_index, entry.data);
 }
 
 void dump_page_tables(linear_address addr)
 {
-	main_terminal->printf("dest_addr=%p\n", addr.data);
+	printk(KERN_INFO, "dest_addr=%p", addr.data);
 	auto* pml4 = reinterpret_cast<page_table_entry*>(get_cr3());
 	dump_page_table(pml4, 4, addr);
 }
@@ -65,7 +65,7 @@ page_table_entry* new_page_table()
 {
 	auto* base_addr = kmalloc(PAGE_SIZE, KMALLOC_ZEROED);
 	if (base_addr == nullptr) {
-		main_terminal->error("Failed to allocate memory for page table.");
+		printk(KERN_ERROR, "Failed to allocate memory for page table.");
 		return nullptr;
 	}
 
@@ -99,8 +99,8 @@ size_t setup_page_table(page_table_entry* page_table,
 		const int page_table_index = addr.part(page_table_level);
 		auto* child_table = set_new_page_table(page_table[page_table_index]);
 		if (child_table == nullptr) {
-			main_terminal->printf("Failed to setup page table: level=%d\n",
-								  page_table_level);
+			printk(KERN_ERROR, "Failed to setup page table: level=%d",
+				   page_table_level);
 			return -1;
 		}
 
@@ -112,8 +112,8 @@ size_t setup_page_table(page_table_entry* page_table,
 			const size_t num_remaining_pages = setup_page_table(
 					child_table, page_table_level - 1, addr, num_pages);
 			if (num_remaining_pages == -1) {
-				main_terminal->errorf("Failed to setup page table: level=%d",
-									  page_table_level);
+				printk(KERN_ERROR, "Failed to setup page table: level=%d",
+					   page_table_level);
 				return -1;
 			}
 
@@ -138,7 +138,7 @@ void setup_page_tables(linear_address addr, size_t num_pages)
 	const size_t num_remaining_pages = setup_page_table(
 			reinterpret_cast<page_table_entry*>(get_cr3()), 4, addr, num_pages);
 	if (num_remaining_pages == -1) {
-		main_terminal->error("Failed to setup page tables.");
+		printk(KERN_ERROR, "Failed to setup page tables.");
 		return;
 	}
 
@@ -174,8 +174,8 @@ void clean_page_tables(linear_address addr)
 
 void initialize_paging()
 {
-	main_terminal->info("Initializing paging...");
+	printk(KERN_INFO, "Initializing paging...");
 	setup_identity_mapping();
 	set_cr3(reinterpret_cast<uint64_t>(&pml4_table));
-	main_terminal->info("Paging initialized successfully.");
+	printk(KERN_INFO, "Paging initialized successfully.");
 }

--- a/kernel/memory/segment.cpp
+++ b/kernel/memory/segment.cpp
@@ -71,13 +71,13 @@ void setup_segments()
 
 void initialize_segmentation()
 {
-	main_terminal->info("Initializing segmentation...");
+	printk(KERN_INFO, "Initializing segmentation...");
 	setup_segments();
 
 	load_data_segment(KERNEL_DS);
 	load_code_segment(KERNEL_CS);
 	load_stack_segment(KERNEL_SS);
-	main_terminal->info("Segmentation initialized successfully.");
+	printk(KERN_INFO, "Segmentation initialized successfully.");
 }
 
 void set_tss(int index, void* addr)
@@ -103,7 +103,7 @@ void initialize_tss()
 	void* stack1 = allocate_stack(stack_size);
 	void* stack2 = allocate_stack(stack_size);
 	if (stack1 == nullptr || stack2 == nullptr) {
-		main_terminal->error("Failed to allocate stack for TSS.");
+		printk(KERN_ERROR, "Failed to allocate stack for TSS.");
 		return;
 	}
 

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -76,7 +76,7 @@ bool m_cache::grow()
 	size_t const bytes_per_slab = num_pages_per_slab_ * PAGE_SIZE;
 	void* addr = memory_manager->allocate(bytes_per_slab);
 	if (addr == nullptr) {
-		main_terminal->error("m_cache_grow: failed to allocate memory");
+		printk(KERN_ERROR, "m_cache_grow: failed to allocate memory");
 		return false;
 	}
 
@@ -102,7 +102,7 @@ void* m_cache::alloc()
 {
 	if (slabs_partial_.empty()) {
 		if (slabs_free_.empty() && !grow()) {
-			main_terminal->error("m_cache_alloc: failed to grow");
+			printk(KERN_ERROR, "m_cache_alloc: failed to grow");
 			return nullptr;
 		}
 
@@ -116,7 +116,7 @@ void* m_cache::alloc()
 
 	void* addr = current_slab->alloc_object(object_size_);
 	if (addr == nullptr) {
-		main_terminal->error("m_cache_alloc: failed to allocate object");
+		printk(KERN_ERROR, "m_cache_alloc: failed to allocate object");
 		return nullptr;
 	}
 
@@ -169,7 +169,7 @@ void m_slab::move_list(m_cache& cache, slab_status to)
 void* m_slab::alloc_object(size_t obj_size)
 {
 	if (free_objects_index_.empty()) {
-		main_terminal->error("m_slab_alloc_object: no free objects");
+		printk(KERN_ERROR, "m_slab_alloc_object: no free objects");
 		return nullptr;
 	}
 
@@ -200,7 +200,7 @@ std::unordered_map<void*, void*> aligned_to_raw_addr_map;
 void* kmalloc(size_t size, unsigned flags, int align)
 {
 	if (align != 1 && (align & (align - 1)) != 0) {
-		main_terminal->error("align must be a power of 2");
+		printk(KERN_ERROR, "align must be a power of 2");
 		return nullptr;
 	}
 
@@ -215,7 +215,7 @@ void* kmalloc(size_t size, unsigned flags, int align)
 
 	void* addr = cache->alloc();
 	if (addr == nullptr) {
-		main_terminal->error("kmalloc: failed to allocate memory");
+		printk(KERN_ERROR, "kmalloc: failed to allocate memory");
 		return nullptr;
 	}
 
@@ -247,7 +247,7 @@ void kfree(void* addr)
 
 	page* page = get_page(addr);
 	if (page == nullptr) {
-		main_terminal->error("kfree: invalid address");
+		printk(KERN_ERROR, "kfree: invalid address");
 		return;
 	}
 
@@ -270,11 +270,11 @@ void kfree(void* addr)
 std::list<std::unique_ptr<m_cache>> cache_chain;
 void initialize_slab_allocator()
 {
-	main_terminal->info("Initializing slab allocator...");
+	printk(KERN_INFO, "Initializing slab allocator...");
 
 	aligned_to_raw_addr_map = std::unordered_map<void*, void*>();
 
 	cache_chain.clear();
 
-	main_terminal->info("Initializing slab allocator successfully.");
+	printk(KERN_INFO, "Initializing slab allocator successfully.");
 }

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -18,7 +18,7 @@ error_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	}
 
 	if (fd == 1) {
-		main_terminal->print(buf);
+		printk(KERN_DEBUG, buf);
 	}
 
 	return OK;
@@ -36,7 +36,7 @@ extern "C" int64_t handle_syscall(uint64_t arg1,
 			sys_write(arg1, arg2, arg3);
 			break;
 		default:
-			main_terminal->errorf("Unknown syscall number: %d\n", syscall_number);
+			printk(KERN_ERROR, "Unknown syscall number: %d", syscall_number);
 			break;
 	}
 

--- a/kernel/task/ipc.cpp
+++ b/kernel/task/ipc.cpp
@@ -6,13 +6,13 @@
 error_t send_message(task_t dst_id, const message* m)
 {
 	if (dst_id == -1 || m->sender == dst_id) {
-		main_terminal->errorf("invalid destination task id: %d", dst_id);
+		printk(KERN_ERROR, "invalid destination task id: %d", dst_id);
 		return ERR_INVALID_ARG;
 	}
 
 	task* dst = tasks[dst_id];
 	if (dst == nullptr) {
-		main_terminal->errorf("task %d is not found", dst_id);
+		printk(KERN_ERROR, "task %d is not found", dst_id);
 		return ERR_INVALID_TASK;
 	}
 

--- a/kernel/task/ipc.hpp
+++ b/kernel/task/ipc.hpp
@@ -7,8 +7,9 @@
 #define NOTIFY_XHCI 1
 #define NOTIFY_CURSOR_BLINK 2
 #define NOTIFY_TIMER_TIMEOUT 3
+#define NOTIFY_WRITE 4
 
-#define NUM_MESSAGE_TYPES 4
+#define NUM_MESSAGE_TYPES 5
 
 enum class timeout_action_t : uint8_t {
 	TERMINAL_CURSOR_BLINK,
@@ -30,6 +31,11 @@ struct message {
 		struct {
 			timeout_action_t action;
 		} timer;
+
+		struct {
+			const char* s;
+			int level;
+		} write;
 	} data;
 };
 

--- a/kernel/timers/acpi.cpp
+++ b/kernel/timers/acpi.cpp
@@ -1,6 +1,7 @@
 #include "acpi.hpp"
 #include "../asm_utils.h"
 #include "../graphics/terminal.hpp"
+#include "types.hpp"
 #include <string.h>
 
 namespace acpi
@@ -41,10 +42,10 @@ const fixed_acpi_description_table* fadt;
 
 void initialize(const root_system_description_pointer& rsdp)
 {
-	main_terminal->info("Initializing ACPI...");
+	printk(KERN_INFO, "Initializing ACPI...");
 
 	if (!rsdp.is_valid()) {
-		main_terminal->print("acpi is invalid\n");
+		printk(KERN_ERROR, "acpi is invalid");
 		return;
 	}
 
@@ -60,13 +61,13 @@ void initialize(const root_system_description_pointer& rsdp)
 	}
 
 	if (fadt == nullptr) {
-		main_terminal->print("FADT is not found\n");
+		printk(KERN_ERROR, "FADT is not found");
 		return;
 	}
 
-	main_terminal->print("PM timer is available\n");
+	printk(KERN_INFO, "PM timer is available");
 
-	main_terminal->info("ACPI initialized successfully.");
+	printk(KERN_INFO, "ACPI initialized successfully.");
 }
 
 const int PM_TIMER_FREQUENCY = 3579545;

--- a/kernel/timers/local_apic.cpp
+++ b/kernel/timers/local_apic.cpp
@@ -3,6 +3,7 @@
 #include "../interrupt/vector.hpp"
 #include "acpi.hpp"
 #include "timer.hpp"
+#include "types.hpp"
 
 namespace local_apic
 {
@@ -19,7 +20,7 @@ const uint32_t COUNT_MAX = 0xffffffffU;
 
 void initialize()
 {
-	main_terminal->info("Initializing local APIC...");
+	printk(KERN_INFO, "Initializing local APIC...");
 
 	DIVIDE_CONF = 0b1011;	   // divide by 1
 	LVT_TIMER = (0b001 << 16); // mask
@@ -33,12 +34,12 @@ void initialize()
 
 	const uint32_t freq = elapsed * 10;
 
-	main_terminal->printf("Local APIC timer frequency: %u Hz\n", freq);
+	printk(KERN_INFO, "Local APIC timer frequency: %u Hz", freq);
 
 	LVT_TIMER = (0b010 << 16) | InterruptVector::kLocalApicTimer;
 	INITIAL_COUNT = freq / TIMER_FREQUENCY;
 
-	main_terminal->info("Local APIC initialized successfully.");
+	printk(KERN_INFO, "Local APIC initialized successfully.");
 }
 
 } // namespace local_apic

--- a/kernel/timers/timer.cpp
+++ b/kernel/timers/timer.cpp
@@ -2,6 +2,7 @@
 #include "../graphics/terminal.hpp"
 #include "../memory/slab.hpp"
 #include "../task/ipc.hpp"
+#include "../types.hpp"
 
 uint64_t kernel_timer::calculate_timeout_ticks(unsigned long millisec) const
 {
@@ -30,7 +31,7 @@ uint64_t kernel_timer::add_periodic_timer_event(unsigned long millisec,
 	if (id == 0) {
 		id = last_id_++;
 	} else if (last_id_ < id) {
-		main_terminal->printf("invalid timer id: %lu\n", id);
+		printk(KERN_ERROR, "invalid timer id: %lu", id);
 		return 0;
 	}
 
@@ -58,7 +59,7 @@ void kernel_timer::add_switch_task_event(unsigned long millisec)
 void kernel_timer::remove_timer_event(uint64_t id)
 {
 	if (id == 0 || last_id_ < id) {
-		main_terminal->printf("invalid timer id: %lu\n", id);
+		printk(KERN_ERROR, "invalid timer id: %lu", id);
 		return;
 	}
 
@@ -99,7 +100,7 @@ bool kernel_timer::increment_tick()
 kernel_timer* ktimer;
 void initialize_timer()
 {
-	main_terminal->info("Initializing logical timer...");
+	printk(KERN_INFO, "Initializing logical timer...");
 
 	void* addr = kmalloc(sizeof(kernel_timer), KMALLOC_UNINITIALIZED);
 	ktimer = new (addr) kernel_timer;
@@ -107,5 +108,5 @@ void initialize_timer()
 	ktimer->add_periodic_timer_event(CURSOR_BLINK_MILLISEC,
 									 timeout_action_t::TERMINAL_CURSOR_BLINK);
 
-	main_terminal->info("Logical timer initialized successfully.");
+	printk(KERN_INFO, "Logical timer initialized successfully.");
 }

--- a/kernel/types.hpp
+++ b/kernel/types.hpp
@@ -17,3 +17,8 @@ using task_t = int;
 
 // task ids
 #define INTERRUPT_TASK_ID 100
+
+// log levels
+#define KERN_DEBUG 0
+#define KERN_ERROR 1
+#define KERN_INFO 2


### PR DESCRIPTION
The print functions were replaced with a newly introduced kernel logging function, printk, across various hardware and memory files to improve logging control. An optimization at the compiler level was also enforced by setting default compile options from -O0 to -Og to allow for debugging with optimization. Minor additions were also made to improve task scheduling logic and log levels were defined for error, debug and info messages.