### PR TITLE
fix: Sweep small memory-management bugs (issue #313)

### DIFF
--- a/kernel/bit_utils.cpp
+++ b/kernel/bit_utils.cpp
@@ -12,6 +12,10 @@ unsigned int bit_width(unsigned int x)
 
 unsigned int bit_width_ceil(unsigned int x)
 {
+	if (x == 0) {
+		return 0;
+	}
+
 	if ((x & (x - 1)) == 0) {
 		return bit_width(x) - 1;
 	}

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -50,7 +50,7 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	kernel::memory::initialize_memory_manager();
 
-	kernel::memory::disable();
+	kernel::memory::release_bootstrap();
 
 	kernel::memory::initialize_slab_allocator();
 

--- a/kernel/memory/bootstrap_allocator.cpp
+++ b/kernel/memory/bootstrap_allocator.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include "../../UchLoaderPkg/memory_map.hpp"
 #include "graphics/log.hpp"
-#include "memory/buddy_system.hpp"
 #include "memory/page.hpp"
 
 #include <sys/types.h>
@@ -148,16 +147,13 @@ void initialize_heap()
 	program_break_end = program_break + heap_size;
 }
 
-void disable()
+void release_bootstrap()
 {
-	if (kernel::memory::boot_allocator != nullptr) {
-		kernel::memory::memory_manager->free(
-				kernel::memory::boot_allocator,
-				sizeof(kernel::memory::BootstrapAllocator));
-		kernel::memory::boot_allocator = nullptr;
-	}
+	// The allocator lives in a static buffer inside the kernel BSS, so its
+	// pages must never be handed to the buddy system; just drop the pointer.
+	kernel::memory::boot_allocator = nullptr;
 
-	LOG_INFO("Bootstrap allocator disabled.");
+	LOG_INFO("Bootstrap allocator released.");
 }
 
 } // namespace kernel::memory

--- a/kernel/memory/bootstrap_allocator.hpp
+++ b/kernel/memory/bootstrap_allocator.hpp
@@ -49,8 +49,20 @@ private:
 
 extern BootstrapAllocator* boot_allocator;
 
+/**
+ * @brief Backing storage for the bootstrap allocator (kernel BSS)
+ * @note Exposed for regression tests only; do not use directly
+ */
+extern char bootstrap_allocator_buffer[sizeof(BootstrapAllocator)];
+
 void initialize(const MemoryMap& mem_map);
 void initialize_heap();
-void disable();
+
+/**
+ * @brief Retire the bootstrap allocator once the buddy system is up
+ * @note Only drops the global pointer. The allocator's static BSS buffer
+ * must never be freed into the buddy system.
+ */
+void release_bootstrap();
 
 } // namespace kernel::memory

--- a/kernel/memory/buddy_system.cpp
+++ b/kernel/memory/buddy_system.cpp
@@ -11,15 +11,18 @@ namespace kernel::memory
 
 BuddySystem* memory_manager;
 
-size_t BuddySystem::calculate_order(size_t num_pages)
+int BuddySystem::calculate_order(size_t num_pages)
 {
-	const size_t order = bit_width_ceil(num_pages);
-
-	if (order > MAX_ORDER) {
-		return MAX_ORDER;
+	if (num_pages == 0) {
+		return -1;
 	}
 
-	return order;
+	const size_t order = bit_width_ceil(num_pages);
+	if (order > MAX_ORDER) {
+		return -1;
+	}
+
+	return static_cast<int>(order);
 }
 
 void BuddySystem::split_memory_block(int order)
@@ -140,12 +143,16 @@ void BuddySystem::register_memory_blocks(size_t num_total_pages, Page* start_pag
 	}
 
 	auto calc_max_order_in_total_pages = [](size_t num_total_pages) -> size_t {
-		size_t order = calculate_order(num_total_pages);
-		if (num_total_pages < (1 << order)) {
-			--order;
+		if (num_total_pages == 0) {
+			return 0;
 		}
 
-		return order;
+		// floor(log2(num_total_pages)), clamped so that regions larger than
+		// the biggest buddy block are chunked into MAX_ORDER blocks
+		const size_t order = bit_width(num_total_pages) - 1;
+		return order > static_cast<size_t>(MAX_ORDER)
+					   ? static_cast<size_t>(MAX_ORDER)
+					   : order;
 	};
 
 	size_t order = calc_max_order_in_total_pages(num_total_pages);

--- a/kernel/memory/buddy_system.hpp
+++ b/kernel/memory/buddy_system.hpp
@@ -84,11 +84,12 @@ private:
 	 * -1 is returned if the size is too large to be allocated by the buddy
 	 * system.
 	 *
-	 * \param size The size of the memory block.
-	 * \return The order of the memory block.
+	 * \param num_pages The number of pages of the memory block.
+	 * \return The order of the memory block, or -1 if num_pages is 0 or
+	 * exceeds the largest block the buddy system can manage.
 	 */
 
-	static size_t calculate_order(size_t num_pages);
+	static int calculate_order(size_t num_pages);
 
 	std::array<std::list<Page*, PoolAllocator<Page*, PAGE_SIZE>>, MAX_ORDER + 1>
 			free_lists_;

--- a/kernel/memory/page.cpp
+++ b/kernel/memory/page.cpp
@@ -30,12 +30,16 @@ void initialize_pages()
 
 Page* get_page(void* ptr)
 {
-	if (ptr == nullptr ||
-		pages.size() < reinterpret_cast<uintptr_t>(ptr) / PAGE_SIZE) {
+	if (ptr == nullptr) {
 		return nullptr;
 	}
 
-	return &pages[reinterpret_cast<uintptr_t>(ptr) / PAGE_SIZE];
+	const size_t index = reinterpret_cast<uintptr_t>(ptr) / PAGE_SIZE;
+	if (index >= pages.size()) {
+		return nullptr;
+	}
+
+	return &pages[index];
 }
 
 void get_memory_usage(size_t* total_mem, size_t* used_mem)

--- a/kernel/memory/page.hpp
+++ b/kernel/memory/page.hpp
@@ -37,7 +37,7 @@ public:
 	 *
 	 * Initializes a page as free with no associated pointer.
 	 */
-	Page() : status_{ 0 }, ptr_{ nullptr } {}
+	Page() : status_{ 0 }, cache_{ nullptr }, slab_{ nullptr }, ptr_{ nullptr } {}
 
 	/**
 	 * @brief Get the page index based on its memory address

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -15,7 +15,7 @@
 namespace kernel::memory
 {
 
-MCache* get_cache_in_chain(char* name)
+MCache* get_cache_in_chain(const char* name)
 {
 	if (cache_chain.empty()) {
 		return nullptr;
@@ -30,7 +30,7 @@ MCache* get_cache_in_chain(char* name)
 	return nullptr;
 }
 
-MCache::MCache(char name[20], size_t object_size)
+MCache::MCache(const char* name, size_t object_size)
 	: object_size_(object_size),
 	  num_active_objects_(0),
 	  num_total_objects_(0),
@@ -39,7 +39,7 @@ MCache::MCache(char name[20], size_t object_size)
 	  num_pages_per_slab_(0)
 {
 	strncpy(name_, name, sizeof(name_) - 1);
-	name[sizeof(name_) - 1] = '\0';
+	name_[sizeof(name_) - 1] = '\0';
 
 	if (object_size <= kernel::memory::PAGE_SIZE) {
 		num_pages_per_slab_ = 1;
@@ -60,7 +60,7 @@ MSlab::MSlab(void* base_addr, size_t num_objs)
 
 MCache& m_cache_create(const char* name, size_t obj_size)
 {
-	obj_size = 1 << bit_width_ceil(obj_size);
+	obj_size = 1UL << bit_width_ceil(obj_size);
 
 	char temp_name[20];
 	if (name == nullptr) {
@@ -68,8 +68,8 @@ MCache& m_cache_create(const char* name, size_t obj_size)
 		name = temp_name;
 	}
 
-	cache_chain.push_back(std::make_unique<kernel::memory::MCache>(
-			const_cast<char*>(name), obj_size));
+	cache_chain.push_back(
+			std::make_unique<kernel::memory::MCache>(name, obj_size));
 
 	return *cache_chain.back();
 }
@@ -86,9 +86,20 @@ bool MCache::grow()
 	size_t const num_objs = bytes_per_slab / object_size_;
 	auto slab = std::make_unique<MSlab>(addr, num_objs);
 
-	Page* page = get_page(addr);
-	page->set_cache(this);
-	page->set_slab(slab.get());
+	// Mark every page of the slab so that free() can resolve the owning
+	// cache/slab from any object address.
+	for (size_t i = 0; i < num_pages_per_slab_; ++i) {
+		Page* page = get_page(reinterpret_cast<char*>(addr) +
+							  i * kernel::memory::PAGE_SIZE);
+		if (page == nullptr) {
+			LOG_ERROR("failed to look up page for slab at %p", addr);
+			kernel::memory::memory_manager->free(addr, bytes_per_slab);
+			return false;
+		}
+
+		page->set_cache(this);
+		page->set_slab(slab.get());
+	}
 
 	++num_total_slabs_;
 	num_total_objects_ += num_objs;
@@ -181,6 +192,7 @@ void* MSlab::alloc_object(size_t obj_size)
 	free_objects_index_.pop_front();
 
 	objects_[obj_index].increase_usage_count();
+	objects_[obj_index].set_in_use(true);
 
 	num_in_use_++;
 
@@ -188,14 +200,47 @@ void* MSlab::alloc_object(size_t obj_size)
 								   obj_index * obj_size);
 }
 
-void MSlab::free_object(void* addr, size_t obj_size)
+bool MSlab::free_object(void* addr, size_t obj_size)
 {
-	const size_t objs_index = (reinterpret_cast<uintptr_t>(addr) -
-							   reinterpret_cast<uintptr_t>(base_addr_)) /
-							  obj_size;
+	const uintptr_t offset = reinterpret_cast<uintptr_t>(addr) -
+							 reinterpret_cast<uintptr_t>(base_addr_);
+	if (offset % obj_size != 0) {
+		LOG_ERROR("free: %p is not an object boundary", addr);
+		return false;
+	}
 
+	const size_t objs_index = offset / obj_size;
+	if (objs_index >= objects_.size()) {
+		LOG_ERROR("free: %p is out of slab range", addr);
+		return false;
+	}
+
+	if (!objects_[objs_index].is_in_use()) {
+		LOG_ERROR("double free detected at address: %p", addr);
+		return false;
+	}
+
+	objects_[objs_index].set_in_use(false);
 	free_objects_index_.push_back(objs_index);
 	--num_in_use_;
+
+	return true;
+}
+
+bool MSlab::is_object_in_use(void* addr, size_t obj_size) const
+{
+	const uintptr_t offset = reinterpret_cast<uintptr_t>(addr) -
+							 reinterpret_cast<uintptr_t>(base_addr_);
+	if (offset % obj_size != 0) {
+		return false;
+	}
+
+	const size_t objs_index = offset / obj_size;
+	if (objs_index >= objects_.size()) {
+		return false;
+	}
+
+	return objects_[objs_index].is_in_use();
 }
 
 } // namespace kernel::memory
@@ -205,14 +250,28 @@ std::unordered_map<void*, void*> aligned_to_raw_addr_map;
 namespace kernel::memory
 {
 
+// Largest single allocation: the biggest block the buddy system can back
+// a slab with.
+constexpr size_t MAX_ALLOC_SIZE = (1UL << MAX_ORDER) * PAGE_SIZE;
+
 void* alloc(size_t size, unsigned flags, int align)
 {
+	if (size == 0) {
+		LOG_ERROR("alloc: size must be non-zero");
+		return nullptr;
+	}
+
 	if (align != 1 && (align & (align - 1)) != 0) {
 		LOG_ERROR("align must be a power of 2");
 		return nullptr;
 	}
 
-	size = 1 << bit_width_ceil(size + align - 1);
+	if (size > MAX_ALLOC_SIZE - (static_cast<size_t>(align) - 1)) {
+		LOG_ERROR("alloc: size %lu is too large", size);
+		return nullptr;
+	}
+
+	size = 1UL << bit_width_ceil(size + align - 1);
 	char name[20];
 	sprintf(name, "cache-%d", static_cast<int>(size));
 
@@ -247,6 +306,10 @@ void* alloc(size_t size, unsigned flags, int align)
 
 void free(void* addr)
 {
+	if (addr == nullptr) {
+		return;
+	}
+
 	auto it = aligned_to_raw_addr_map.find(addr);
 	if (it != aligned_to_raw_addr_map.end()) {
 		addr = it->second;
@@ -261,8 +324,15 @@ void free(void* addr)
 
 	MCache* cache = p->cache();
 	MSlab* slab = p->slab();
+	if (cache == nullptr || slab == nullptr) {
+		LOG_ERROR("free: %p was not allocated by the slab allocator", addr);
+		return;
+	}
 
-	slab->free_object(addr, cache->object_size());
+	if (!slab->free_object(addr, cache->object_size())) {
+		return;
+	}
+
 	cache->decrease_num_active_objects();
 
 	if (slab->status() == SlabStatus::FULL) {
@@ -273,6 +343,25 @@ void free(void* addr)
 		slab->move_list(*cache, SlabStatus::FREE);
 		cache->decrease_num_active_slabs();
 	}
+}
+
+bool is_slab_object_in_use(void* addr)
+{
+	if (addr == nullptr) {
+		return false;
+	}
+
+	auto it = aligned_to_raw_addr_map.find(addr);
+	if (it != aligned_to_raw_addr_map.end()) {
+		addr = it->second;
+	}
+
+	Page* p = get_page(addr);
+	if (p == nullptr || p->cache() == nullptr || p->slab() == nullptr) {
+		return false;
+	}
+
+	return p->slab()->is_object_in_use(addr, p->cache()->object_size());
 }
 
 std::list<std::unique_ptr<MCache>> cache_chain;

--- a/kernel/memory/slab.hpp
+++ b/kernel/memory/slab.hpp
@@ -38,8 +38,13 @@ public:
 
 	void increase_usage_count() { usage_count_++; }
 
+	bool is_in_use() const { return in_use_; }
+
+	void set_in_use(bool in_use) { in_use_ = in_use; }
+
 private:
-	unsigned int usage_count_;
+	unsigned int usage_count_ = 0;
+	bool in_use_ = false;
 };
 
 class MCache;
@@ -64,7 +69,22 @@ public:
 
 	void* alloc_object(size_t obj_size);
 
-	void free_object(void* addr, size_t obj_size);
+	/**
+	 * @brief Return an object to this slab
+	 * @param addr Address previously returned by alloc_object
+	 * @param obj_size Object size of the owning cache
+	 * @return true on success, false if addr is not a live object of this
+	 * slab (out of range, misaligned, or already freed)
+	 */
+	bool free_object(void* addr, size_t obj_size);
+
+	/**
+	 * @brief Check whether addr is a live (allocated) object of this slab
+	 * @param addr Object address to check
+	 * @param obj_size Object size of the owning cache
+	 * @return true if addr is currently allocated
+	 */
+	bool is_object_in_use(void* addr, size_t obj_size) const;
 
 	void move_list(MCache& cache, SlabStatus to);
 
@@ -80,7 +100,7 @@ private:
 class MCache
 {
 public:
-	MCache(char name[20], size_t object_size);
+	MCache(const char* name, size_t object_size);
 
 	char* name() { return name_; }
 	size_t object_size() const { return object_size_; }
@@ -112,7 +132,7 @@ extern std::list<std::unique_ptr<MCache>> cache_chain;
  * @param name Name of the cache to retrieve
  * @return Pointer to the found cache, or nullptr if not found
  */
-MCache* get_cache_in_chain(char* name);
+MCache* get_cache_in_chain(const char* name);
 
 /**
  * @brief Create a new memory cache
@@ -138,6 +158,14 @@ void* alloc(size_t size, unsigned flags, int align = 1);
  * @note Does nothing if addr is nullptr
  */
 void free(void* addr);
+
+/**
+ * @brief Check whether addr points to a live slab allocation
+ * @param addr Address previously returned by alloc()
+ * @return true if addr is currently allocated by the slab allocator
+ * @note Intended for tests and debugging
+ */
+bool is_slab_object_in_use(void* addr);
 
 struct FreeDeleter {
 	void operator()(void* p) { free(p); }

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -225,8 +225,13 @@ void schedule_task(ProcessId id)
 void switch_task(const Context& current_ctx)
 {
 	if (CURRENT_TASK->state == TASK_EXITED) {
-		delete tasks[CURRENT_TASK->id.raw()];
-		tasks[CURRENT_TASK->id.raw()] = nullptr;
+		// ~Task frees the kernel stack we are still running on; keep
+		// interrupts off until restore_context switches to the next
+		// task's stack so nothing can reuse it in between.
+		asm volatile("cli");
+		const pid_t exited_id = CURRENT_TASK->id.raw();
+		delete tasks[exited_id];
+		tasks[exited_id] = nullptr;
 	} else {
 		memcpy(&CURRENT_TASK->ctx, &current_ctx, sizeof(Context));
 		if (CURRENT_TASK->state != TASK_WAITING) {

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -50,8 +50,13 @@ struct Task {
 
 	~Task()
 	{
-		kernel::memory::clean_page_tables(
-				reinterpret_cast<kernel::memory::page_table_entry*>(ctx.cr3));
+		if (ctx.cr3 != 0) {
+			kernel::memory::clean_page_tables(
+					reinterpret_cast<kernel::memory::page_table_entry*>(
+							ctx.cr3));
+		}
+
+		kernel::memory::free(stack);
 	}
 
 	static void* operator new(size_t size)

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include "task/task.hpp"
 #include "tests/framework.hpp"
+#include "tests/test_cases/bit_utils_test.hpp"
 #include "tests/test_cases/fd_test.hpp"
 #include "tests/test_cases/fs_test.hpp"
 #include "tests/test_cases/memory_test.hpp"
@@ -66,6 +67,7 @@ namespace kernel::tests
 
 void run_bootstrap_stage_tests()
 {
+	run_test_suite(register_bit_utils_tests);
 	run_test_suite(register_bootstrap_allocator_tests);
 }
 

--- a/kernel/tests/runner.hpp
+++ b/kernel/tests/runner.hpp
@@ -18,8 +18,8 @@ namespace kernel::tests
  * @brief Run suites that need the bootstrap allocator to be alive
  *
  * Must be called after kernel::memory::initialize() and before
- * kernel::memory::disable(), because the bootstrap allocator suite
- * exercises the global boot_allocator directly.
+ * kernel::memory::release_bootstrap(), because the bootstrap allocator
+ * suite exercises the global boot_allocator directly.
  */
 void run_bootstrap_stage_tests();
 

--- a/kernel/tests/test_cases/CMakeLists.txt
+++ b/kernel/tests/test_cases/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TESTCASES_SOURCE_FILES
+        bit_utils_test.cpp
         memory_test.cpp
         task_test.cpp
         timer_test.cpp

--- a/kernel/tests/test_cases/bit_utils_test.cpp
+++ b/kernel/tests/test_cases/bit_utils_test.cpp
@@ -1,0 +1,30 @@
+#include "tests/test_cases/bit_utils_test.hpp"
+#include "bit_utils.hpp"
+#include "tests/framework.hpp"
+#include "tests/macros.hpp"
+
+void test_bit_width()
+{
+	ASSERT_EQ(bit_width(0), 0U);
+	ASSERT_EQ(bit_width(1), 1U);
+	ASSERT_EQ(bit_width(4), 3U);
+	ASSERT_EQ(bit_width(5), 3U);
+	ASSERT_EQ(bit_width(8), 4U);
+}
+
+void test_bit_width_ceil()
+{
+	// bit_width_ceil(0) used to underflow and return a huge value (issue #313)
+	ASSERT_EQ(bit_width_ceil(0), 0U);
+	ASSERT_EQ(bit_width_ceil(1), 0U);
+	ASSERT_EQ(bit_width_ceil(2), 1U);
+	ASSERT_EQ(bit_width_ceil(5), 3U);
+	ASSERT_EQ(bit_width_ceil(8), 3U);
+	ASSERT_EQ(bit_width_ceil(9), 4U);
+}
+
+void register_bit_utils_tests()
+{
+	test_register("bit_width", test_bit_width);
+	test_register("bit_width_ceil", test_bit_width_ceil);
+}

--- a/kernel/tests/test_cases/bit_utils_test.hpp
+++ b/kernel/tests/test_cases/bit_utils_test.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void register_bit_utils_tests();

--- a/kernel/tests/test_cases/memory_test.cpp
+++ b/kernel/tests/test_cases/memory_test.cpp
@@ -1,6 +1,7 @@
 #include "tests/test_cases/memory_test.hpp"
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include "memory/bootstrap_allocator.hpp"
 #include "memory/buddy_system.hpp"
 #include "memory/page.hpp"
@@ -138,12 +139,46 @@ void test_buddy_system_error_handling()
 	ASSERT_NULL(too_large);
 }
 
+void test_get_page_bounds()
+{
+	// nullptr is rejected
+	ASSERT_NULL(kernel::memory::get_page(nullptr));
+
+	// the last valid page resolves
+	const size_t num_pages = kernel::memory::pages.size();
+	void* last_page_addr = reinterpret_cast<void*>((num_pages - 1) *
+												   kernel::memory::PAGE_SIZE);
+	ASSERT_NOT_NULL(kernel::memory::get_page(last_page_addr));
+
+	// one page past the end must not resolve (used to be an off-by-one)
+	void* out_of_range =
+			reinterpret_cast<void*>(num_pages * kernel::memory::PAGE_SIZE);
+	ASSERT_NULL(kernel::memory::get_page(out_of_range));
+}
+
+void test_bootstrap_buffer_stays_reserved()
+{
+	// The bootstrap allocator's static BSS buffer must stay marked used
+	// after release_bootstrap(); handing it to the buddy system would let
+	// kernel BSS pages be reallocated (issue #313)
+	char* buffer = kernel::memory::bootstrap_allocator_buffer;
+	for (size_t offset = 0; offset < sizeof(kernel::memory::BootstrapAllocator);
+		 offset += kernel::memory::PAGE_SIZE) {
+		kernel::memory::Page* page = kernel::memory::get_page(buffer + offset);
+		ASSERT_NOT_NULL(page);
+		ASSERT_TRUE(page->is_used());
+	}
+}
+
 void register_buddy_system_tests()
 {
 	test_register("buddy_system_basic", test_buddy_system_basic);
 	test_register("buddy_system_multi_page", test_buddy_system_multi_page);
 	test_register("buddy_system_split_and_merge", test_buddy_system_split_and_merge);
 	test_register("buddy_system_error_handling", test_buddy_system_error_handling);
+	test_register("get_page_bounds", test_get_page_bounds);
+	test_register("bootstrap_buffer_stays_reserved",
+				  test_bootstrap_buffer_stays_reserved);
 }
 
 void test_slab_basic()
@@ -165,8 +200,7 @@ void test_slab_cache_creation()
 	ASSERT_NOT_NULL(obj);
 
 	// Get the cache by name and verify it exists
-	auto* found_cache =
-			kernel::memory::get_cache_in_chain(const_cast<char*>("test-cache"));
+	auto* found_cache = kernel::memory::get_cache_in_chain("test-cache");
 	ASSERT_NOT_NULL(found_cache);
 	ASSERT_EQ(found_cache->object_size(), obj_size);
 }
@@ -209,6 +243,60 @@ void test_slab_error_handling()
 	ASSERT_NULL(ptr);
 }
 
+void test_slab_double_free_detected()
+{
+	// Use a size class of its own so the slab holds exactly one object
+	constexpr size_t size = 100000; // rounds up to a 128 KiB cache
+	void* ptr = kernel::memory::alloc(size, kernel::memory::ALLOC_UNINITIALIZED);
+	ASSERT_NOT_NULL(ptr);
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(ptr));
+
+	kernel::memory::free(ptr);
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(ptr));
+
+	// A second free must be detected and ignored (issue #313)
+	kernel::memory::free(ptr);
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(ptr));
+
+	// The object is handed out exactly once afterwards
+	void* again = kernel::memory::alloc(size, kernel::memory::ALLOC_UNINITIALIZED);
+	ASSERT_EQ(again, ptr);
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(again));
+	kernel::memory::free(again);
+}
+
+void test_slab_free_rejects_foreign_pointer()
+{
+	// A page owned by the buddy system was never a slab object; freeing it
+	// through the slab allocator must be rejected, not dereference garbage
+	void* raw = kernel::memory::memory_manager->allocate(kernel::memory::PAGE_SIZE);
+	ASSERT_NOT_NULL(raw);
+
+	kernel::memory::free(raw);
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(raw));
+
+	// The page still belongs to the buddy system
+	kernel::memory::Page* page = kernel::memory::get_page(raw);
+	ASSERT_NOT_NULL(page);
+	ASSERT_TRUE(page->is_used());
+
+	kernel::memory::memory_manager->free(raw, kernel::memory::PAGE_SIZE);
+}
+
+void test_slab_cache_name_truncation()
+{
+	// A name longer than the cache's 20-byte buffer must be truncated inside
+	// the cache and must not write a terminator into the caller's buffer
+	char long_name[32] = "0123456789012345678901234567890";
+	kernel::memory::m_cache_create(long_name, 512);
+
+	ASSERT_EQ(long_name[19], '9');
+
+	auto* cache = kernel::memory::get_cache_in_chain("0123456789012345678");
+	ASSERT_NOT_NULL(cache);
+	ASSERT_EQ(strlen(cache->name()), 19UL);
+}
+
 void register_slab_tests()
 {
 	test_register("slab_basic", test_slab_basic);
@@ -216,6 +304,10 @@ void register_slab_tests()
 	test_register("slab_aligned_allocation", test_slab_aligned_allocation);
 	test_register("slab_zeroed_allocation", test_slab_zeroed_allocation);
 	test_register("slab_error_handling", test_slab_error_handling);
+	test_register("slab_double_free_detected", test_slab_double_free_detected);
+	test_register("slab_free_rejects_foreign_pointer",
+				  test_slab_free_rejects_foreign_pointer);
+	test_register("slab_cache_name_truncation", test_slab_cache_name_truncation);
 }
 
 static void helper_alloc_or_return_void()

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -21,6 +21,33 @@ extern ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 extern ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 } // namespace kernel::syscall
 
+namespace
+{
+// Impersonate `t` as CURRENT_TASK for a scope. The impersonated task must
+// be RUNNING while it is current: if a timer preemption hits while
+// CURRENT_TASK is WAITING, switch_task() does not requeue it and the test
+// runner's execution context is lost for good — the boot hangs with no
+// output (issue #313). RAII also restores CURRENT_TASK when an ASSERT
+// macro returns early.
+class ScopedCurrentTask
+{
+public:
+	explicit ScopedCurrentTask(Task* t) : prev_(CURRENT_TASK)
+	{
+		t->state = kernel::task::TASK_RUNNING;
+		CURRENT_TASK = t;
+	}
+
+	~ScopedCurrentTask() { CURRENT_TASK = prev_; }
+
+	ScopedCurrentTask(const ScopedCurrentTask&) = delete;
+	ScopedCurrentTask& operator=(const ScopedCurrentTask&) = delete;
+
+private:
+	Task* prev_;
+};
+} // namespace
+
 void test_fd_table_init()
 {
 	// Create a test task
@@ -49,8 +76,7 @@ void test_write_to_stdout()
 	Task* t = create_task("write_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test writing to stdout
 	const char* test_msg = "Hello, stdout!";
@@ -61,8 +87,6 @@ void test_write_to_stdout()
 	ASSERT_GT(result, 0);
 	ASSERT_EQ(result, strlen(test_msg));
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_write_to_stderr()
@@ -71,8 +95,7 @@ void test_write_to_stderr()
 	Task* t = create_task("stderr_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test writing to stderr
 	const char* test_msg = "Error message";
@@ -83,8 +106,6 @@ void test_write_to_stderr()
 	ASSERT_GT(result, 0);
 	ASSERT_EQ(result, strlen(test_msg));
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_read_from_stdin()
@@ -93,8 +114,7 @@ void test_read_from_stdin()
 	Task* t = create_task("read_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test reading from stdin (currently returns 0)
 	char buffer[128];
@@ -104,8 +124,6 @@ void test_read_from_stdin()
 	// Currently stdin returns 0 (no data available)
 	ASSERT_EQ(result, 0);
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_invalid_fd()
@@ -114,8 +132,7 @@ void test_invalid_fd()
 	Task* t = create_task("invalid_fd_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test invalid file descriptor (negative)
 	char buffer[128];
@@ -134,8 +151,6 @@ void test_invalid_fd()
 			10, reinterpret_cast<uint64_t>(buffer), sizeof(buffer));
 	ASSERT_EQ(result3, ERR_INVALID_FD);
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_fd_inheritance()
@@ -151,8 +166,7 @@ void test_fd_inheritance()
 	ASSERT_GT(fd, -1);
 
 	// Set parent as current task for copy_task
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = parent;
+	const ScopedCurrentTask scoped_task(parent);
 
 	// Create child task (this would normally be done by fork)
 	kernel::task::Context dummy_ctx = {};
@@ -169,8 +183,6 @@ void test_fd_inheritance()
 	ASSERT_EQ(strcmp(child->fd_table[fd].name, "test.txt"), 0);
 	ASSERT_EQ(child->fd_table[fd].size, 100);
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_stdout_redirection()
@@ -179,8 +191,7 @@ void test_stdout_redirection()
 	Task* t = create_task("redirect_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Allocate a file descriptor to redirect to
 	fd_t file_fd = kernel::fs::allocate_process_fd(
@@ -210,8 +221,6 @@ void test_stdout_redirection()
 	// Restore stdout
 	// t->fd_table[STDOUT_FILENO].redirect_to = NO_FD;
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_stderr_redirection()
@@ -220,8 +229,7 @@ void test_stderr_redirection()
 	Task* t = create_task("stderr_redirect_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Allocate a file descriptor to redirect to
 	fd_t file_fd = kernel::fs::allocate_process_fd(
@@ -242,8 +250,6 @@ void test_stderr_redirection()
 	// Restore stderr
 	// t->fd_table[STDERR_FILENO].redirect_to = NO_FD;
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_large_write_redirection()
@@ -252,8 +258,7 @@ void test_large_write_redirection()
 	Task* t = create_task("large_redirect_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Allocate a file descriptor to redirect to
 	fd_t file_fd = kernel::fs::allocate_process_fd(
@@ -276,8 +281,6 @@ void test_large_write_redirection()
 	// Restore stdout
 	// t->fd_table[STDOUT_FILENO].redirect_to = NO_FD;
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void register_stdio_tests()

--- a/kernel/tests/test_cases/task_test.cpp
+++ b/kernel/tests/test_cases/task_test.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
+#include "memory/slab.hpp"
 #include "task/context.hpp"
 #include "task/task.hpp"
 #include "tests/framework.hpp"
@@ -133,10 +134,15 @@ void test_task_memory_management()
 	ASSERT_EQ(t->state, TASK_WAITING);
 	ASSERT_TRUE(t->is_initilized);
 
+	void* stack = t->stack;
+	ASSERT_NOT_NULL(stack);
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(stack));
+
 	// Test task deallocation with operator delete
 	delete t;
-	// Note: We can't verify the deletion directly, but the destructor should have
-	// cleaned up the page tables
+
+	// ~Task must free the kernel stack along with the page tables (issue #313)
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(stack));
 }
 
 void register_task_tests()


### PR DESCRIPTION
## 概要

[#313](https://github.com/junyaU/uchos/issues/313) のメモリ管理サブシステムの小粒バグ一掃(PR 分割の 1 本目)。各修正に回帰テストを追加。

## 修正内容

| 対象 | バグ | 修正 |
|------|------|------|
| `kernel/bit_utils.cpp` | `bit_width_ceil(0)` が桁下がりで巨大値を返す | doc どおり 0 を返す |
| `kernel/memory/page.cpp` | `get_page()` の `pages.size() < index` off-by-one で配列末尾外を返す | `index >= size` に修正 |
| `kernel/memory/page.hpp` | `Page::cache_/slab_` が未初期化のまま deref され得る | ctor で nullptr 初期化 |
| `kernel/memory/buddy_system.cpp` | `calculate_order` が超過サイズを MAX_ORDER に丸め、要求より小さい領域を返す | size 0 / 超過を -1 で拒否(doc 記載どおりに)。`register_memory_blocks` の丸めロジックはローカルに floor+clamp で維持 |
| `kernel/memory/bootstrap_allocator.cpp` | `disable()` が静的 BSS バッファを buddy に free し、カーネル BSS ページが再配布対象になる | ポインタ破棄のみに変更し `release_bootstrap()` へ改名 |
| `kernel/memory/slab.cpp` | `MCache` ctor が null 終端を **引数バッファ** に書き込む(文字列リテラル破壊) | `name_` へ書くよう修正、`const char*` 化 |
| `kernel/memory/slab.cpp` | `alloc(0)` / 過大サイズで `1 << bit_width_ceil` が UB | 入口で明示的に拒否(上限 = buddy 最大ブロック) |
| `kernel/memory/slab.cpp` | free の provenance 未検証・二重 free 未検出 | ページの cache/slab 帰属・境界整列・範囲・in-use を検証し、不正 free は LOG_ERROR で拒否。複数ページ slab の全ページをマーク |
| `kernel/task/task.hpp` | `~Task` が 32KB カーネルスタックをタスク終了ごとにリーク | `~Task` で解放(`messages` は std::queue の dtor で解放済みを確認)。`switch_task` は解放済み Task から id を再読せず、自スタック解放中は割り込み禁止に |

## テスト

- 新規 `bit_utils` スイート(bootstrap ステージ): `bit_width` / `bit_width_ceil`(0 を含む境界値)
- buddy スイート: `get_page_bounds`(off-by-one 回帰)、`bootstrap_buffer_stays_reserved`(BSS ページが buddy に渡らないこと)
- slab スイート: `slab_double_free_detected` / `slab_free_rejects_foreign_pointer` / `slab_cache_name_truncation`
- task スイート: `test_task_memory_management` を拡張し、`delete` 後にスタックが解放されることを新 API `is_slab_object_in_use()` で検証
- 既存の `buddy_system_error_handling` / `slab_error_handling`(size 0・過大)は従来「偶然 nullptr が返って」通っていたが、今回の修正で決定的に PASS するようになった

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)