### PR TITLE
feat: Run kernel tests headlessly in CI via QEMU

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -18,9 +18,13 @@ paths:
 1. `kernel/tests/test_cases/` に `<対象>_test.cpp` / `<対象>_test.hpp` を作成
 2. `<対象>_test.hpp` に `register_<対象>_tests()` を宣言し、cpp 内で `test_register` を呼ぶ
 3. `kernel/tests/test_cases/CMakeLists.txt` にソースを追加
-4. `kernel/main.cpp` に `run_test_suite(register_<対象>_tests);` を追加
+4. `kernel/tests/runner.cpp` の適切なステージ(bootstrap / timer / main)に `run_test_suite(register_<対象>_tests);` を追加
 5. ビルド確認: `cmake -B build kernel && cmake --build build`
 
-## 注意
+## 実行方法
 - テストの実行自体は QEMU 上で行われる(`./run_qemu.sh` はユーザーが実行)
+- CI では `scripts/run_kernel_tests.sh` がヘッドレス実行する: `-DKERNEL_TEST_EXIT=ON` でビルドしたカーネルが isa-debug-exit(port 0xf4)へ結果を書き、QEMU 終了コード(33=PASS / 35=FAIL)とシリアルの `TEST_SUMMARY:` マーカーの両方で判定される
+- 結果マーカー(`TEST_SUMMARY: total=N passed=N failed=N result=PASS|FAIL`)の形式を変える場合は `scripts/run_kernel_tests.sh` のパース処理も更新すること
+
+## 注意
 - 既存テスト(memory / task / timer / virtio_blk / fs / fd / stdio)の書き方を踏襲すること

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -41,8 +41,11 @@ jobs:
         sudo apt-get install -y build-essential uuid-dev python3 python-is-python3
         git clone --depth 1 --branch "$EDK2_TAG" https://github.com/tianocore/edk2.git "$HOME/edk2"
         cd "$HOME/edk2"
-        # Only BaseTools needs a submodule; the loader itself is MdePkg-only.
-        git submodule update --init --depth 1 BaseTools/Source/C/BrotliCompress/brotli
+        # Keep submodules minimal: BaseTools needs brotli, and MdePkg.dec
+        # references the mipisyst include directory.
+        git submodule update --init --depth 1 \
+            BaseTools/Source/C/BrotliCompress/brotli \
+            MdePkg/Library/MipiSysTLib/mipisyst
         make -C BaseTools -j"$(nproc)"
         ln -s "$GITHUB_WORKSPACE/UchLoaderPkg" UchLoaderPkg
         source edksetup.sh

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -1,5 +1,6 @@
-# This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
-# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
+# Build the kernel, run the kernel test suites headlessly in QEMU, and lint.
+# The UEFI loader is built from UchLoaderPkg with EDK2 and cached; the cache
+# is only invalidated when UchLoaderPkg/ or the pinned EDK2 tag changes.
 name: CMake on a single platform
 
 on:
@@ -11,41 +12,67 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  EDK2_TAG: edk2-stable202405
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Install dependencie
+    - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y nasm clang lld clang-tidy iwyu
+        sudo apt-get install -y nasm clang lld clang-tidy qemu-system-x86 ovmf mtools dosfstools
         curl -L https://github.com/uchan-nos/mikanos-build/releases/download/v2.0/x86_64-elf.tar.gz -o x86_64-elf.tar.gz
-        tar -xzvf x86_64-elf.tar.gz
-        
+        tar -xzf x86_64-elf.tar.gz
+
+    - name: Cache UEFI loader
+      id: cache-loader
+      uses: actions/cache@v4
+      with:
+        path: Loader.efi
+        key: loader-${{ env.EDK2_TAG }}-${{ hashFiles('UchLoaderPkg/**') }}
+
+    - name: Build UEFI loader
+      if: steps.cache-loader.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get install -y build-essential uuid-dev python3 python-is-python3
+        git clone --depth 1 --branch "$EDK2_TAG" https://github.com/tianocore/edk2.git "$HOME/edk2"
+        cd "$HOME/edk2"
+        # Only BaseTools needs a submodule; the loader itself is MdePkg-only.
+        git submodule update --init --depth 1 BaseTools/Source/C/BrotliCompress/brotli
+        make -C BaseTools -j"$(nproc)"
+        ln -s "$GITHUB_WORKSPACE/UchLoaderPkg" UchLoaderPkg
+        source edksetup.sh
+        build -p UchLoaderPkg/UchLoaderPkg.dsc -b RELEASE -a X64 -t GCC
+        cp Build/UchLoaderPkgX64/RELEASE_GCC/X64/Loader.efi "$GITHUB_WORKSPACE/Loader.efi"
+
     - name: Configure CMake
       run: |
-        IWYU_PATH=$(which include-what-you-use)
         cmake -S kernel -B build \
               -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+              -DKERNEL_TESTS=ON \
+              -DKERNEL_TEST_EXIT=ON
 
     - name: Build
-      run: | 
-          cmake --build build --config ${{env.BUILD_TYPE}} 
+      run: cmake --build build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      working-directory: build
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
-  
+    - name: Run kernel tests in QEMU
+      run: |
+        chmod +x ./scripts/run_kernel_tests.sh
+        WORK_DIR=qemu-test ./scripts/run_kernel_tests.sh
+
+    - name: Upload serial log
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: kernel-test-serial-log
+        path: qemu-test/serial.log
+        if-no-files-found: ignore
+
     - name: Run clang-tidy
       run: |
         chmod +x ./lint.sh
@@ -55,4 +82,3 @@ jobs:
           echo "clang-tidy found warnings or errors"
           exit 1
         fi
-

--- a/UchLoaderPkg/main.c
+++ b/UchLoaderPkg/main.c
@@ -86,8 +86,15 @@ EFI_STATUS OpenRootDir(EFI_HANDLE image_handle, EFI_FILE_PROTOCOL** buffer)
 EFI_STATUS ReadFile(EFI_FILE_PROTOCOL* file, VOID** buffer)
 {
 	EFI_STATUS status;
-	EFI_FILE_INFO* file_info = NULL;
-	UINTN file_info_size = sizeof(EFI_FILE_INFO) + sizeof(CHAR16) * 12;
+	// GetInfo needs a real buffer; passing NULL is undefined behavior that
+	// GCC RELEASE builds turn into a ud2 trap (#UD). The union keeps the
+	// buffer aligned for EFI_FILE_INFO while leaving room for the filename.
+	union {
+		EFI_FILE_INFO info;
+		UINT8 buf[sizeof(EFI_FILE_INFO) + sizeof(CHAR16) * 12];
+	} file_info_buffer;
+	EFI_FILE_INFO* file_info = &file_info_buffer.info;
+	UINTN file_info_size = sizeof(file_info_buffer);
 
 	status = file->GetInfo(file, &gEfiFileInfoGuid, &file_info_size, file_info);
 	if (EFI_ERROR(status)) {

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -87,9 +87,15 @@ set(SOURCE_FILES
         panic.cpp
 )
 
-# Build the kernel test suites and run them at boot. Will default to OFF
-# once CI (issue #311 PR 3) becomes the primary way to run the tests.
+# Build the kernel test suites and run them at boot. Left ON by default for
+# interactive use; CI runs the same tests headlessly via KERNEL_TEST_EXIT
+# below instead of toggling this option off.
 option(KERNEL_TESTS "Build kernel test suites and run them at boot" ON)
+
+# Report the cumulative test result to QEMU via isa-debug-exit (port 0xf4)
+# and exit after the main-stage suites finish. For headless CI runs only;
+# leave OFF for interactive use so the boot continues into kernel_service.
+option(KERNEL_TEST_EXIT "Exit QEMU with the test result after tests complete" OFF)
 
 # Add subdirectories that contain their own CMakeLists.txt files.
 add_subdirectory(memory)
@@ -105,6 +111,14 @@ add_subdirectory(net)
 set(KERNEL_TEST_LIBS "")
 if(KERNEL_TESTS)
         add_compile_definitions(KERNEL_TESTS_ENABLED)
+
+        # Must be defined before add_subdirectory(tests): directory properties
+        # are inherited when the subdirectory is added, and runner.cpp (which
+        # consumes this define) is compiled there.
+        if(KERNEL_TEST_EXIT)
+                add_compile_definitions(KERNEL_TEST_EXIT_ENABLED)
+        endif()
+
         add_subdirectory(tests)
         set(KERNEL_TEST_LIBS UchosTest)
 endif()

--- a/kernel/asm_utils.asm
+++ b/kernel/asm_utils.asm
@@ -30,6 +30,20 @@ write_to_io_port:
     out dx, eax
     ret
 
+global read_from_io_port8 ; uint8_t read_from_io_port8(uint16_t addr)
+read_from_io_port8:
+    mov dx, di
+    in al, dx
+    movzx eax, al
+    ret
+
+global write_to_io_port8 ; void write_to_io_port8(uint16_t addr, uint8_t value)
+write_to_io_port8:
+    mov dx, di
+    mov ax, si
+    out dx, al
+    ret
+
 global most_significant_bit ; int most_significant_bit(uint32_t value)
 most_significant_bit:
     bsr eax, edi

--- a/kernel/asm_utils.h
+++ b/kernel/asm_utils.h
@@ -42,6 +42,32 @@ uint32_t read_from_io_port(uint16_t port);
 void write_to_io_port(uint16_t port, uint32_t value);
 
 /**
+ * @brief Read an 8-bit value from an I/O port
+ *
+ * Performs an x86 IN instruction to read data from the specified I/O port.
+ * Used for communicating with legacy hardware devices.
+ *
+ * @param port The I/O port number to read from
+ * @return The 8-bit value read from the port
+ *
+ * @note This function uses the INB instruction
+ */
+uint8_t read_from_io_port8(uint16_t port);
+
+/**
+ * @brief Write an 8-bit value to an I/O port
+ *
+ * Performs an x86 OUT instruction to write data to the specified I/O port.
+ * Used for configuring and controlling legacy hardware devices.
+ *
+ * @param port The I/O port number to write to
+ * @param value The 8-bit value to write
+ *
+ * @note This function uses the OUTB instruction
+ */
+void write_to_io_port8(uint16_t port, uint8_t value);
+
+/**
  * @brief Find the position of the most significant bit
  *
  * Returns the bit position of the highest set bit in the value.

--- a/kernel/graphics/log.cpp
+++ b/kernel/graphics/log.cpp
@@ -23,7 +23,7 @@ void change_log_level(LogLevel level) { current_log_level = level; }
 
 void printk(kernel::graphics::LogLevel level, const char* format, ...)
 {
-	if (level != current_log_level || format == nullptr) {
+	if (format == nullptr) {
 		return;
 	}
 
@@ -34,10 +34,16 @@ void printk(kernel::graphics::LogLevel level, const char* format, ...)
 	vsnprintf(s, sizeof(s), format, ap);
 	va_end(ap);
 
-	// Mirror to the serial port; the framebuffer path below implicitly
-	// ends each message with a newline, so mirror that here too.
+	// The serial port receives every message regardless of the on-screen
+	// log level: it is the only output visible in headless runs and serves
+	// as a full boot trace when debugging CI failures.
 	kernel::hw::serial::write_string(s);
 	kernel::hw::serial::write_string("\n");
+
+	// The screen shows only messages that match the current log level.
+	if (level != current_log_level) {
+		return;
+	}
 
 	for (size_t i = 0; i < strlen(s) && s[i] != '\0'; ++i) {
 		kernel::graphics::write_ascii(

--- a/kernel/graphics/log.cpp
+++ b/kernel/graphics/log.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include "graphics/font.hpp"
 #include "graphics/screen.hpp"
+#include "hardware/serial.hpp"
 
 namespace
 {
@@ -32,6 +33,11 @@ void printk(kernel::graphics::LogLevel level, const char* format, ...)
 	va_start(ap, format);
 	vsnprintf(s, sizeof(s), format, ap);
 	va_end(ap);
+
+	// Mirror to the serial port; the framebuffer path below implicitly
+	// ends each message with a newline, so mirror that here too.
+	kernel::hw::serial::write_string(s);
+	kernel::hw::serial::write_string("\n");
 
 	for (size_t i = 0; i < strlen(s) && s[i] != '\0'; ++i) {
 		kernel::graphics::write_ascii(

--- a/kernel/hardware/CMakeLists.txt
+++ b/kernel/hardware/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HARDWARE_SOURCE_FILES
         keyboard.cpp
         pci.cpp
+        serial.cpp
         )
 
 add_library(UchosHardware ${HARDWARE_SOURCE_FILES})

--- a/kernel/hardware/serial.cpp
+++ b/kernel/hardware/serial.cpp
@@ -1,0 +1,62 @@
+#include "hardware/serial.hpp"
+#include <cstddef>
+#include <cstdint>
+#include "asm_utils.h"
+
+namespace
+{
+constexpr uint16_t COM1_BASE = 0x3f8;
+
+constexpr uint16_t REG_DATA = COM1_BASE + 0;		 ///< Data register (DLL when DLAB=1)
+constexpr uint16_t REG_INT_ENABLE = COM1_BASE + 1;	 ///< Interrupt enable (DLM when DLAB=1)
+constexpr uint16_t REG_FIFO_CTRL = COM1_BASE + 2;	 ///< FIFO control register
+constexpr uint16_t REG_LINE_CTRL = COM1_BASE + 3;	 ///< Line control register (DLAB bit)
+constexpr uint16_t REG_MODEM_CTRL = COM1_BASE + 4;	 ///< Modem control register
+constexpr uint16_t REG_LINE_STATUS = COM1_BASE + 5; ///< Line status register
+
+constexpr uint8_t LCR_DLAB = 0x80;			  ///< Divisor latch access bit
+constexpr uint8_t LCR_8N1 = 0x03;			  ///< 8 data bits, no parity, 1 stop bit
+constexpr uint8_t FCR_ENABLE_CLEAR_14 = 0xc7; ///< Enable/clear FIFOs, 14-byte threshold
+constexpr uint8_t MCR_DTR_RTS_OUT2 = 0x0b;	  ///< DTR | RTS | OUT2
+constexpr uint8_t LSR_THR_EMPTY = 0x20;	  ///< Transmit holding register empty
+
+bool initialized = false;
+} // namespace
+
+namespace kernel::hw::serial
+{
+
+void initialize()
+{
+	write_to_io_port8(REG_INT_ENABLE, 0x00); // disable all interrupts
+	write_to_io_port8(REG_LINE_CTRL, LCR_DLAB);
+	write_to_io_port8(REG_DATA, 0x01);		 // divisor low byte: 115200 baud
+	write_to_io_port8(REG_INT_ENABLE, 0x00); // divisor high byte
+	write_to_io_port8(REG_LINE_CTRL, LCR_8N1);
+	write_to_io_port8(REG_FIFO_CTRL, FCR_ENABLE_CLEAR_14);
+	write_to_io_port8(REG_MODEM_CTRL, MCR_DTR_RTS_OUT2);
+
+	initialized = true;
+}
+
+// Serial mirror of the kernel log so headless CI can observe test results.
+void write_string(const char* s)
+{
+	if (!initialized || s == nullptr) {
+		return;
+	}
+
+	for (size_t i = 0; s[i] != '\0'; ++i) {
+		if (s[i] == '\n') {
+			while ((read_from_io_port8(REG_LINE_STATUS) & LSR_THR_EMPTY) == 0) {
+			}
+			write_to_io_port8(REG_DATA, '\r');
+		}
+
+		while ((read_from_io_port8(REG_LINE_STATUS) & LSR_THR_EMPTY) == 0) {
+		}
+		write_to_io_port8(REG_DATA, static_cast<uint8_t>(s[i]));
+	}
+}
+
+} // namespace kernel::hw::serial

--- a/kernel/hardware/serial.hpp
+++ b/kernel/hardware/serial.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file hardware/serial.hpp
+ * @brief Polled COM1 serial output for headless logging
+ */
+
+#pragma once
+
+namespace kernel::hw::serial
+{
+
+/**
+ * @brief Initialize the COM1 UART for polled output
+ *
+ * Programs the 16550 UART at COM1 for 115200 baud, 8N1, with FIFOs
+ * enabled. Must be called once before write_string() is used.
+ */
+void initialize();
+
+/**
+ * @brief Write a NUL-terminated string to COM1
+ *
+ * Polls the line status register until the transmit holding register is
+ * empty before writing each byte. '\n' is translated to "\r\n" so output
+ * displays correctly on a serial terminal.
+ *
+ * @param s NUL-terminated string to write; ignored if nullptr
+ *
+ * @note Does nothing if initialize() has not been called yet
+ */
+void write_string(const char* s);
+
+} // namespace kernel::hw::serial

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -1,5 +1,6 @@
 #include "graphics/font.hpp"
 #include "graphics/screen.hpp"
+#include "hardware/serial.hpp"
 #include "interrupt/idt.hpp"
 #include "memory/bootstrap_allocator.hpp"
 #include "memory/buddy_system.hpp"
@@ -27,6 +28,8 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 					 const MemoryMap& memory_map,
 					 const kernel::timers::acpi::RootSystemDescriptionPointer& rsdp)
 {
+	kernel::hw::serial::initialize();
+
 	kernel::graphics::initialize(frame_buffer_conf, { 0, 0, 0 });
 
 	kernel::graphics::initialize_font();

--- a/kernel/tests/framework.cpp
+++ b/kernel/tests/framework.cpp
@@ -79,16 +79,20 @@ void run_test_suite(void (*test_suite)())
 	kernel::graphics::change_log_level(kernel::graphics::LogLevel::ERROR);
 }
 
+bool test_all_passed()
+{
+	return total_stats.total > 0 && total_stats.failed == 0;
+}
+
 void test_print_summary()
 {
 	// printk only emits messages whose level matches the current log level
 	// exactly, so the summary must be printed while the level is TEST.
 	kernel::graphics::change_log_level(kernel::graphics::LogLevel::TEST);
 
-	const bool passed = total_stats.total > 0 && total_stats.failed == 0;
 	LOG_TEST("TEST_SUMMARY: total=%d passed=%d failed=%d result=%s",
 			 total_stats.total, total_stats.passed, total_stats.failed,
-			 passed ? "PASS" : "FAIL");
+			 test_all_passed() ? "PASS" : "FAIL");
 
 	kernel::graphics::change_log_level(kernel::graphics::LogLevel::ERROR);
 }

--- a/kernel/tests/framework.hpp
+++ b/kernel/tests/framework.hpp
@@ -73,6 +73,16 @@ void test_mark_failed();
 void test_print_summary();
 
 /**
+ * @brief Check the cumulative test result across all executed suites
+ *
+ * Reflects the same totals reported by test_print_summary(): the result
+ * across every suite run since boot.
+ *
+ * @return true if at least one test ran and none of them failed
+ */
+bool test_all_passed();
+
+/**
  * @brief Run a complete test suite
  *
  * Convenience function that initializes the test framework, runs the

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -15,8 +15,27 @@
 #include "tests/test_cases/timer_test.hpp"
 #include "tests/test_cases/virtio_blk_test.hpp"
 
+#ifdef KERNEL_TEST_EXIT_ENABLED
+#include "asm_utils.h"
+#endif
+
 namespace
 {
+
+#ifdef KERNEL_TEST_EXIT_ENABLED
+constexpr uint16_t QEMU_ISA_DEBUG_EXIT_PORT = 0xf4;
+constexpr uint8_t QEMU_EXIT_CODE_PASS = 0x10; // QEMU exits with (0x10 << 1) | 1 = 33
+constexpr uint8_t QEMU_EXIT_CODE_FAIL = 0x11; // QEMU exits with (0x11 << 1) | 1 = 35
+
+// Writes the test result to the isa-debug-exit device so QEMU terminates
+// with a status the CI runner can check. When the device is absent
+// (interactive run), the write is ignored and boot continues normally.
+void exit_qemu(bool passed)
+{
+	write_to_io_port8(QEMU_ISA_DEBUG_EXIT_PORT,
+					   passed ? QEMU_EXIT_CODE_PASS : QEMU_EXIT_CODE_FAIL);
+}
+#endif
 
 std::array<bool, kernel::task::MAX_TASKS> slot_snapshot;
 
@@ -68,6 +87,10 @@ void run_main_stage_tests()
 	run_test_suite(register_fd_tests);
 
 	test_print_summary();
+
+#ifdef KERNEL_TEST_EXIT_ENABLED
+	exit_qemu(test_all_passed());
+#endif
 }
 
 } // namespace kernel::tests

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -280,13 +280,8 @@ void test_large_write_redirection()
 	CURRENT_TASK = prev_task;
 }
 
-// TEMPORARY: intentional failure to prove the CI gate detects failing
-// tests (issue #311 completion criterion). Reverted immediately after.
-void test_intentional_ci_gate_check() { ASSERT_EQ(1, 2); }
-
 void register_stdio_tests()
 {
-	test_register("test_intentional_ci_gate_check", test_intentional_ci_gate_check);
 	test_register("test_fd_table_init", test_fd_table_init);
 	test_register("test_write_to_stdout", test_write_to_stdout);
 	test_register("test_write_to_stderr", test_write_to_stderr);

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -280,8 +280,13 @@ void test_large_write_redirection()
 	CURRENT_TASK = prev_task;
 }
 
+// TEMPORARY: intentional failure to prove the CI gate detects failing
+// tests (issue #311 completion criterion). Reverted immediately after.
+void test_intentional_ci_gate_check() { ASSERT_EQ(1, 2); }
+
 void register_stdio_tests()
 {
+	test_register("test_intentional_ci_gate_check", test_intentional_ci_gate_check);
 	test_register("test_fd_table_init", test_fd_table_init);
 	test_register("test_write_to_stdout", test_write_to_stdout);
 	test_register("test_write_to_stderr", test_write_to_stderr);

--- a/scripts/run_kernel_tests.sh
+++ b/scripts/run_kernel_tests.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Headless kernel test runner for CI.
+#
+# Builds a minimal FAT32 boot disk (UEFI loader + kernel) with mtools, boots
+# it in QEMU with no display, and judges the result from two independent
+# signals:
+#   1. QEMU's exit status, driven by the kernel writing to isa-debug-exit
+#      (0x10 -> status 33 = all tests passed, 0x11 -> status 35 = failures)
+#   2. The machine-readable "TEST_SUMMARY: ... result=PASS" marker the kernel
+#      prints over COM1 (captured via -serial stdio)
+#
+# The kernel must be configured with -DKERNEL_TESTS=ON -DKERNEL_TEST_EXIT=ON;
+# it then exits right after the main-stage suites, before kernel_service, so
+# no userland binaries, virtio storage, TAP network or USB devices are needed.
+# Unlike run_qemu.sh this script is non-interactive and needs no sudo, loop
+# mounts or GDB stub.
+#
+# Usage (all inputs overridable via environment variables):
+#   KERNEL_ELF=build/UchosKernel LOADER_EFI=Loader.efi ./scripts/run_kernel_tests.sh
+
+set -euo pipefail
+
+KERNEL_ELF="${KERNEL_ELF:-build/UchosKernel}"
+LOADER_EFI="${LOADER_EFI:-Loader.efi}"
+OVMF_CODE="${OVMF_CODE:-}"
+OVMF_VARS="${OVMF_VARS:-}"
+TIMEOUT_SEC="${TIMEOUT_SEC:-300}"
+WORK_DIR="${WORK_DIR:-}"
+
+if [ -z "$WORK_DIR" ]; then
+    WORK_DIR="$(mktemp -d)"
+else
+    mkdir -p "$WORK_DIR"
+fi
+
+# Locate OVMF firmware if not given explicitly (package layout differs
+# between Ubuntu releases).
+if [ -z "$OVMF_CODE" ]; then
+    for candidate in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd OVMF_CODE.fd; do
+        if [ -f "$candidate" ]; then
+            OVMF_CODE="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$OVMF_VARS" ]; then
+    for candidate in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd OVMF_VARS.fd; do
+        if [ -f "$candidate" ]; then
+            OVMF_VARS="$candidate"
+            break
+        fi
+    done
+fi
+
+for required in "$KERNEL_ELF" "$LOADER_EFI" "$OVMF_CODE" "$OVMF_VARS"; do
+    if [ -z "$required" ] || [ ! -f "$required" ]; then
+        echo "error: required file not found: ${required:-<OVMF firmware>}" >&2
+        exit 1
+    fi
+done
+
+disk_img="$WORK_DIR/test-disk.img"
+vars_img="$WORK_DIR/OVMF_VARS.fd"
+serial_log="$WORK_DIR/serial.log"
+
+# Assemble the boot disk without mounting anything: FAT32 image holding the
+# UEFI loader (as the default boot entry) and the kernel.
+rm -f "$disk_img"
+truncate -s 128M "$disk_img"
+mkfs.fat -n 'UCH OS' -s 2 -f 2 -R 32 -F 32 "$disk_img" > /dev/null
+mmd -i "$disk_img" ::/EFI ::/EFI/BOOT
+mcopy -i "$disk_img" "$LOADER_EFI" ::/EFI/BOOT/BOOTX64.EFI
+mcopy -i "$disk_img" "$KERNEL_ELF" ::/kernel.elf
+
+# OVMF variable store must be writable; work on a copy.
+cp "$OVMF_VARS" "$vars_img"
+
+echo "booting kernel tests in QEMU (timeout ${TIMEOUT_SEC}s, log: $serial_log)"
+
+set +e
+timeout --foreground "$TIMEOUT_SEC" qemu-system-x86_64 -m 1G \
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+    -drive if=pflash,format=raw,file="$vars_img" \
+    -drive if=ide,index=0,media=disk,format=raw,file="$disk_img" \
+    -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+    -display none -serial stdio -monitor none -no-reboot \
+    | tee "$serial_log"
+qemu_status=${PIPESTATUS[0]}
+set -e
+
+echo "qemu exit status: $qemu_status"
+
+if [ "$qemu_status" -eq 124 ]; then
+    echo "FAIL: timed out after ${TIMEOUT_SEC}s (kernel never reported a test result)" >&2
+    exit 1
+fi
+
+# (0x10 << 1) | 1 = 33 is the only status the kernel emits on success.
+if [ "$qemu_status" -ne 33 ]; then
+    echo "FAIL: kernel reported test failures or crashed (status $qemu_status)" >&2
+    exit 1
+fi
+
+if ! grep -q "TEST_SUMMARY:.*result=PASS" "$serial_log"; then
+    echo "FAIL: exit status says PASS but no passing TEST_SUMMARY marker was seen on serial" >&2
+    exit 1
+fi
+
+echo "PASS: all kernel tests passed"


### PR DESCRIPTION
## 概要

Issue #311 の PR 案 3。CI に QEMU ヘッドレステスト実行を追加し、「ビルド → QEMU でテスト実行 → 結果判定」を自動化する。

## 変更内容

### カーネル
- **COM1 シリアルドライバ追加**(`kernel/hardware/serial.{hpp,cpp}`): ポーリング式 16550。`printk` の全出力をシリアルへミラーし、`-display none -serial stdio` でテスト結果を観測可能に(画面 = レベルフィルタ済み、シリアル = 全量ブートトレース)
- **終了プロトコル**(`KERNEL_TEST_EXIT`、デフォルト OFF): main ステージのスイート完了後、`isa-debug-exit`(port 0xf4)へ累積結果を書き込み QEMU を終了
  - PASS → 0x10(QEMU exit 33)/ FAIL → 0x11(QEMU exit 35)
  - `kernel_service()` 突入前に終了するため、CI はユーザーランド・virtio・TAP・USB 不要の最小構成で済む
  - デバイス未接続(対話実行)なら書き込みは無視されブート継続 → `./run_qemu.sh` に影響なし
- 8bit ポート I/O ヘルパー `read_from_io_port8` / `write_to_io_port8` を追加
- `test_all_passed()` をフレームワークに追加(TEST_SUMMARY と同じ累積判定)

### ローダー(CI で発覚した実バグの修正)
- `ReadFile()` が `GetInfo` に NULL バッファを渡して直後にデリファレンスしていた(未定義動作)。ローカルの CLANG38 ビルドでは「UEFI 環境ではアドレス 0 が書き込み可能」なため偶然動作していたが、CI の GCC RELEASE ビルドは `ud2` トラップに変換し #UD でクラッシュ。スタック上の正規バッファを渡す形に修正

### スクリプト / CI
- **`scripts/run_kernel_tests.sh`**(新規): mtools で FAT32 ブートディスクを sudo なしで組み立て、OVMF でヘッドレスブート。判定は二重化 — QEMU 終了コード 33 **かつ** シリアルの `TEST_SUMMARY: ... result=PASS` マーカーの両方を要求。タイムアウト(既定 300s)は fail 扱い
- **workflow 再構成**:
  - EDK2(edk2-stable202405 / GCC toolchain)で Loader.efi をビルドし、`UchLoaderPkg/**` のハッシュでキャッシュ(2回目以降は EDK2 ビルドをスキップ、submodule は brotli + mipisyst のみ)
  - `-DKERNEL_TEST_EXIT=ON` でビルド → QEMU テスト実行 → シリアルログを artifact 化
  - 空振りしていた ctest ステップ・未使用 `IWYU_PATH`・宙に浮いた行継続 `\` を削除
- **`run_qemu.sh`**: `-monitor stdio` を `-serial stdio` に置き換え。CI 用に追加したシリアルミラー(全 printk ログ)がローカルのターミナルにもリアルタイムで表示される(QEMU モニタは滅多に使われていなかったため。GDB は従来どおり tcp::12345)
- `.claude/rules/tests.md` の古い手順(main.cpp 直接登録)を runner.cpp ステージ登録に更新し、CI 実行方法を追記

## 完了条件の実証

- [x] CI がクリーン環境で build → QEMU テスト → 判定まで通ること
  - [Run 29643411830](https://github.com/junyaU/uchos/actions/runs/29643411830): 48 テスト全 PASS、QEMU exit 33、`TEST_SUMMARY: total=48 passed=48 failed=0 result=PASS`
- [x] 故意に失敗するテストが CI を fail させること
  - [Run 29643542308](https://github.com/junyaU/uchos/actions/runs/29643542308)(検証用コミット e671bf9、revert 済み): `FAIL: test_intentional_ci_gate_check` → `TEST_SUMMARY: total=49 passed=48 failed=1 result=FAIL` → QEMU exit 35 → CI fail

## 備考

- 検証過程で一度だけ、カーネルジャンプ直後に無出力のまま 300s タイムアウトする事象が発生([Run 29643160237](https://github.com/junyaU/uchos/actions/runs/29643160237))。同一ロジックのまま後続 run では安定して 1 秒未満でブートしており、タイミング依存の潜在ハングの可能性がある。CI で flaky が再発する場合は別 issue で追跡する

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
