### PR TITLE
Implement kill_userland function and improve ELF handling

### DIFF
--- a/kernel/asm_utils.asm
+++ b/kernel/asm_utils.asm
@@ -61,3 +61,18 @@ call_userland:
     push rdx ; cs
     push rcx  ; rip
     o64 retf
+
+global exit_userland ; void exit_userland(uint64_t kernel_rsp, int32_t status);
+exit_userland:
+    mov rsp, rdi
+    mov eax, esi
+
+    ; restore callee-saved registers
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rbp
+    pop rbx
+
+    ret

--- a/kernel/asm_utils.h
+++ b/kernel/asm_utils.h
@@ -17,4 +17,6 @@ void call_userland(int argc,
 				   uint64_t rip,
 				   uint64_t rsp,
 				   uint64_t* kernel_rsp);
+
+void exit_userland(uint64_t kernel_rsp, int32_t status);
 }

--- a/kernel/elf.cpp
+++ b/kernel/elf.cpp
@@ -4,6 +4,7 @@
 #include "memory/paging.hpp"
 #include "types.hpp"
 #include <cstdint>
+#include <cstring>
 
 elf64_phdr_t* get_program_header(elf64_ehdr_t* elf_header)
 {
@@ -21,6 +22,14 @@ uintptr_t get_first_load_addr(elf64_ehdr_t* elf_header)
 	}
 
 	return 0;
+}
+
+bool is_elf(elf64_ehdr_t* elf_header)
+{
+	return memcmp(elf_header->e_ident,
+				  "\x7f"
+				  "ELF",
+				  4) == 0;
 }
 
 void copy_load_segment(elf64_ehdr_t* elf_header)

--- a/kernel/elf.hpp
+++ b/kernel/elf.hpp
@@ -83,3 +83,5 @@ typedef struct {
 void load_elf(elf64_ehdr_t* elf_header);
 
 uintptr_t get_first_load_addr(elf64_ehdr_t* elf_header);
+
+bool is_elf(elf64_ehdr_t* elf_header);

--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -6,6 +6,7 @@
 #include "../memory/segment.hpp"
 #include "../task/task.hpp"
 #include "elf.hpp"
+#include "types.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -191,13 +192,8 @@ void execute_file(const directory_entry& entry, const char* args)
 	}
 
 	auto* elf_header = reinterpret_cast<elf64_ehdr_t*>(file_buffer.data());
-	if (memcmp(elf_header->e_ident,
-			   "\x7f"
-			   "ELF",
-			   4) != 0) {
-		using func_t = void (*)();
-		auto f = reinterpret_cast<func_t>(file_buffer.data());
-		f();
+	if (!is_elf(elf_header)) {
+		printk(KERN_ERROR, "Not an ELF file.");
 		return;
 	}
 

--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -6,9 +6,7 @@
 #include "font.hpp"
 #include "screen.hpp"
 #include "types.hpp"
-#include <cstdarg>
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <memory>
 

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -17,6 +17,7 @@
 #include "color.hpp"
 #include "font.hpp"
 #include "task/ipc.hpp"
+#include "task/task.hpp"
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -119,7 +120,7 @@ void printk(int level, const char* format, Args... args)
 	}
 
 	const int task_id = main_terminal->task_id();
-	if (task_id == -1) {
+	if (task_id == -1 || task_id == CURRENT_TASK->id) {
 		switch (level) {
 			case KERN_DEBUG:
 				main_terminal->print(s);

--- a/kernel/interrupt/handlers.cpp
+++ b/kernel/interrupt/handlers.cpp
@@ -1,4 +1,5 @@
 #include "handlers.hpp"
+#include "../asm_utils.h"
 #include "../task/context.hpp"
 #include "../task/ipc.hpp"
 #include "../task/task.hpp"
@@ -32,4 +33,16 @@ extern "C" void switch_task_by_timer_interrupt(context* ctx)
 	if (need_switch_task) {
 		switch_task(*ctx);
 	}
+}
+
+void kill_userland(InterruptFrame* frame)
+{
+	auto cpl = frame->cs & 0x3;
+	if (cpl != 3) {
+		return;
+	}
+
+	__asm__("sti");
+
+	exit_userland(CURRENT_TASK->kernel_stack_top, 128);
 }

--- a/kernel/interrupt/handlers.hpp
+++ b/kernel/interrupt/handlers.hpp
@@ -22,10 +22,13 @@ struct InterruptFrame {
 
 void on_xhci_interrupt(InterruptFrame* frame);
 
+[[gnu::no_caller_saved_registers]] void kill_userland(InterruptFrame* frame);
+
 #define FaultHandlerWithError(error_code)                                           \
 	inline __attribute__((interrupt)) void InterruptHandler##error_code(            \
 			InterruptFrame* frame, uint64_t code)                                   \
 	{                                                                               \
+		kill_userland(frame);                                                       \
 		main_terminal->print(#error_code);                                          \
 		main_terminal->print("\n");                                                 \
 		main_terminal->print("RIP : ");                                             \
@@ -46,6 +49,7 @@ void on_xhci_interrupt(InterruptFrame* frame);
 	inline __attribute__((interrupt)) void InterruptHandler##error_code(            \
 			InterruptFrame* frame, uint64_t code)                                   \
 	{                                                                               \
+		kill_userland(frame);                                                       \
 		main_terminal->print(#error_code);                                          \
 		while (1)                                                                   \
 			__asm__("hlt");                                                         \

--- a/kernel/memory/page.cpp
+++ b/kernel/memory/page.cpp
@@ -2,6 +2,7 @@
 #include "../graphics/terminal.hpp"
 #include "bootstrap_allocator.hpp"
 #include "types.hpp"
+#include <vector>
 
 std::vector<page> pages;
 


### PR DESCRIPTION
Added a function to handle userland exit in response to specific interrupts, and improved handling of non-ELF files in the FAT module and terminal output. Also, simplified the use of templates in terminal.hpp and terminal.cpp for printk function. Additionally, the vector class was included in page.cpp to manage memory pages.