### PR TITLE
Implement SYS_EXIT syscall and adjust task kernel stack

### DIFF
--- a/kernel/asm_utils.asm
+++ b/kernel/asm_utils.asm
@@ -44,12 +44,20 @@ write_msr:
     wrmsr
     ret
 
-global call_userland ; void call_userland(int argc, char** argv, uint16_t cs, uint16_t ss, uint64_t rip, uint64_t rsp);
+global call_userland ; void call_userland(int argc, char** argv, uint16_t ss, uint64_t rip, uint64_t rsp, uint64_t* kernel_rsp)
 call_userland:
+    ; save callee-saved registers
+    push rbx
     push rbp
-    mov rbp, rsp
-    push rcx ; ss
-    push r9  ; rsp
+    push r12
+    push r13
+    push r14
+    push r15
+    mov [r9], rsp ; save kernel stack pointer
+
+    push rdx ; ss
+    push r8  ; rsp
+    add rdx, 8 ; get cs
     push rdx ; cs
-    push r8  ; rip
+    push rcx  ; rip
     o64 retf

--- a/kernel/asm_utils.h
+++ b/kernel/asm_utils.h
@@ -13,8 +13,8 @@ void write_msr(uint32_t msr, uint64_t value);
 
 void call_userland(int argc,
 				   char** argv,
-				   uint16_t cs,
 				   uint16_t ss,
 				   uint64_t rip,
-				   uint64_t rsp);
+				   uint64_t rsp,
+				   uint64_t* kernel_rsp);
 }

--- a/kernel/command_line/controller.cpp
+++ b/kernel/command_line/controller.cpp
@@ -37,7 +37,6 @@ void controller::process_command(const char* command, terminal& term)
 	auto* entry = file_system::find_directory_entry(command_name, 0);
 	if (entry != nullptr) {
 		file_system::execute_file(*entry, args);
-		term.printf("Command exited with status %d", 0);
 		return;
 	}
 

--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -4,6 +4,7 @@
 #include "../memory/page.hpp"
 #include "../memory/paging.hpp"
 #include "../memory/segment.hpp"
+#include "../task/task.hpp"
 #include "elf.hpp"
 #include <algorithm>
 #include <cstdint>
@@ -218,9 +219,11 @@ void execute_file(const directory_entry& entry, const char* args)
 	const linear_address stack_addr{ 0xffff'ffff'ffff'f000 };
 	setup_page_tables(stack_addr, 1);
 
+	task* t = CURRENT_TASK;
+
 	auto entry_addr = elf_header->e_entry;
-	call_userland(argc, argv, USER_CS, USER_SS, entry_addr,
-				  stack_addr.data + PAGE_SIZE - 8);
+	call_userland(argc, argv, USER_SS, entry_addr, stack_addr.data + PAGE_SIZE - 8,
+				  &t->kernel_stack_top);
 
 	const auto addr_first = get_first_load_addr(elf_header);
 	clean_page_tables(linear_address{ addr_first });

--- a/kernel/syscall/entry.asm
+++ b/kernel/syscall/entry.asm
@@ -13,6 +13,7 @@ syscall_entry:
     push rbp
     push rcx ; save RIP
     push r11 ; save RFLAGS
+    push rax ; save syscall number
 
     mov rcx, r10 ; 4th argument
     mov r9, rax ; save syscall number in 6th argument
@@ -24,7 +25,25 @@ syscall_entry:
 
     mov rsp, rbp ; restore stack pointer
 
+    pop rsi ; restore syscall number
+    cmp esi, 60
+    je .exit
+
     pop r11 ; restore RFLAGS
     pop rcx ; restore RIP
     pop rbp
     o64 sysret
+
+.exit:
+    mov rsp, rax ; restore kernel stack pointer
+    mov eax, 0;
+
+    ; restore registers
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rbp
+    pop rbx
+
+    ret

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -1,4 +1,5 @@
 #include "../graphics/terminal.hpp"
+#include "../task/task.hpp"
 #include "../types.hpp"
 #include "syscall.hpp"
 #include <cerrno>
@@ -24,22 +25,33 @@ error_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	return OK;
 }
 
-extern "C" int64_t handle_syscall(uint64_t arg1,
-								  uint64_t arg2,
-								  uint64_t arg3,
-								  uint64_t arg4,
-								  uint64_t arg5,
-								  uint64_t syscall_number)
+uint64_t sys_exit()
 {
+	task* t = CURRENT_TASK;
+	return t->kernel_stack_top;
+}
+
+extern "C" uint64_t handle_syscall(uint64_t arg1,
+								   uint64_t arg2,
+								   uint64_t arg3,
+								   uint64_t arg4,
+								   uint64_t arg5,
+								   uint64_t syscall_number)
+{
+	uint64_t result = 0;
+
 	switch (syscall_number) {
 		case SYS_WRITE:
 			sys_write(arg1, arg2, arg3);
+			break;
+		case SYS_EXIT:
+			result = sys_exit();
 			break;
 		default:
 			printk(KERN_ERROR, "Unknown syscall number: %d", syscall_number);
 			break;
 	}
 
-	return 0;
+	return result;
 }
 } // namespace syscall

--- a/kernel/syscall/syscall.hpp
+++ b/kernel/syscall/syscall.hpp
@@ -15,6 +15,7 @@
 
 // system call number
 #define SYS_WRITE 1
+#define SYS_EXIT 60
 
 namespace syscall
 {

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <queue>
 #include <vector>
 
@@ -21,6 +22,7 @@ struct task {
 	int priority;
 	task_state state;
 	std::vector<uint64_t> stack;
+	uint64_t kernel_stack_top;
 	alignas(16) context ctx;
 	list_elem_t run_queue_elem;
 	std::queue<message> messages;


### PR DESCRIPTION
The SYS_EXIT system call was added to support clean termination of tasks. Also, the format of `call_userland` was modified to save callee-saved registers and the kernel stack top of the current task.  Further, the 'syscall_number' was saved before 'handle_syscall' and was used to handle task termination directly in the syscall entry code.