### PR TITLE
fix: Detect test failures in kernel test framework

### DIFF
--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -67,6 +67,7 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 	run_test_suite(register_virtio_blk_tests);
 	run_test_suite(register_stdio_tests);
 	run_test_suite(register_fd_tests);
+	test_print_summary();
 
 	kernel::task::kernel_service();
 }

--- a/kernel/tests/framework.cpp
+++ b/kernel/tests/framework.cpp
@@ -45,7 +45,6 @@ void test_register(const char* name, test_func_t func)
 void test_run()
 {
 	stats.total = test_count;
-	LOG_TEST("running %d tests", test_count);
 
 	for (int i = 0; i < test_count; i++) {
 		current_test_failed = false;
@@ -63,8 +62,12 @@ void test_run()
 	total_stats.passed += stats.passed;
 	total_stats.failed += stats.failed;
 
-	LOG_TEST("suite result: total=%d passed=%d failed=%d", stats.total, stats.passed,
-			 stats.failed);
+	// The screen console cannot scroll yet, so stay silent unless something
+	// failed; the cumulative result is printed by test_print_summary().
+	if (stats.failed > 0) {
+		LOG_TEST("suite result: total=%d passed=%d failed=%d", stats.total,
+				 stats.passed, stats.failed);
+	}
 }
 
 void run_test_suite(void (*test_suite)())

--- a/kernel/tests/framework.cpp
+++ b/kernel/tests/framework.cpp
@@ -19,6 +19,7 @@ constexpr int MAX_TEST_CASES = 100;
 TestCaseT test_cases[MAX_TEST_CASES];
 int test_count = 0;
 TestStatsT stats = { 0, 0, 0 };
+TestStatsT total_stats = { 0, 0, 0 };
 bool current_test_failed = false;
 } // namespace
 void test_init()
@@ -28,6 +29,8 @@ void test_init()
 	current_test_failed = false;
 	memset(test_cases, 0, sizeof(test_cases));
 }
+
+void test_mark_failed() { current_test_failed = true; }
 
 void test_register(const char* name, test_func_t func)
 {
@@ -42,14 +45,26 @@ void test_register(const char* name, test_func_t func)
 void test_run()
 {
 	stats.total = test_count;
+	LOG_TEST("running %d tests", test_count);
+
 	for (int i = 0; i < test_count; i++) {
-		LOG_INFO("Running test: %s", test_cases[i].name);
+		current_test_failed = false;
 		test_cases[i].func();
 
-		if (!current_test_failed) {
+		if (current_test_failed) {
+			stats.failed++;
+			LOG_TEST("FAIL: %s", test_cases[i].name);
+		} else {
 			stats.passed++;
 		}
 	}
+
+	total_stats.total += stats.total;
+	total_stats.passed += stats.passed;
+	total_stats.failed += stats.failed;
+
+	LOG_TEST("suite result: total=%d passed=%d failed=%d", stats.total, stats.passed,
+			 stats.failed);
 }
 
 void run_test_suite(void (*test_suite)())
@@ -58,5 +73,19 @@ void run_test_suite(void (*test_suite)())
 	test_init();
 	test_suite();
 	test_run();
+	kernel::graphics::change_log_level(kernel::graphics::LogLevel::ERROR);
+}
+
+void test_print_summary()
+{
+	// printk only emits messages whose level matches the current log level
+	// exactly, so the summary must be printed while the level is TEST.
+	kernel::graphics::change_log_level(kernel::graphics::LogLevel::TEST);
+
+	const bool passed = total_stats.total > 0 && total_stats.failed == 0;
+	LOG_TEST("TEST_SUMMARY: total=%d passed=%d failed=%d result=%s",
+			 total_stats.total, total_stats.passed, total_stats.failed,
+			 passed ? "PASS" : "FAIL");
+
 	kernel::graphics::change_log_level(kernel::graphics::LogLevel::ERROR);
 }

--- a/kernel/tests/framework.hpp
+++ b/kernel/tests/framework.hpp
@@ -53,6 +53,26 @@ void test_register(const char* name, test_func_t func);
 void test_run();
 
 /**
+ * @brief Mark the currently running test as failed
+ *
+ * Called by the assertion macros in tests/macros.hpp when a check fails.
+ * The failure is counted in the statistics reported by test_run().
+ */
+void test_mark_failed();
+
+/**
+ * @brief Print the cumulative test results across all executed suites
+ *
+ * Prints a machine-readable summary line
+ * (TEST_SUMMARY: total=N passed=N failed=N result=PASS|FAIL) covering every
+ * suite executed since boot. Call once after all test suites have run so
+ * CI can parse the overall result.
+ *
+ * @note result is PASS only if at least one test ran and none failed
+ */
+void test_print_summary();
+
+/**
  * @brief Run a complete test suite
  *
  * Convenience function that initializes the test framework, runs the

--- a/kernel/tests/macros.hpp
+++ b/kernel/tests/macros.hpp
@@ -5,6 +5,8 @@
  * This file provides assertion and expectation macros for writing unit tests.
  * ASSERT macros will cause the test to return immediately on failure, while
  * EXPECT macros will log the failure but continue test execution.
+ * Both mark the current test as failed via test_mark_failed() so the
+ * framework counts it in the suite statistics.
  *
  * @date 2024
  */
@@ -13,6 +15,7 @@
 
 #include <cstddef>
 #include "graphics/log.hpp"
+#include "tests/framework.hpp"
 
 /**
  * @brief Assert that two values are equal
@@ -23,6 +26,7 @@
 #define ASSERT_EQ(x, y)                                                             \
 	do {                                                                            \
 		if ((x) != (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_EQ failed: %d != %d", x, y);                           \
 			return;                                                                 \
 		}                                                                           \
@@ -37,6 +41,7 @@
 #define ASSERT_NE(x, y)                                                             \
 	do {                                                                            \
 		if ((x) == (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_NE failed: %d == %d", x, y);                           \
 			return;                                                                 \
 		}                                                                           \
@@ -51,6 +56,7 @@
 #define ASSERT_GT(x, y)                                                             \
 	do {                                                                            \
 		if ((x) <= (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_GT failed: %d <= %d", x, y);                           \
 			return;                                                                 \
 		}                                                                           \
@@ -65,6 +71,7 @@
 #define ASSERT_LT(x, y)                                                             \
 	do {                                                                            \
 		if ((x) >= (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_LT failed: %d >= %d", x, y);                           \
 			return;                                                                 \
 		}                                                                           \
@@ -78,6 +85,7 @@
 #define ASSERT_TRUE(x)                                                              \
 	do {                                                                            \
 		if (!(x)) {                                                                 \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_TRUE failed: %d", x);                                  \
 			return;                                                                 \
 		}                                                                           \
@@ -91,6 +99,7 @@
 #define ASSERT_FALSE(x)                                                             \
 	do {                                                                            \
 		if (x) {                                                                    \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_FALSE failed: %d", x);                                 \
 			return;                                                                 \
 		}                                                                           \
@@ -104,6 +113,7 @@
 #define ASSERT_NULL(x)                                                              \
 	do {                                                                            \
 		if ((x) != nullptr) {                                                       \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_NULL failed: %d", x);                                  \
 			return;                                                                 \
 		}                                                                           \
@@ -117,6 +127,7 @@
 #define ASSERT_NOT_NULL(x)                                                          \
 	do {                                                                            \
 		if ((x) == NULL) {                                                          \
+			test_mark_failed();                                                     \
 			LOG_TEST("ASSERT_NOT_NULL failed: %d", x);                              \
 			return;                                                                 \
 		}                                                                           \
@@ -131,6 +142,7 @@
 #define EXPECT_EQ(x, y)                                                             \
 	do {                                                                            \
 		if ((x) != (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_EQ failed: %d != %d", x, y);                           \
 		}                                                                           \
 	} while (0)
@@ -144,6 +156,7 @@
 #define EXPECT_NE(x, y)                                                             \
 	do {                                                                            \
 		if ((x) == (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_NE failed: %d == %d", x, y);                           \
 		}                                                                           \
 	} while (0)
@@ -151,6 +164,7 @@
 #define EXPECT_GT(x, y)                                                             \
 	do {                                                                            \
 		if ((x) <= (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_GT failed: %d <= %d", x, y);                           \
 		}                                                                           \
 	} while (0)
@@ -158,6 +172,7 @@
 #define EXPECT_LT(x, y)                                                             \
 	do {                                                                            \
 		if ((x) >= (y)) {                                                           \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_LT failed: %d >= %d", x, y);                           \
 		}                                                                           \
 	} while (0)
@@ -165,6 +180,7 @@
 #define EXPECT_TRUE(x)                                                              \
 	do {                                                                            \
 		if (!(x)) {                                                                 \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_TRUE failed: %d", x);                                  \
 		}                                                                           \
 	} while (0)
@@ -172,6 +188,7 @@
 #define EXPECT_FALSE(x)                                                             \
 	do {                                                                            \
 		if (x) {                                                                    \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_FALSE failed: %d", x);                                 \
 		}                                                                           \
 	} while (0)
@@ -179,6 +196,7 @@
 #define EXPECT_NULL(x)                                                              \
 	do {                                                                            \
 		if ((x) != nullptr) {                                                       \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_NULL failed: %d", x);                                  \
 		}                                                                           \
 	} while (0)
@@ -191,6 +209,7 @@
 #define EXPECT_NOT_NULL(x)                                                          \
 	do {                                                                            \
 		if ((x) == NULL) {                                                          \
+			test_mark_failed();                                                     \
 			LOG_TEST("EXPECT_NOT_NULL failed: %d", x);                              \
 		}                                                                           \
 	} while (0)

--- a/kernel/tests/test_cases/fd_test.cpp
+++ b/kernel/tests/test_cases/fd_test.cpp
@@ -38,8 +38,6 @@ void test_fd_allocation()
 									   ProcessId::from_raw(1));
 	ASSERT_NE(fd1, fd2);
 	ASSERT_GT(fd2, -1);
-
-	LOG_TEST("test_fd_allocation passed");
 }
 
 void test_fd_release()
@@ -66,8 +64,6 @@ void test_fd_release()
 
 	result = fs::release_process_fd(fd_table, 32, STDOUT_FILENO);
 	ASSERT_EQ(result, ERR_INVALID_FD);
-
-	LOG_TEST("test_fd_release passed");
 }
 
 void test_fd_fork_copy()
@@ -107,8 +103,6 @@ void test_fd_fork_copy()
 	ASSERT_TRUE(child_table[STDIN_FILENO].is_used());
 	ASSERT_TRUE(child_table[STDOUT_FILENO].is_used());
 	ASSERT_TRUE(child_table[STDERR_FILENO].is_used());
-
-	LOG_TEST("test_fd_fork_copy passed");
 }
 
 void test_fd_dup2()
@@ -135,8 +129,6 @@ void test_fd_dup2()
 	fs::FileDescriptor* redirected = fs::get_process_fd(fd_table, 32, STDOUT_FILENO);
 	ASSERT_NOT_NULL(redirected);
 	ASSERT_EQ(strcmp(redirected->name, "output.txt"), 0);
-
-	LOG_TEST("test_fd_dup2 passed");
 }
 
 void test_fd_limits()
@@ -167,8 +159,6 @@ void test_fd_limits()
 	fd_t new_fd = fs::allocate_process_fd(fd_table, 8, "new.txt", 100,
 										  ProcessId::from_raw(1));
 	ASSERT_EQ(new_fd, fds[0]); // Should reuse the freed slot
-
-	LOG_TEST("test_fd_limits passed");
 }
 
 void test_release_all_fds()
@@ -201,8 +191,6 @@ void test_release_all_fds()
 	ASSERT_TRUE(fd_table[STDIN_FILENO].is_used());
 	ASSERT_TRUE(fd_table[STDOUT_FILENO].is_used());
 	ASSERT_TRUE(fd_table[STDERR_FILENO].is_used());
-
-	LOG_TEST("test_release_all_fds passed");
 }
 
 void register_fd_tests()

--- a/kernel/tests/test_cases/fd_test.cpp
+++ b/kernel/tests/test_cases/fd_test.cpp
@@ -96,6 +96,13 @@ void test_fd_fork_copy()
 	ASSERT_EQ(strcmp(parent_entry1->name, child_entry1->name), 0);
 	ASSERT_EQ(parent_entry1->size, child_entry1->size);
 
+	fs::FileDescriptor* parent_entry2 = fs::get_process_fd(parent_table, 32, fd2);
+	fs::FileDescriptor* child_entry2 = fs::get_process_fd(child_table, 32, fd2);
+	ASSERT_NOT_NULL(parent_entry2);
+	ASSERT_NOT_NULL(child_entry2);
+	ASSERT_EQ(strcmp(parent_entry2->name, child_entry2->name), 0);
+	ASSERT_EQ(parent_entry2->size, child_entry2->size);
+
 	// Verify standard descriptors are also copied
 	ASSERT_TRUE(child_table[STDIN_FILENO].is_used());
 	ASSERT_TRUE(child_table[STDOUT_FILENO].is_used());
@@ -200,10 +207,10 @@ void test_release_all_fds()
 
 void register_fd_tests()
 {
-	// test_register("test_fd_allocation", test_fd_allocation);
-	// test_register("test_fd_release", test_fd_release);
-	// test_register("test_fd_fork_copy", test_fd_fork_copy);
-	// test_register("test_fd_dup2", test_fd_dup2);
-	// test_register("test_fd_limits", test_fd_limits);
-	// test_register("test_release_all_fds", test_release_all_fds);
+	test_register("test_fd_allocation", test_fd_allocation);
+	test_register("test_fd_release", test_fd_release);
+	test_register("test_fd_fork_copy", test_fd_fork_copy);
+	test_register("test_fd_dup2", test_fd_dup2);
+	test_register("test_fd_limits", test_fd_limits);
+	test_register("test_release_all_fds", test_release_all_fds);
 }


### PR DESCRIPTION
## 概要

[#311](https://github.com/junyaU/uchos/issues/311)(Phase 0: テスト・CI 安全網の修理)の PR 案 1/3。

テストフレームワークには `current_test_failed` を `true` にするコードが存在せず、**アサーションが失敗しても全テストが常に PASS 扱い**になっていた。本 PR で失敗検知を実装し、CI がパースできる機械可読サマリーを追加する。

## 変更内容

- 全 16 の ASSERT_*/EXPECT_* マクロの失敗分岐に `test_mark_failed()` を追加(`kernel/tests/macros.hpp`)
- `test_run()` がテスト毎に失敗フラグをリセットし、失敗テストを `FAIL: <テスト名>` として出力・`stats.failed` に計上
- `test_print_summary()` を新設し、全スイート累積の機械可読サマリーを出力(`kernel/main.cpp` 末尾から呼ぶ)
  - `TEST_SUMMARY: total=N passed=N failed=N result=PASS|FAIL`
  - テスト 0 件は FAIL 扱い(fail-closed)
  - printk はレベル完全一致でしか出力しないため、内部で TEST レベルへ切替えて出力
- **画面スクロール未実装への配慮で出力は最小化**: 全成功時は TEST_SUMMARY の 1 行のみ。`suite result:` 行は失敗があったスイートのみ出力。fd_test 内の無条件 `LOG_TEST("... passed")` 行は削除
- `register_fd_tests()` が全登録コメントアウトで **0 件実行の no-op だった**問題を修正し、6 テストを有効化
- `test_fd_fork_copy` に 2 つ目の fd のコピー検証を追加(未使用変数 `fd2` 警告も解消)

## 検証

ホスト用ハーネス(実物の `framework.cpp` を printk スタブとコンパイル。スタブは実物と同じ完全一致レベルフィルタを再現)で実走確認:

失敗ありの場合:
```
ASSERT_EQ failed: 1 != 2
FAIL: test_assert_fails
EXPECT_TRUE failed: 0
FAIL: test_expect_fails_but_continues
suite result: total=4 passed=2 failed=2
TEST_SUMMARY: total=4 passed=2 failed=2 result=FAIL
```

全成功の場合(出力はこの 1 行のみ):
```
TEST_SUMMARY: total=1 passed=1 failed=0 result=PASS
```

- ASSERT 失敗の検知 / EXPECT の「計上して継続」/ 失敗後テストの正常 PASS 計上(テスト毎リセット)を確認
- カーネルビルド警告ゼロ、`./lint.sh` クリーン

## レビュー時の注意

- QEMU での実機確認は未実施(`./run_qemu.sh` で `TEST_SUMMARY` 行をご確認ください)
- 有効化した fd テストが実バグを検知して FAIL が表示される可能性があります。それはこの修理の意図どおりの挙動です
- サマリーは現状フレームバッファのみに出ます。シリアル出力と CI 連携は PR 案 3 で対応予定

Part of #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
