### PR TITLE
Correct filename typo and add EOT detection

### DIFF
--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -2,6 +2,7 @@
 #include "graphics/color.hpp"
 #include "graphics/font.hpp"
 #include "graphics/screen.hpp"
+#include "hardware/keyboard.hpp"
 #include "shell/controller.hpp"
 #include "task/ipc.hpp"
 #include "task/task.hpp"
@@ -271,6 +272,11 @@ size_t term_file_descriptor::read(void* buf, size_t len)
 		t->messages.pop();
 		if (m.type != NOTIFY_KEY_INPUT) {
 			continue;
+		}
+
+		if (is_EOT(m.data.key_input.modifier, m.data.key_input.key_code)) {
+			main_terminal->print("^D");
+			return 0;
 		}
 
 		bufc[0] = m.data.key_input.ascii;

--- a/kernel/hardware/keyboard.cpp
+++ b/kernel/hardware/keyboard.cpp
@@ -1,7 +1,8 @@
 #include "usb/class_driver/keyboard.hpp"
 #include "graphics/terminal.hpp"
-#include "hardware/keyboad.hpp"
+#include "hardware/keyboard.hpp"
 #include "task/ipc.hpp"
+#include "types.hpp"
 
 namespace
 {
@@ -56,17 +57,22 @@ void initialize_keyboard()
 		const char ascii =
 				shift ? keycode_map_shifted[keycode] : keycode_map[keycode];
 
-		message m{ NOTIFY_KEY_INPUT,
-				   INTERRUPT_TASK_ID,
-				   { .key_input{
-						   .key_code = keycode,
-						   .modifier = modifier,
-						   .ascii = static_cast<uint8_t>(ascii),
-						   .press = static_cast<int>(press),
-				   } } };
+		const message m{ NOTIFY_KEY_INPUT,
+						 INTERRUPT_TASK_ID,
+						 { .key_input{
+								 .key_code = keycode,
+								 .modifier = modifier,
+								 .ascii = static_cast<uint8_t>(ascii),
+								 .press = static_cast<int>(press),
+						 } } };
 
 		if (m.data.key_input.press != 0) {
 			send_message(main_terminal->task_id(), &m);
 		}
 	};
+}
+
+bool is_EOT(uint8_t modifier, uint8_t keycode)
+{
+	return ((modifier & (L_CONTROL | R_CONTROL)) != 0) && keycode == 7;
 }

--- a/kernel/hardware/keyboard.hpp
+++ b/kernel/hardware/keyboard.hpp
@@ -14,3 +14,5 @@ static const int R_ALT = 0b01000000U;
 static const int R_GUI = 0b10000000U;
 
 void initialize_keyboard();
+
+bool is_EOT(uint8_t modifier, uint8_t keycode);

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -5,7 +5,7 @@ struct MemoryMap;
 #include "graphics/font.hpp"
 #include "graphics/screen.hpp"
 #include "graphics/terminal.hpp"
-#include "hardware/keyboad.hpp"
+#include "hardware/keyboard.hpp"
 #include "hardware/pci.hpp"
 #include "hardware/usb/xhci/xhci.hpp"
 #include "interrupt/idt.hpp"


### PR DESCRIPTION
Fixed a typo in the filename from "keyboad.hpp" to "keyboard.hpp". Also, added a check to detect EOT (End Of Transmission) sequences in the keyboard input. This will allow for more efficient handling of keyboard events and improve the overall user experience with the system.