### PR TITLE
Implement standard input functionality and improve terminal handling

### DIFF
--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <string.h>
 #include <vector>
 
@@ -305,10 +306,13 @@ void execute_file(const directory_entry& entry, const char* args)
 	setup_page_tables(stack_addr, 1);
 
 	task* t = CURRENT_TASK;
+	t->fds[0] = std::make_unique<term_file_descriptor>();
 
 	auto entry_addr = elf_header->e_entry;
 	call_userland(argc, argv, USER_SS, entry_addr, stack_addr.data + PAGE_SIZE - 8,
 				  &t->kernel_stack_top);
+
+	t->fds[0].reset();
 
 	const auto addr_first = get_first_load_addr(elf_header);
 	clean_page_tables(linear_address{ addr_first });

--- a/kernel/file_system/fat.hpp
+++ b/kernel/file_system/fat.hpp
@@ -120,7 +120,7 @@ struct file_descriptor : public ::file_descriptor {
 	{
 	}
 
-	size_t read(void* buf, size_t len);
+	size_t read(void* buf, size_t len) override;
 };
 
 } // namespace file_system

--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -253,3 +253,28 @@ void task_terminal()
 
 	process_messages(t);
 }
+
+size_t term_file_descriptor::read(void* buf, size_t len)
+{
+	char* bufc = reinterpret_cast<char*>(buf);
+	task* t = CURRENT_TASK;
+
+	while (true) {
+		if (t->messages.empty()) {
+			t->state = TASK_WAITING;
+			continue;
+		}
+
+		t->state = TASK_RUNNING;
+
+		const message m = t->messages.front();
+		t->messages.pop();
+		if (m.type != NOTIFY_KEY_INPUT) {
+			continue;
+		}
+
+		bufc[0] = m.data.key_input.ascii;
+		main_terminal->print(bufc);
+		return 1;
+	}
+}

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "file_system/file_descriptor.hpp"
 #include "graphics/color.hpp"
 #include "graphics/font.hpp"
 #include "task/ipc.hpp"
@@ -47,14 +48,6 @@ public:
 		char s[1024];
 		sprintf(s, format, args...);
 		print(s);
-	}
-
-	template<typename... Args>
-	void errorf(const char* format, Args... args)
-	{
-		char s[1024];
-		sprintf(s, format, args...);
-		error(s);
 	}
 
 	task_t task_id() const { return task_id_; }
@@ -137,3 +130,8 @@ void printk(int level, const char* format, Args... args)
 		send_message(main_terminal->task_id(), &m);
 	}
 }
+
+struct term_file_descriptor : public file_descriptor {
+	term_file_descriptor() = default;
+	size_t read(void* buf, size_t len) override;
+};

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <fcntl.h>
 #include <memory>
 
@@ -23,8 +24,6 @@ size_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	if (fd >= t->fds.size() || t->fds[fd] == nullptr) {
 		return 0;
 	}
-
-	main_terminal->printf("sys_read: fd=%d, count=%d\n", fd, count);
 
 	return t->fds[fd]->read(buf, count);
 }
@@ -55,8 +54,11 @@ fd_t sys_open(uint64_t arg1, uint64_t arg2)
 		return NO_FD;
 	}
 
+	if (strncmp(path, "/dev/stdin", 10) == 0) {
+		return STDIN_FILENO;
+	}
+
 	if ((flags & O_ACCMODE) == O_WRONLY) {
-		main_terminal->printf("open: %s: Write-only file system\n", path);
 		return NO_FD;
 	}
 

--- a/kernel/types.hpp
+++ b/kernel/types.hpp
@@ -26,3 +26,6 @@ using fd_t = int;
 
 // file descriptor
 #define NO_FD -1
+#define STDIN_FILENO 0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2


### PR DESCRIPTION
Added standard input support by implementing term_file_descriptor in terminal scope, which improves overall read functionality. This enhances terminal handling and streamlines file descriptor management. Defined standard file descriptors STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO in types.hpp and removed redundant terminal print statements.