### PR TITLE
Add file creation and path splitting in FAT file system

### DIFF
--- a/kernel/file_system/fat.hpp
+++ b/kernel/file_system/fat.hpp
@@ -104,6 +104,8 @@ void execute_file(const directory_entry& entry, const char* args);
 
 void read_dir_entry_name(const directory_entry& entry, char* dest);
 
+directory_entry* create_file(const char* path);
+
 void initialize_fat(void* volume_image);
 
 struct file_descriptor : public ::file_descriptor {


### PR DESCRIPTION
Adds a function for creating a new file and a utility function for splitting file paths. This allows more intuitive handling of file paths and more precise error output message when a file or directory is not found.