### PR TITLE
std::functionの撤廃

### DIFF
--- a/kernel/hardware/virtio/blk.cpp
+++ b/kernel/hardware/virtio/blk.cpp
@@ -181,27 +181,10 @@ void virtio_blk_task()
 
 	init_blk_device();
 
-	t->message_handlers2[IPC_READ_FROM_BLK_DEVICE] = handle_read_request;
-	t->message_handlers2[IPC_WRITE_TO_BLK_DEVICE] = handle_write_request;
+	t->message_handlers[IPC_READ_FROM_BLK_DEVICE] = handle_read_request;
+	t->message_handlers[IPC_WRITE_TO_BLK_DEVICE] = handle_write_request;
 
 	t->is_initilized = true;
 
-	while (true) {
-		if (t->messages.empty()) {
-			switch_next_task(true);
-			continue;
-		}
-
-		t->state = TASK_RUNNING;
-
-		const message m = t->messages.front();
-		t->messages.pop();
-
-		if (m.type < 0 || m.type >= NUM_MESSAGE_TYPES) {
-			continue;
-		}
-
-		t->message_handlers2[m.type](m);
-	}
-	// process_messages(t);
+	process_messages(t);
 }

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -289,10 +289,7 @@ task::task(int id,
 	  state{ state },
 	  stack{ nullptr },
 	  messages{ std::queue<message>() },
-	  message_handlers2({ std::array<message_handler_t, NUM_MESSAGE_TYPES>() }),
-	  message_handlers{
-		  std::array<std::function<void(const message&)>, NUM_MESSAGE_TYPES>()
-	  },
+	  message_handlers({ std::array<message_handler_t, NUM_MESSAGE_TYPES>() }),
 	  fds{ std::array<std::shared_ptr<file_descriptor>, 10>() }
 {
 	list_elem_init(&run_queue_elem);

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -258,7 +258,7 @@ void initialize_task()
 {
 	tasks = std::array<task*, MAX_TASKS>();
 	list_init(&run_queue);
-	// pending_messages = std::queue<message, kernel_allocator<message>>();
+	pending_messages = std::queue<message, kernel_allocator<message>>();
 
 	for (const auto& t_info : initial_tasks) {
 		task* new_task = create_task(t_info.name, t_info.addr, t_info.setup_context,
@@ -289,6 +289,7 @@ task::task(int id,
 	  state{ state },
 	  stack{ nullptr },
 	  messages{ std::queue<message>() },
+	  message_handlers2({ std::array<message_handler_t, NUM_MESSAGE_TYPES>() }),
 	  message_handlers{
 		  std::array<std::function<void(const message&)>, NUM_MESSAGE_TYPES>()
 	  },

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -34,9 +34,7 @@ struct task {
 	page_table_entry* page_table_snapshot;
 	list_elem_t run_queue_elem;
 	std::queue<message> messages;
-	std::array<message_handler_t, NUM_MESSAGE_TYPES> message_handlers2;
-	std::array<std::function<void(const message&)>, NUM_MESSAGE_TYPES>
-			message_handlers;
+	std::array<message_handler_t, NUM_MESSAGE_TYPES> message_handlers;
 	std::array<std::shared_ptr<file_descriptor>, 10> fds;
 
 	task(int id,

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -34,6 +34,7 @@ struct task {
 	page_table_entry* page_table_snapshot;
 	list_elem_t run_queue_elem;
 	std::queue<message> messages;
+	std::array<message_handler_t, NUM_MESSAGE_TYPES> message_handlers2;
 	std::array<std::function<void(const message&)>, NUM_MESSAGE_TYPES>
 			message_handlers;
 	std::array<std::shared_ptr<file_descriptor>, 10> fds;

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -3,12 +3,16 @@
 #include <cstddef>
 #include <cstdint>
 
+struct message;
+
 using error_t = int;
 using pid_t = int;
 using fd_t = int;
 using cluster_t = unsigned long;
 using paddr_t = uint64_t;
 using fs_id_t = size_t;
+
+using message_handler_t = void (*)(const message&);
 
 // error codes
 #define IS_OK(err) (!IS_ERR(err))


### PR DESCRIPTION
動的メモリ確保が悪さしていそうなので撤廃する