### PR TITLE
Improve filesystem operation handling and introduce write method

### DIFF
--- a/kernel/file_system/fat.cpp
+++ b/kernel/file_system/fat.cpp
@@ -336,13 +336,17 @@ void execute_file(const directory_entry& entry, const char* args)
 	setup_page_tables(stack_addr, 1);
 
 	task* t = CURRENT_TASK;
-	t->fds[0] = std::make_unique<term_file_descriptor>();
+	for (int i = 0; i < 3; ++i) {
+		t->fds[i] = std::make_unique<term_file_descriptor>();
+	}
 
 	auto entry_addr = elf_header->e_entry;
 	call_userland(argc, argv, USER_SS, entry_addr, stack_addr.data + PAGE_SIZE - 8,
 				  &t->kernel_stack_top);
 
-	t->fds[0].reset();
+	for (int i = 0; i < 3; ++i) {
+		t->fds[i].reset();
+	}
 
 	const auto addr_first = get_first_load_addr(elf_header);
 	clean_page_tables(linear_address{ addr_first });

--- a/kernel/file_system/fat.hpp
+++ b/kernel/file_system/fat.hpp
@@ -125,6 +125,7 @@ struct file_descriptor : public ::file_descriptor {
 	}
 
 	size_t read(void* buf, size_t len) override;
+	size_t write(const void* buf, size_t len) override { return 0; }
 };
 
 } // namespace file_system

--- a/kernel/file_system/file_descriptor.hpp
+++ b/kernel/file_system/file_descriptor.hpp
@@ -9,4 +9,5 @@
 struct file_descriptor {
 	virtual ~file_descriptor() = default;
 	virtual size_t read(void* buf, size_t len) = 0;
+	virtual size_t write(const void* buf, size_t len) = 0;
 };

--- a/kernel/graphics/terminal.cpp
+++ b/kernel/graphics/terminal.cpp
@@ -284,3 +284,9 @@ size_t term_file_descriptor::read(void* buf, size_t len)
 		return 1;
 	}
 }
+
+size_t term_file_descriptor::write(const void* buf, size_t len)
+{
+	printk(KERN_DEBUG, reinterpret_cast<const char*>(buf));
+	return len;
+}

--- a/kernel/graphics/terminal.hpp
+++ b/kernel/graphics/terminal.hpp
@@ -134,4 +134,5 @@ void printk(int level, const char* format, Args... args)
 struct term_file_descriptor : public file_descriptor {
 	term_file_descriptor() = default;
 	size_t read(void* buf, size_t len) override;
+	size_t write(const void* buf, size_t len) override;
 };


### PR DESCRIPTION
Updated the file descriptor interface to include a write method while modifying corresponding filesystem implementations to work with this change. Improved file operation handling in syscall/handler.cpp and file_system/fat.cpp by utilizing the new write method and enhancing error management for better operation status reflection.