### PR TITLE
feat: Separate kernel tests from production init paths

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -87,6 +87,10 @@ set(SOURCE_FILES
         panic.cpp
 )
 
+# Build the kernel test suites and run them at boot. Will default to OFF
+# once CI (issue #311 PR 3) becomes the primary way to run the tests.
+option(KERNEL_TESTS "Build kernel test suites and run them at boot" ON)
+
 # Add subdirectories that contain their own CMakeLists.txt files.
 add_subdirectory(memory)
 add_subdirectory(graphics)
@@ -97,7 +101,13 @@ add_subdirectory(hardware)
 add_subdirectory(fs)
 add_subdirectory(syscall)
 add_subdirectory(net)
-add_subdirectory(tests)
+
+set(KERNEL_TEST_LIBS "")
+if(KERNEL_TESTS)
+        add_compile_definitions(KERNEL_TESTS_ENABLED)
+        add_subdirectory(tests)
+        set(KERNEL_TEST_LIBS UchosTest)
+endif()
 
 # Define the main target and link it with the necessary libraries.
 add_executable(UchosKernel ${SOURCE_FILES})
@@ -118,5 +128,5 @@ target_link_libraries(
         UchosFileSystem
         UchosSyscall
         UchosNet
-        UchosTest
+        ${KERNEL_TEST_LIBS}
 )

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -10,10 +10,7 @@
 #include "syscall/syscall.hpp"
 #include "task/builtin.hpp"
 #include "task/task.hpp"
-#include "tests/framework.hpp"
-#include "tests/test_cases/fd_test.hpp"
-#include "tests/test_cases/stdio_test.hpp"
-#include "tests/test_cases/virtio_blk_test.hpp"
+#include "tests/runner.hpp"
 #include "timers/acpi.hpp"
 #include "timers/local_apic.hpp"
 #include "timers/timer.hpp"
@@ -42,6 +39,8 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	kernel::memory::initialize(memory_map);
 
+	kernel::tests::run_bootstrap_stage_tests();
+
 	kernel::memory::initialize_heap();
 
 	kernel::memory::initialize_pages();
@@ -58,16 +57,15 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	kernel::timers::initialize();
 
+	kernel::tests::run_timer_stage_tests();
+
 	kernel::timers::local_apic::initialize();
 
 	kernel::syscall::initialize();
 
 	kernel::task::initialize();
 
-	run_test_suite(register_virtio_blk_tests);
-	run_test_suite(register_stdio_tests);
-	run_test_suite(register_fd_tests);
-	test_print_summary();
+	kernel::tests::run_main_stage_tests();
 
 	kernel::task::kernel_service();
 }

--- a/kernel/memory/bootstrap_allocator.cpp
+++ b/kernel/memory/bootstrap_allocator.cpp
@@ -7,8 +7,6 @@
 #include "graphics/log.hpp"
 #include "memory/buddy_system.hpp"
 #include "memory/page.hpp"
-#include "tests/framework.hpp"
-#include "tests/test_cases/memory_test.hpp"
 
 #include <sys/types.h>
 
@@ -128,8 +126,6 @@ void initialize(const MemoryMap& mem_map)
 	}
 
 	kernel::memory::boot_allocator->show_available_memory();
-
-	run_test_suite(register_bootstrap_allocator_tests);
 
 	LOG_INFO("Bootstrap allocator initialized successfully.");
 }

--- a/kernel/memory/buddy_system.cpp
+++ b/kernel/memory/buddy_system.cpp
@@ -5,8 +5,6 @@
 #include "bit_utils.hpp"
 #include "graphics/log.hpp"
 #include "memory/page.hpp"
-#include "tests/framework.hpp"
-#include "tests/test_cases/memory_test.hpp"
 
 namespace kernel::memory
 {
@@ -233,8 +231,6 @@ void initialize_memory_manager()
 	if (num_total_pages > 0) {
 		memory_manager->register_memory_blocks(num_total_pages, &pages[start_index]);
 	}
-
-	run_test_suite(register_buddy_system_tests);
 
 	LOG_INFO("Memory manager initialized successfully.");
 }

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -11,8 +11,6 @@
 #include "buddy_system.hpp"
 #include "graphics/log.hpp"
 #include "page.hpp"
-#include "tests/framework.hpp"
-#include "tests/test_cases/memory_test.hpp"
 
 namespace kernel::memory
 {
@@ -286,8 +284,6 @@ void initialize_slab_allocator()
 	aligned_to_raw_addr_map = std::unordered_map<void*, void*>();
 
 	cache_chain.clear();
-
-	run_test_suite(register_slab_tests);
 
 	LOG_INFO("Initializing slab allocator successfully.");
 }

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -23,8 +23,6 @@
 #include "task/context.hpp"
 #include "task/context_switch.h"
 #include "task/ipc.hpp"
-#include "tests/framework.hpp"
-#include "tests/test_cases/task_test.hpp"
 #include "timers/timer.hpp"
 
 namespace kernel::task
@@ -305,8 +303,6 @@ void initialize()
 	CURRENT_TASK->state = TASK_RUNNING;
 
 	kernel::timers::ktimer->add_switch_task_event(200);
-
-	run_test_suite(register_task_tests);
 }
 
 Task::Task(int raw_id,

--- a/kernel/tests/CMakeLists.txt
+++ b/kernel/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCE_FILES
         framework.cpp
+        runner.cpp
 )
 
 add_library(UchosTest ${TEST_SOURCE_FILES})

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file tests/runner.cpp
+ * @brief Staged kernel test runner implementation
+ */
+
+#include "tests/runner.hpp"
+#include <array>
+#include "task/task.hpp"
+#include "tests/framework.hpp"
+#include "tests/test_cases/fd_test.hpp"
+#include "tests/test_cases/fs_test.hpp"
+#include "tests/test_cases/memory_test.hpp"
+#include "tests/test_cases/stdio_test.hpp"
+#include "tests/test_cases/task_test.hpp"
+#include "tests/test_cases/timer_test.hpp"
+#include "tests/test_cases/virtio_blk_test.hpp"
+
+namespace
+{
+
+std::array<bool, kernel::task::MAX_TASKS> slot_snapshot;
+
+void snapshot_task_slots()
+{
+	for (int i = 0; i < kernel::task::MAX_TASKS; ++i) {
+		slot_snapshot[i] = kernel::task::tasks[i] != nullptr;
+	}
+}
+
+// Tasks created by test cases are never scheduled, so clearing the slot is
+// enough to keep the task table usable after the suites. The Task objects
+// themselves are not deleted here: ~Task frees the page tables, which are
+// partly shared with the kernel address space (see #313).
+void release_new_task_slots()
+{
+	for (int i = 0; i < kernel::task::MAX_TASKS; ++i) {
+		if (!slot_snapshot[i] && kernel::task::tasks[i] != nullptr) {
+			kernel::task::tasks[i] = nullptr;
+		}
+	}
+}
+
+} // namespace
+
+namespace kernel::tests
+{
+
+void run_bootstrap_stage_tests()
+{
+	run_test_suite(register_bootstrap_allocator_tests);
+}
+
+void run_timer_stage_tests() { run_test_suite(register_timer_tests); }
+
+void run_main_stage_tests()
+{
+	run_test_suite(register_buddy_system_tests);
+	run_test_suite(register_slab_tests);
+	run_test_suite(register_alloc_macro_tests);
+
+	snapshot_task_slots();
+	run_test_suite(register_task_tests);
+	run_test_suite(register_stdio_tests);
+	release_new_task_slots();
+
+	run_test_suite(register_virtio_blk_tests);
+	run_test_suite(register_fs_tests);
+	run_test_suite(register_fd_tests);
+
+	test_print_summary();
+}
+
+} // namespace kernel::tests

--- a/kernel/tests/runner.hpp
+++ b/kernel/tests/runner.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file tests/runner.hpp
+ * @brief Staged kernel test runner
+ *
+ * Groups all test suites into three stages that main.cpp invokes at the
+ * points in the boot sequence where their preconditions hold. When the
+ * KERNEL_TESTS CMake option is OFF the stages compile to empty inline
+ * stubs and no test code is linked into the kernel.
+ */
+
+#pragma once
+
+namespace kernel::tests
+{
+
+#ifdef KERNEL_TESTS_ENABLED
+/**
+ * @brief Run suites that need the bootstrap allocator to be alive
+ *
+ * Must be called after kernel::memory::initialize() and before
+ * kernel::memory::disable(), because the bootstrap allocator suite
+ * exercises the global boot_allocator directly.
+ */
+void run_bootstrap_stage_tests();
+
+/**
+ * @brief Run suites that need the timer to be idle
+ *
+ * Must be called after kernel::timers::initialize() and before
+ * kernel::timers::local_apic::initialize(), because the timer suite
+ * assumes tick 0 and manually advances the tick counter.
+ */
+void run_timer_stage_tests();
+
+/**
+ * @brief Run all remaining suites and print the cumulative summary
+ *
+ * Must be called after kernel::task::initialize(). Task slots created
+ * by test cases are released afterwards so the task table is left
+ * usable for the rest of the boot.
+ */
+void run_main_stage_tests();
+#else
+inline void run_bootstrap_stage_tests() {}
+inline void run_timer_stage_tests() {}
+inline void run_main_stage_tests() {}
+#endif
+
+} // namespace kernel::tests

--- a/kernel/tests/test_cases/fd_test.cpp
+++ b/kernel/tests/test_cases/fd_test.cpp
@@ -116,19 +116,16 @@ void test_fd_dup2()
 										   ProcessId::from_raw(1));
 	ASSERT_GT(file_fd, -1);
 
-	// Test redirection setup
-	// fd_table[STDOUT_FILENO].fd.redirect_to = file_fd;
+	// dup2 replaces the target entry with a copy of the source entry
+	// (see handle_fs_dup2 in kernel/fs/fat/file.cpp)
+	fs::FileDescriptor* src = fs::get_process_fd(fd_table, 32, file_fd);
+	ASSERT_NOT_NULL(src);
+	fd_table[STDOUT_FILENO] = *src;
 
-	// Verify redirection
-	fs::FileDescriptor* stdout_entry =
-			fs::get_process_fd(fd_table, 32, STDOUT_FILENO);
-	ASSERT_NOT_NULL(stdout_entry);
-	// ASSERT_EQ(stdout_entry->fd.redirect_to, file_fd);
-
-	// Get should follow redirection
 	fs::FileDescriptor* redirected = fs::get_process_fd(fd_table, 32, STDOUT_FILENO);
 	ASSERT_NOT_NULL(redirected);
 	ASSERT_EQ(strcmp(redirected->name, "output.txt"), 0);
+	ASSERT_EQ(redirected->size, src->size);
 }
 
 void test_fd_limits()

--- a/kernel/timers/timer.cpp
+++ b/kernel/timers/timer.cpp
@@ -6,8 +6,6 @@
 #include "graphics/log.hpp"
 #include "memory/slab.hpp"
 #include "task/ipc.hpp"
-#include "tests/framework.hpp"
-#include "tests/test_cases/timer_test.hpp"
 
 namespace
 {
@@ -134,8 +132,6 @@ void initialize()
 	ALLOC_OR_RETURN(addr, sizeof(KernelTimer), kernel::memory::ALLOC_ZEROED);
 
 	ktimer = new (addr) KernelTimer;
-
-	run_test_suite(register_timer_tests);
 
 	LOG_INFO("Logical timer initialized successfully.");
 }


### PR DESCRIPTION
## 概要

[#311](https://github.com/junyaU/uchos/issues/311)(Phase 0)の PR 案 2/3。

テストスイートが本番初期化関数(bootstrap allocator / buddy / slab / task / timer)の内部に埋め込まれ、毎ブート無条件実行されていた。全ての `run_test_suite` 呼び出しを本番コードから除去し、ステージ式テストランナーに集約する。

## 変更内容

### ステージ式ランナー(`kernel/tests/runner.{hpp,cpp}`)

各スイートには実行タイミングの前提条件があるため、main.cpp(初期化順序を握る composition root)から 3 ステージで呼び出す:

| ステージ | 呼び出し位置 | 対象スイート | 理由 |
|---|---|---|---|
| bootstrap | `memory::initialize()` 直後 | bootstrap_allocator | `disable()` 後は `boot_allocator` が nullptr になり実行不可能 |
| timer | `timers::initialize()` 直後 | timer | tick==0 前提+手動 tick 増加のため LAPIC 起動前が必須 |
| main | `task::initialize()` 後 | buddy / slab / **alloc_macro(初有効化)** / task / stdio / virtio_blk / **fs(初有効化)** / fd | 全初期化後で安全 |

- `KERNEL_TESTS` OFF 時はステージ関数がインラインの空実装になり、**テストコードは一切ビルド・リンクされない**
- main.cpp から `#ifdef` とテストヘッダ依存を排除(`tests/runner.hpp` のみ include)

### `KERNEL_TESTS` CMake オプション

- 既定 **ON**(現状テストの実行手段がブートしかないため)。PR 案 3 で CI が実行主体になった時点で既定 OFF に切替予定
- `cmake -B build kernel -DKERNEL_TESTS=OFF` で本番相当ビルド

### タスクスロットの隔離

task / stdio スイートは `create_task` で本番 `tasks[]` にタスクを作る。ランナーがスイート前後でスロットをスナップショット比較し、テストが作ったスロットを解放する(ASSERT の早期 return でも漏れない)。Task オブジェクト自体の delete は、ページテーブルがカーネル空間と共有されているため #313 の修正後に対応(現状はブート時の従来挙動と同等のリークに留まる)。

### `test_fd_dup2` の修正

旧 `redirect_to` 設計前提の自己矛盾テスト(準備コードがコメントアウトされたまま結果だけ要求 → 必ず FAIL)を、現行の dup2 実装(`handle_fs_dup2` = エントリのコピー)に合わせて書き直した。

## 検証

- `KERNEL_TESTS=ON`(既定): ビルド成功・警告ゼロ、`./lint.sh` クリーン
- `KERNEL_TESTS=OFF`: ビルド成功、成果物に UchosTest オブジェクトが 0 件(完全除外を確認)
- 本番コード(kernel/tests 以外)からの `run_test_suite`・テストヘッダ参照が 0 件

## レビュー時の注意

- QEMU での実機確認をお願いします。**新たに実行されるスイート(fs / alloc_macro)と実行順の変化により、これまで隠れていた FAIL が新たに表示される可能性があります**(例: buddy の error_handling は #313 の size-0 バグを検知し得る)。表示された FAIL は Phase 1(#313)の修正対象リストと突合してください
- timer / slab スイートの本番グローバル汚染(ktimer の tick 前進・test-cache 残留)は従来と同等で、本 PR では位置のみ変更。根本対処は #313

Part of #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
