### PR TITLE
Update task ID usage and improve send_message in interrupt handling

### DIFF
--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -266,6 +266,7 @@ void printk(int level, const char* format, ...)
 	va_start(args, format);
 	char s[1024];
 	vsprintf(s, format, args);
+	va_end(args);
 
 	const int task_id = main_terminal->task_id();
 	if (task_id == -1) {
@@ -284,6 +285,4 @@ void printk(int level, const char* format, ...)
 		const message m{ NOTIFY_WRITE, task_id, { .write = { s, level } } };
 		send_message(main_terminal->task_id(), &m);
 	}
-
-	va_end(args);
 }

--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -255,37 +255,3 @@ void task_terminal()
 
 	process_messages(t);
 }
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvariadic-macros"
-void printk(int level, const char* format, ...)
-{
-	if (main_terminal == nullptr) {
-		return;
-	}
-
-	va_list args;
-	va_start(args, format);
-	char s[1024];
-	vsprintf(s, format, args);
-	va_end(args);
-
-	const int task_id = main_terminal->task_id();
-	if (task_id == -1) {
-		switch (level) {
-			case KERN_DEBUG:
-				main_terminal->print(s);
-				break;
-			case KERN_ERROR:
-				main_terminal->error(s);
-				break;
-			case KERN_INFO:
-				main_terminal->info(s);
-				break;
-		}
-	} else {
-		const message m{ NOTIFY_WRITE, task_id, { .write = { s, level } } };
-		send_message(main_terminal->task_id(), &m);
-	}
-}
-#pragma GCC diagnostic pop

--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -256,6 +256,8 @@ void task_terminal()
 	process_messages(t);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
 void printk(int level, const char* format, ...)
 {
 	if (main_terminal == nullptr) {
@@ -286,3 +288,4 @@ void printk(int level, const char* format, ...)
 		send_message(main_terminal->task_id(), &m);
 	}
 }
+#pragma GCC diagnostic pop

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -99,4 +99,7 @@ extern terminal* main_terminal;
 void initialize_terminal();
 void task_terminal();
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
 void printk(int level, const char* format, ...);
+#pragma GCC diagnostic pop

--- a/kernel/interrupt/handlers.cpp
+++ b/kernel/interrupt/handlers.cpp
@@ -17,8 +17,9 @@ namespace
 
 __attribute__((interrupt)) void on_xhci_interrupt(InterruptFrame* frame)
 {
+	const int xhci_task_id = 3;
 	const message m = { NOTIFY_XHCI, INTERRUPT_TASK_ID, {} };
-	send_message(get_task_id_by_name("usb_handler"), &m);
+	send_message(xhci_task_id, &m);
 
 	notify_end_of_interrupt();
 }

--- a/kernel/memory/paging.hpp
+++ b/kernel/memory/paging.hpp
@@ -95,6 +95,8 @@ union page_table_entry {
 
 void dump_page_tables(linear_address addr);
 
+page_table_entry* new_page_table();
+
 void setup_page_tables(linear_address addr, size_t num_pages);
 
 void clean_page_tables(linear_address addr);

--- a/kernel/task/ipc.hpp
+++ b/kernel/task/ipc.hpp
@@ -39,4 +39,5 @@ struct message {
 	} data;
 };
 
-error_t send_message(task_t dst, const message* m);
+[[gnu::no_caller_saved_registers]] error_t
+send_message(task_t dst, const message* m);

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -36,6 +36,8 @@ struct task {
 		 int priority,
 		 bool is_init);
 
+	~task() { kfree(reinterpret_cast<void*>(ctx.cr3)); }
+
 	static void* operator new(size_t size) { return kmalloc(size, KMALLOC_ZEROED); }
 
 	static void operator delete(void* p) { kfree(p); }


### PR DESCRIPTION
Task ID is updated to a constant value in on_xhci_interrupt() to improve efficiency. Furthermore, send_message() is modified with the 'no_caller_saved_registers' attribute to better control performance by avoiding unnecessary register saving, thus optimizing interrupt handling.