### PR TITLE
Change debug print method in syscall handler

### DIFF
--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -18,7 +18,7 @@ error_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	}
 
 	if (fd == 1) {
-		printk(KERN_DEBUG, buf);
+		main_terminal->print(buf);
 	}
 
 	return OK;


### PR DESCRIPTION
The syscall handler's print method has been updated for better handling. Previously, it was printing directly using printk with KERN_DEBUG. This has now been changed to print through the main_terminal object. This enhances type safety and improves the clarity and organization of the code.