### PR TITLE
fix: Multiplex the monitor and serial on stdio in run_qemu.sh

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -42,4 +42,4 @@ sudo qemu-system-x86_64 -m 1G \
     -device virtio-blk-pci,drive=drive-virtio-disk0,id=virtio-disk0 \
     -netdev tap,id=net0,ifname=tap0,script=no \
     -device virtio-net-pci,netdev=net0,mac=52:54:00:12:34:56 \
-    -serial stdio -S -gdb tcp::12345
+    -serial mon:stdio -S -gdb tcp::12345


### PR DESCRIPTION
Plain -serial stdio removed the monitor, leaving no way to type "c" to resume the VM started with -S. mon:stdio keeps both: Ctrl-a c switches between the monitor (to start execution) and the serial log.