### PR TITLE
Refactor and extend FAT file system functionality

### DIFF
--- a/kernel/file_system/fat.hpp
+++ b/kernel/file_system/fat.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "file_system/file_descriptor.hpp"
+#include "types.hpp"
 #include <cstdint>
 #include <vector>
 
@@ -79,22 +80,23 @@ struct directory_entry {
 	}
 } __attribute__((packed));
 
-static const unsigned long END_OF_CLUSTERCHAIN = 0x0FFFFFFFLU;
+static const cluster_t END_OF_CLUSTER_CHAIN = 0x0FFFFFFFLU;
 
-extern bios_parameter_block* boot_volume_image;
-extern unsigned long bytes_per_cluster;
+extern bios_parameter_block* BOOT_VOLUME_IMAGE;
+extern unsigned long BYTES_PER_CLUSTER;
+extern uint32_t* FAT_TABLE;
 
-uintptr_t get_cluster_addr(unsigned long cluster_id);
+uintptr_t get_cluster_addr(cluster_t cluster_id);
 
 template<class T>
-T* get_sector(unsigned long cluster_id)
+T* get_sector(cluster_t cluster_id)
 {
 	return reinterpret_cast<T*>(get_cluster_addr(cluster_id));
 }
 
-unsigned long next_cluster(unsigned long cluster_id);
+cluster_t next_cluster(cluster_t cluster_id);
 
-directory_entry* find_directory_entry(const char* name, unsigned long cluster_id);
+directory_entry* find_directory_entry(const char* name, cluster_t cluster_id);
 
 directory_entry* find_directory_entry_by_path(const char* path);
 

--- a/kernel/shell/commands.cpp
+++ b/kernel/shell/commands.cpp
@@ -36,11 +36,11 @@ void cat(terminal& term, const char* file_name)
 	auto cluster_id = entry->first_cluster();
 	auto remain_bytes = entry->file_size;
 
-	while (cluster_id != file_system::END_OF_CLUSTERCHAIN) {
+	while (cluster_id != file_system::END_OF_CLUSTER_CHAIN) {
 		auto* p = file_system::get_sector<char>(cluster_id);
 
 		int i = 0;
-		for (; i < file_system::bytes_per_cluster && i < remain_bytes; ++i) {
+		for (; i < file_system::BYTES_PER_CLUSTER && i < remain_bytes; ++i) {
 			term.printf("%c", *p++);
 		}
 

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -64,7 +64,13 @@ fd_t sys_open(uint64_t arg1, uint64_t arg2)
 
 	auto* entry = file_system::find_directory_entry_by_path(path);
 	if (entry == nullptr) {
-		return NO_FD;
+		auto* new_entry = file_system::create_file(path);
+		if (new_entry == nullptr) {
+			main_terminal->printf("open: %s: No such file or directory\n", path);
+			return NO_FD;
+		}
+
+		entry = new_entry;
 	}
 
 	task* t = CURRENT_TASK;

--- a/kernel/types.hpp
+++ b/kernel/types.hpp
@@ -29,3 +29,6 @@ using fd_t = int;
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
+
+// fat
+using cluster_t = unsigned long;


### PR DESCRIPTION
This commit refactors and extends the FAT file system functionality. Adjustments include revised variable names for better consistency, implementing an extended cluster chain function and allocating directory entries function. A functionality for creating a new file was added, which included adding a utility function for splitting file paths. This development leads to more intuitive handling of file paths and improved error output messages when a file or directory is not found.