### PR TITLE
Add UTF-8 support and refactor font rendering

### DIFF
--- a/kernel/graphics/font.cpp
+++ b/kernel/graphics/font.cpp
@@ -1,5 +1,8 @@
-#include "font.hpp"
-
+#include "graphics/font.hpp"
+#include "graphics/screen.hpp"
+#include "point2d.hpp"
+#include "terminal.hpp"
+#include <cstdint>
 #include <new>
 
 extern const uint8_t _binary_hankaku_bin_start;
@@ -11,6 +14,8 @@ bitmap_font::bitmap_font(int width, int height)
 {
 }
 
+bool is_ascii_code(char32_t c) { return c <= 0x7E; }
+
 const uint8_t* bitmap_font::get_font(char c)
 {
 	auto index = height_ * static_cast<unsigned int>(c);
@@ -19,6 +24,88 @@ const uint8_t* bitmap_font::get_font(char c)
 	}
 
 	return &font_data_[index];
+}
+
+void write_ascii(screen& scr, Point2D position, char c, uint32_t color_code)
+{
+	const uint8_t* font = kfont->get_font(c);
+	if (font != nullptr) {
+		for (int dy = 0; dy < kfont->height(); dy++) {
+			for (int dx = 0; dx < kfont->width(); dx++) {
+				if ((font[dy] << dx & 0x80) != 0) {
+					scr.put_pixel(position + Point2D{ dx, dy }, color_code);
+				}
+			}
+		}
+	}
+}
+
+int utf8_size(char c)
+{
+	if (c < 0x80) {
+		return 1;
+	}
+
+	if (0xc0 <= c && c < 0xe0) {
+		return 2;
+	}
+
+	if (0xe0 <= c && c < 0xf0) {
+		return 3;
+	}
+
+	if (0xf0 <= c && c < 0xf8) {
+		return 4;
+	}
+
+	return 0;
+}
+
+void write_unicode(screen& scr, Point2D position, char32_t c, uint32_t color_code)
+{
+	if (is_ascii_code(c)) {
+		write_ascii(scr, position, c, color_code);
+		return;
+	}
+
+	write_ascii(scr, position, '?', color_code);
+}
+
+char32_t utf8_to_unicode(const char* utf8)
+{
+	switch (utf8_size(*utf8)) {
+		case 1:
+			return static_cast<char32_t>(utf8[0]);
+		case 2:
+			return (static_cast<char32_t>(utf8[0]) & 0b0001'1111) << 6 |
+				   (static_cast<char32_t>(utf8[1]) & 0b0011'1111) << 0;
+		case 3:
+			return (static_cast<char32_t>(utf8[0]) & 0b0000'1111) << 12 |
+				   (static_cast<char32_t>(utf8[1]) & 0b0011'1111) << 6 |
+				   (static_cast<char32_t>(utf8[2]) & 0b0011'1111) << 0;
+		case 4:
+			return (static_cast<char32_t>(utf8[0]) & 0b0000'0111) << 18 |
+				   (static_cast<char32_t>(utf8[1]) & 0b0011'1111) << 12 |
+				   (static_cast<char32_t>(utf8[2]) & 0b0011'1111) << 6 |
+				   (static_cast<char32_t>(utf8[3]) & 0b0011'1111) << 0;
+		default:
+			return 0;
+	}
+}
+
+void write_string(screen& scr, Point2D position, const char* s, uint32_t color_code)
+{
+	int font_position = 0;
+	while (*s != '\0') {
+		const int size = utf8_size(*s);
+		const char32_t c = utf8_to_unicode(s);
+
+		write_unicode(scr, position + Point2D{ font_position * kfont->width(), 0 },
+					  c, color_code);
+
+		font_position += is_ascii_code(c) ? 1 : 2;
+		s += size;
+	}
 }
 
 bitmap_font* kfont;

--- a/kernel/graphics/font.hpp
+++ b/kernel/graphics/font.hpp
@@ -19,6 +19,20 @@ private:
 	int height_;
 };
 
+class screen;
+
+bool is_ascii_code(char32_t c);
+
+int utf8_size(char c);
+
+char32_t utf8_to_unicode(const char* utf8);
+
+void write_ascii(screen& scr, Point2D position, char c, uint32_t color_code);
+
+void write_unicode(screen& scr, Point2D position, char32_t c, uint32_t color_code);
+
+void write_string(screen& scr, Point2D position, const char* s, uint32_t color_code);
+
 extern bitmap_font* kfont;
 
 void initialize_font();

--- a/kernel/graphics/screen.cpp
+++ b/kernel/graphics/screen.cpp
@@ -2,6 +2,7 @@
 #include "../../UchLoaderPkg/frame_buffer_conf.hpp"
 #include "graphics/color.hpp"
 #include "graphics/font.hpp"
+#include <cstdint>
 #include <new>
 
 screen::screen(const FrameBufferConf& frame_buffer_conf, Color bg_color)
@@ -29,36 +30,6 @@ void screen::fill_rectangle(Point2D position,
 			put_pixel(position + Point2D{ dx, dy }, color_code);
 		}
 	}
-}
-
-void screen::draw_string(Point2D position, const char* s, uint32_t color_code)
-{
-	int font_position = 0;
-	while (*s != '\0') {
-		const uint8_t* font = kfont->get_font(*s);
-		if (font != nullptr) {
-			for (int dy = 0; dy < kfont->height(); dy++) {
-				for (int dx = 0; dx < kfont->width(); dx++) {
-					if ((font[dy] << dx & 0x80) != 0) {
-						put_pixel(
-								position +
-										Point2D{ font_position * kfont->width() + dx,
-												 dy },
-								color_code);
-					}
-				}
-			}
-		}
-
-		font_position++;
-		s++;
-	}
-}
-
-void screen::draw_string(Point2D position, char s, uint32_t color_code)
-{
-	char temp[2] = { s, '\0' };
-	draw_string(position, temp, color_code);
 }
 
 screen* kscreen;

--- a/kernel/graphics/screen.hpp
+++ b/kernel/graphics/screen.hpp
@@ -19,8 +19,6 @@ public:
 
 	void put_pixel(Point2D point, uint32_t color_code);
 	void fill_rectangle(Point2D position, Point2D size, uint32_t color_code);
-	void draw_string(Point2D position, const char* s, uint32_t color_code);
-	void draw_string(Point2D position, char s, uint32_t color_code);
 
 private:
 	uint64_t pixels_per_scan_line_;


### PR DESCRIPTION
The update introduces Unicode (UTF-8) handling functions, extending support for non-ASCII characters. The existing ASCII rendering function has been refactored and relocated under 'font.hpp'. Also, 'write_string', 'write_unicode' and 'write_ascii' were added for better control over text output. Unnecessary 'draw_string' methods were purged from 'screen' state.