### PR TITLE
fix: ドライバ層(PCI / xHCI)の既知バグ修正(issue #313)

### DIFF
--- a/kernel/bit_utils.cpp
+++ b/kernel/bit_utils.cpp
@@ -12,6 +12,10 @@ unsigned int bit_width(unsigned int x)
 
 unsigned int bit_width_ceil(unsigned int x)
 {
+	if (x == 0) {
+		return 0;
+	}
+
 	if ((x & (x - 1)) == 0) {
 		return bit_width(x) - 1;
 	}

--- a/kernel/fs/fat/init.cpp
+++ b/kernel/fs/fat/init.cpp
@@ -58,7 +58,7 @@ void handle_initialize(const Message& m)
 		while (!pending_messages.empty()) {
 			auto msg = pending_messages.front();
 			pending_messages.pop();
-			kernel::task::CURRENT_TASK->messages.push(msg);
+			kernel::task::CURRENT_TASK->messages.push_back(msg);
 		}
 	}
 }

--- a/kernel/hardware/pci.cpp
+++ b/kernel/hardware/pci.cpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 #include "asm_utils.h"
+#include "graphics/log.hpp"
 #include "hardware/mm_register.hpp"
 
 namespace kernel::hw::pci
@@ -63,6 +64,12 @@ bool is_single_function_device(uint8_t header_type)
 
 void read_function(uint8_t bus, uint8_t dev, uint8_t func)
 {
+	if (num_devices >= static_cast<int>(devices.size())) {
+		LOG_ERROR("pci device table is full: ignoring device %d:%d.%d", bus, dev,
+				  func);
+		return;
+	}
+
 	auto header_type = read_header_type(bus, dev, func);
 	auto class_code = read_class_code(bus, dev, func);
 
@@ -75,8 +82,7 @@ void read_function(uint8_t bus, uint8_t dev, uint8_t func)
 	d.vendor_id = read_vendor_id(bus, dev, func);
 	d.device_id = read_device_id(bus, dev, func);
 
-	devices[dev] = d;
-	++num_devices;
+	devices[num_devices++] = d;
 }
 
 void read_device(uint8_t bus, uint8_t device)

--- a/kernel/hardware/usb/xhci/device.cpp
+++ b/kernel/hardware/usb/xhci/device.cpp
@@ -52,22 +52,42 @@ void Device::control_in(const ControlTransferData& data)
 	auto status_trb = status_stage_trb{};
 
 	if (data.buf != nullptr) {
-		auto* setup_trb_position = trb_dynamic_cast<setup_stage_trb>(
-				transfer_ring->push(make_setup_stage_trb(
-						data.setup_data, setup_stage_trb::IN_DATA_STAGE)));
+		trb* pushed_setup_trb = transfer_ring->push(make_setup_stage_trb(
+				data.setup_data, setup_stage_trb::IN_DATA_STAGE));
+		if (pushed_setup_trb == nullptr) {
+			LOG_ERROR("failed to push setup stage trb");
+			return;
+		}
+
+		auto* setup_trb_position =
+				trb_dynamic_cast<setup_stage_trb>(pushed_setup_trb);
 		auto data_trb = make_data_stage_trb(data.buf, data.len, true);
 		data_trb.bits.interrupt_on_completion = true;
 		auto* data_trb_position = transfer_ring->push(data_trb);
+		if (data_trb_position == nullptr ||
+			transfer_ring->push(status_trb) == nullptr) {
+			LOG_ERROR("failed to push control transfer trbs");
+			return;
+		}
 
-		transfer_ring->push(status_trb);
 		setup_stages_.put(data_trb_position, setup_trb_position);
 	} else {
-		auto* setup_trb_position = trb_dynamic_cast<setup_stage_trb>(
-				transfer_ring->push(make_setup_stage_trb(
-						data.setup_data, setup_stage_trb::NO_DATA_STAGE)));
+		trb* pushed_setup_trb = transfer_ring->push(make_setup_stage_trb(
+				data.setup_data, setup_stage_trb::NO_DATA_STAGE));
+		if (pushed_setup_trb == nullptr) {
+			LOG_ERROR("failed to push setup stage trb");
+			return;
+		}
+
+		auto* setup_trb_position =
+				trb_dynamic_cast<setup_stage_trb>(pushed_setup_trb);
 		status_trb.bits.direction = true;
 		status_trb.bits.interrupt_on_completion = true;
 		auto* status_trb_position = transfer_ring->push(status_trb);
+		if (status_trb_position == nullptr) {
+			LOG_ERROR("failed to push status stage trb");
+			return;
+		}
 
 		setup_stages_.put(status_trb_position, setup_trb_position);
 	}
@@ -95,21 +115,41 @@ void Device::control_out(const ControlTransferData& data)
 	status_trb.bits.direction = true;
 
 	if (data.buf != nullptr) {
-		auto* setup_trb_position = trb_dynamic_cast<setup_stage_trb>(
-				transfer_ring->push(make_setup_stage_trb(
-						data.setup_data, setup_stage_trb::OUT_DATA_STAGE)));
+		trb* pushed_setup_trb = transfer_ring->push(make_setup_stage_trb(
+				data.setup_data, setup_stage_trb::OUT_DATA_STAGE));
+		if (pushed_setup_trb == nullptr) {
+			LOG_ERROR("failed to push setup stage trb");
+			return;
+		}
+
+		auto* setup_trb_position =
+				trb_dynamic_cast<setup_stage_trb>(pushed_setup_trb);
 		auto data_trb = make_data_stage_trb(data.buf, data.len, false);
 		data_trb.bits.interrupt_on_completion = true;
 		auto* data_trb_position = transfer_ring->push(data_trb);
-		transfer_ring->push(status_trb);
+		if (data_trb_position == nullptr ||
+			transfer_ring->push(status_trb) == nullptr) {
+			LOG_ERROR("failed to push control transfer trbs");
+			return;
+		}
 
 		setup_stages_.put(data_trb_position, setup_trb_position);
 	} else {
-		auto* setup_trb_position = trb_dynamic_cast<setup_stage_trb>(
-				transfer_ring->push(make_setup_stage_trb(
-						data.setup_data, setup_stage_trb::NO_DATA_STAGE)));
+		trb* pushed_setup_trb = transfer_ring->push(make_setup_stage_trb(
+				data.setup_data, setup_stage_trb::NO_DATA_STAGE));
+		if (pushed_setup_trb == nullptr) {
+			LOG_ERROR("failed to push setup stage trb");
+			return;
+		}
+
+		auto* setup_trb_position =
+				trb_dynamic_cast<setup_stage_trb>(pushed_setup_trb);
 		status_trb.bits.interrupt_on_completion = true;
 		auto* status_trb_position = transfer_ring->push(status_trb);
+		if (status_trb_position == nullptr) {
+			LOG_ERROR("failed to push status stage trb");
+			return;
+		}
 
 		setup_stages_.put(status_trb_position, setup_trb_position);
 	}
@@ -134,7 +174,11 @@ void Device::interrupt_in(const InterruptTransferData& data)
 	trb.bits.interrupt_on_short_packet = true;
 	trb.bits.interrupt_on_completion = true;
 
-	transfer_ring->push(trb);
+	if (transfer_ring->push(trb) == nullptr) {
+		LOG_ERROR("failed to push interrupt transfer trb");
+		return;
+	}
+
 	doorbell_register_->ring(dc_index.value);
 }
 
@@ -149,6 +193,14 @@ void Device::interrupt_out(const InterruptTransferData& data)
 void Device::on_transfer_event_received(const transfer_event_trb& event_trb)
 {
 	const auto residual_length = event_trb.bits.trb_transfer_length;
+
+	// Advance the transfer ring's consumer position so that Ring::push can
+	// detect a full ring.
+	const DeviceContextIndex event_dc_index{ event_trb.EndpointId() };
+	if (event_dc_index.value >= 1 && event_dc_index.value <= 31 &&
+		transfer_rings_[event_dc_index.value - 1] != nullptr) {
+		transfer_rings_[event_dc_index.value - 1]->on_consumed(event_trb.pointer());
+	}
 
 	const bool is_success = event_trb.bits.completion_code == 1 ||
 							event_trb.bits.completion_code == 13;

--- a/kernel/hardware/usb/xhci/port.cpp
+++ b/kernel/hardware/usb/xhci/port.cpp
@@ -5,6 +5,13 @@
 
 namespace kernel::hw::usb::xhci
 {
+
+namespace
+{
+// Bounded wait so that broken hardware cannot hang the kernel forever
+constexpr int SPIN_TIMEOUT_ITERATIONS = 1'000'000;
+} // namespace
+
 uint8_t Port::number() const { return port_num_; }
 
 bool Port::is_connected() const
@@ -29,14 +36,23 @@ bool Port::is_port_reset_changed() const
 
 int Port::speed() const { return regs_.port_sc.read().bits.port_speed; }
 
-void Port::reset()
+bool Port::reset()
 {
 	auto portsc = regs_.port_sc.read();
 	portsc.data[0] &= 0x0e00c3e0U;
 	portsc.data[0] |= 0x00020010U;
 	regs_.port_sc.write(portsc);
-	while (regs_.port_sc.read().bits.port_reset) {
+
+	for (int i = 0; i < SPIN_TIMEOUT_ITERATIONS; ++i) {
+		if (!regs_.port_sc.read().bits.port_reset) {
+			return true;
+		}
+
+		asm volatile("pause");
 	}
+
+	LOG_ERROR("timed out waiting for port %d reset to complete", port_num_);
+	return false;
 }
 
 void reset_port(Port& p)
@@ -60,7 +76,11 @@ void reset_port(Port& p)
 
 	addressing_port = p.number();
 	port_connection_states[p.number()] = PortConnectionState::RESETTING_PORT;
-	p.reset();
+	if (!p.reset()) {
+		// Give up on this port so that other ports can still be addressed.
+		port_connection_states[p.number()] = PortConnectionState::DISCONNECTED;
+		addressing_port = 0;
+	}
 }
 
 void configure_port(Port& p)

--- a/kernel/hardware/usb/xhci/port.hpp
+++ b/kernel/hardware/usb/xhci/port.hpp
@@ -43,7 +43,12 @@ public:
 	bool is_connect_status_changed() const;
 	bool is_port_reset_changed() const;
 	int speed() const;
-	void reset();
+
+	/**
+	 * @brief Reset the port
+	 * @return true on success, false when the reset does not complete in time
+	 */
+	bool reset();
 
 	void clear_connect_status_changed() { CLEAR_STATUS_BIT(connect_status_change); }
 

--- a/kernel/hardware/usb/xhci/ring.cpp
+++ b/kernel/hardware/usb/xhci/ring.cpp
@@ -16,6 +16,7 @@ void Ring::initialize(size_t buf_size)
 {
 	cycle_bit_ = true;
 	write_index_ = 0;
+	read_index_ = 0;
 	buffer_size_ = buf_size;
 	void* buffer_ptr;
 	ALLOC_OR_RETURN(buffer_ptr, sizeof(trb) * buffer_size_,
@@ -35,6 +36,22 @@ void Ring::copy_to_last(const std::array<uint32_t, 4>& data)
 
 trb* Ring::push(const std::array<uint32_t, 4>& data)
 {
+	if (buffer_ == nullptr || buffer_size_ < 2) {
+		LOG_ERROR("ring is not initialized");
+		return nullptr;
+	}
+
+	// The last slot is reserved for the link TRB.
+	size_t next_write_index = write_index_ + 1;
+	if (next_write_index == buffer_size_ - 1) {
+		next_write_index = 0;
+	}
+
+	if (next_write_index == read_index_) {
+		LOG_ERROR("ring is full");
+		return nullptr;
+	}
+
 	auto* trb_ptr = &buffer_[write_index_];
 	copy_to_last(data);
 
@@ -49,6 +66,21 @@ trb* Ring::push(const std::array<uint32_t, 4>& data)
 	}
 
 	return trb_ptr;
+}
+
+void Ring::on_consumed(const trb* consumed_trb)
+{
+	if (buffer_ == nullptr || consumed_trb < buffer_ ||
+		consumed_trb >= buffer_ + buffer_size_) {
+		return;
+	}
+
+	size_t next_read_index = static_cast<size_t>(consumed_trb - buffer_) + 1;
+	if (next_read_index >= buffer_size_ - 1) {
+		next_read_index = 0;
+	}
+
+	read_index_ = next_read_index;
 }
 
 void EventRing::initialize(size_t buf_size,

--- a/kernel/hardware/usb/xhci/ring.hpp
+++ b/kernel/hardware/usb/xhci/ring.hpp
@@ -28,11 +28,23 @@ public:
 
 	void initialize(size_t buf_size);
 
+	/**
+	 * @brief Push a TRB to the ring
+	 * @param trb TRB to push
+	 * @return Pointer to the TRB written on the ring, or nullptr when the ring
+	 * is full or not initialized
+	 */
 	template<class trb_type>
 	trb* push(const trb_type& trb)
 	{
 		return push(trb.data);
 	}
+
+	/**
+	 * @brief Advance the consumer position past a TRB the xHC has processed
+	 * @param consumed_trb Pointer to the processed TRB reported by an event
+	 */
+	void on_consumed(const trb* consumed_trb);
 
 	trb* buffer() const { return buffer_; }
 
@@ -42,6 +54,7 @@ private:
 
 	bool cycle_bit_;
 	size_t write_index_;
+	size_t read_index_ = 0;
 
 	void copy_to_last(const std::array<uint32_t, 4>& data);
 

--- a/kernel/hardware/usb/xhci/xhci.cpp
+++ b/kernel/hardware/usb/xhci/xhci.cpp
@@ -20,6 +20,32 @@ namespace
 {
 using namespace kernel::hw::usb::xhci;
 
+// xHCI completion code indicating a successful command (xHCI spec 6.4.5).
+constexpr uint32_t COMPLETION_CODE_SUCCESS = 1;
+
+// Upper bound for register polling loops so that broken hardware cannot
+// hang the kernel forever.
+constexpr int SPIN_TIMEOUT_ITERATIONS = 1'000'000;
+
+/**
+ * @brief Poll a condition with a bounded spin loop
+ * @param condition Callable returning true when the wait is over
+ * @return true if the condition became true, false on timeout
+ */
+template<class Condition>
+bool wait_with_timeout(Condition condition)
+{
+	for (int i = 0; i < SPIN_TIMEOUT_ITERATIONS; ++i) {
+		if (condition()) {
+			return true;
+		}
+
+		asm volatile("pause");
+	}
+
+	return false;
+}
+
 unsigned int determine_max_packet_size_for_control_pipe(int port_speed)
 {
 	switch (port_speed) {
@@ -29,6 +55,33 @@ unsigned int determine_max_packet_size_for_control_pipe(int port_speed)
 			return 64;
 		default:
 			return 8;
+	}
+}
+
+/**
+ * @brief Kick the reset of the next port waiting to be addressed, if any
+ */
+void proceed_to_next_waiting_port(Controller& xhc)
+{
+	addressing_port = 0;
+	for (int i = 0; i < static_cast<int>(port_connection_states.size()); i++) {
+		if (port_connection_states[i] == PortConnectionState::WAITING_ADDRESSED) {
+			auto p = xhc.port_at(i);
+			reset_port(p);
+			break;
+		}
+	}
+}
+
+/**
+ * @brief Abort the initialization of a single port, keeping the controller
+ * and the other ports running
+ */
+void abort_port_initialization(Controller& xhc, uint8_t port_id)
+{
+	port_connection_states[port_id] = PortConnectionState::DISCONNECTED;
+	if (addressing_port == port_id) {
+		proceed_to_next_waiting_port(xhc);
 	}
 }
 
@@ -42,7 +95,12 @@ void enable_slot(Controller& xhc, Port& p)
 		port_connection_states[p.number()] = PortConnectionState::ENABLEING_SLOT;
 
 		const enable_slot_command_trb cmd{};
-		xhc.command_ring()->push(cmd);
+		if (xhc.command_ring()->push(cmd) == nullptr) {
+			LOG_ERROR("failed to push enable slot command for port %d", p.number());
+			abort_port_initialization(xhc, p.number());
+			return;
+		}
+
 		xhc.doorbell_register_at(0)->ring(0);
 	}
 }
@@ -101,7 +159,12 @@ void address_device(Controller& xhc, uint8_t port_id, uint8_t slot_id)
 	port_connection_states[port_id] = PortConnectionState::ADDRESSING_DEVICE;
 
 	const address_device_command_trb cmd{ dev->input_context(), slot_id };
-	xhc.command_ring()->push(cmd);
+	if (xhc.command_ring()->push(cmd) == nullptr) {
+		LOG_ERROR("failed to push address device command for port %d", port_id);
+		abort_port_initialization(xhc, port_id);
+		return;
+	}
+
 	xhc.doorbell_register_at(0)->ring(0);
 }
 
@@ -145,12 +208,23 @@ void on_event(Controller& xhc, command_completion_event_trb& trb)
 {
 	const auto issuer_type = trb.pointer()->bits.trb_type;
 	const auto slot_id = trb.bits.slot_id;
+	const auto completion_code = trb.bits.completion_code;
+
+	// The command TRB pointed to by this event has been consumed by the xHC.
+	xhc.command_ring()->on_consumed(trb.pointer());
 
 	switch (issuer_type) {
 		case enable_slot_command_trb::TYPE:
 			if (port_connection_states[addressing_port] !=
 				PortConnectionState::ENABLEING_SLOT) {
 				LOG_ERROR("port %d is not enabling slot", addressing_port);
+				break;
+			}
+
+			if (completion_code != COMPLETION_CODE_SUCCESS) {
+				LOG_ERROR("enable slot command failed on port %d: completion code %u",
+						  addressing_port, completion_code);
+				abort_port_initialization(xhc, addressing_port);
 				break;
 			}
 
@@ -177,15 +251,15 @@ void on_event(Controller& xhc, command_completion_event_trb& trb)
 				break;
 			}
 
-			addressing_port = 0;
-			for (int i = 0; i < port_connection_states.size(); i++) {
-				if (port_connection_states[i] ==
-					PortConnectionState::WAITING_ADDRESSED) {
-					auto p = xhc.port_at(i);
-					reset_port(p);
-					break;
-				}
+			if (completion_code != COMPLETION_CODE_SUCCESS) {
+				LOG_ERROR(
+						"address device command failed on port %d: completion code %u",
+						port_id, completion_code);
+				abort_port_initialization(xhc, port_id);
+				break;
 			}
+
+			proceed_to_next_waiting_port(xhc);
 
 			initialize_device(xhc, port_id, slot_id);
 			break;
@@ -205,6 +279,14 @@ void on_event(Controller& xhc, command_completion_event_trb& trb)
 				break;
 			}
 
+			if (completion_code != COMPLETION_CODE_SUCCESS) {
+				LOG_ERROR("configure endpoint command failed on port %d: completion "
+						  "code %u",
+						  port_id, completion_code);
+				abort_port_initialization(xhc, port_id);
+				break;
+			}
+
 			complete_configuration(xhc, port_id, slot_id);
 			break;
 		}
@@ -215,7 +297,7 @@ void on_event(Controller& xhc, command_completion_event_trb& trb)
 	}
 }
 
-void request_hc_ownership(uintptr_t mmio_base, hcc_params1_register hccp)
+bool request_hc_ownership(uintptr_t mmio_base, hcc_params1_register hccp)
 {
 	const ExtendedRegisterList extended_regs{ mmio_base, hccp };
 
@@ -223,22 +305,26 @@ void request_hc_ownership(uintptr_t mmio_base, hcc_params1_register hccp)
 			extended_regs.begin(), extended_regs.end(),
 			[](auto& reg) { return reg.read().bits.capability_id == 1; });
 	if (ext_usb_legacy_support == extended_regs.end()) {
-		return;
+		return true;
 	}
 
 	auto& reg = reinterpret_cast<MemoryMappedRegister<usb_legacy_support_bitmap>&>(
 			*ext_usb_legacy_support);
 	auto r = reg.read();
 	if (r.bits.hc_os_owned_semaphore) {
-		return;
+		return true;
 	}
 
 	r.bits.hc_os_owned_semaphore = 1;
 	reg.write(r);
 
-	do {
-		r = reg.read();
-	} while (r.bits.hc_os_owned_semaphore == 0);
+	if (!wait_with_timeout(
+				[&reg] { return reg.read().bits.hc_os_owned_semaphore != 0; })) {
+		LOG_ERROR("timed out waiting for xHC ownership handover from BIOS");
+		return false;
+	}
+
+	return true;
 }
 } // namespace
 
@@ -253,11 +339,13 @@ Controller::Controller(uintptr_t mmio_base)
 {
 }
 
-void Controller::initialize()
+bool Controller::initialize()
 {
 	device_manager_.initialize(DEVICE_SIZE);
 
-	request_hc_ownership(mmio_base_, cap_regs_->hcc_params1.read());
+	if (!request_hc_ownership(mmio_base_, cap_regs_->hcc_params1.read())) {
+		return false;
+	}
 
 	// Stop the controller for initialization
 	auto usb_command = op_regs_->usb_cmd.read();
@@ -269,16 +357,29 @@ void Controller::initialize()
 	}
 
 	op_regs_->usb_cmd.write(usb_command);
-	while (!op_regs_->usb_sts.read().bits.host_controller_halted) {
+	if (!wait_with_timeout([this] {
+			return op_regs_->usb_sts.read().bits.host_controller_halted != 0;
+		})) {
+		LOG_ERROR("timed out waiting for xHC to halt");
+		return false;
 	}
 
 	// Reset controller
 	usb_command = op_regs_->usb_cmd.read();
 	usb_command.bits.host_controller_reset = true;
 	op_regs_->usb_cmd.write(usb_command);
-	while (op_regs_->usb_cmd.read().bits.host_controller_reset) {
+	if (!wait_with_timeout([this] {
+			return op_regs_->usb_cmd.read().bits.host_controller_reset == 0;
+		})) {
+		LOG_ERROR("timed out waiting for xHC reset to complete");
+		return false;
 	}
-	while (op_regs_->usb_sts.read().bits.controller_not_ready) {
+
+	if (!wait_with_timeout([this] {
+			return op_regs_->usb_sts.read().bits.controller_not_ready == 0;
+		})) {
+		LOG_ERROR("timed out waiting for xHC to become ready");
+		return false;
 	}
 
 	auto config = op_regs_->config.read();
@@ -291,10 +392,15 @@ void Controller::initialize()
 			(hcs_params2.bits.max_scratchpad_buffers_high << 5);
 
 	if (max_scratchpad_buffers > 0) {
-		void* scratchpad_buf_arr_ptr;
-		ALLOC_OR_RETURN(scratchpad_buf_arr_ptr,
-						sizeof(void*) * max_scratchpad_buffers,
-						kernel::memory::ALLOC_UNINITIALIZED);
+		void* scratchpad_buf_arr_ptr = kernel::memory::alloc(
+				sizeof(void*) * max_scratchpad_buffers,
+				kernel::memory::ALLOC_UNINITIALIZED);
+		if (scratchpad_buf_arr_ptr == nullptr) {
+			LOG_ERROR("Memory allocation failed: scratchpad_buf_arr_ptr (size=%zu)",
+					  sizeof(void*) * max_scratchpad_buffers);
+			return false;
+		}
+
 		auto* scratchpad_buf_arr = reinterpret_cast<void**>(scratchpad_buf_arr_ptr);
 
 		for (int i = 0; i < max_scratchpad_buffers; i++) {
@@ -305,7 +411,7 @@ void Controller::initialize()
 						"Memory allocation failed: scratchpad_buf_arr[%d] "
 						"(size=4096)",
 						i);
-				return;
+				return false;
 			}
 		}
 
@@ -332,16 +438,24 @@ void Controller::initialize()
 	usb_command = op_regs_->usb_cmd.read();
 	usb_command.bits.interrupter_enable = true;
 	op_regs_->usb_cmd.write(usb_command);
+
+	return true;
 }
 
-void Controller::run()
+bool Controller::run()
 {
 	auto usb_command = op_regs_->usb_cmd.read();
 	usb_command.bits.run_stop = true;
 	op_regs_->usb_cmd.write(usb_command);
 
-	while (op_regs_->usb_sts.read().bits.host_controller_halted) {
+	if (!wait_with_timeout([this] {
+			return op_regs_->usb_sts.read().bits.host_controller_halted == 0;
+		})) {
+		LOG_ERROR("timed out waiting for xHC to start running");
+		return false;
 	}
+
+	return true;
 }
 
 DoorbellRegister* Controller::doorbell_register_at(uint8_t index)
@@ -420,7 +534,12 @@ void configure_endpoints(Controller& xhc, Device& dev)
 	port_connection_states[port_id] = PortConnectionState::CONFIGURING_ENDPOINTS;
 
 	const configure_endpoint_command_trb cmd{ dev.input_context(), dev.slot_id() };
-	xhc.command_ring()->push(cmd);
+	if (xhc.command_ring()->push(cmd) == nullptr) {
+		LOG_ERROR("failed to push configure endpoint command for port %d", port_id);
+		abort_port_initialization(xhc, port_id);
+		return;
+	}
+
 	xhc.doorbell_register_at(0)->ring(0);
 }
 
@@ -481,9 +600,11 @@ void initialize()
 
 	Controller& xhc = *host_controller;
 
-	xhc.initialize();
-
-	xhc.run();
+	if (!xhc.initialize() || !xhc.run()) {
+		LOG_ERROR("failed to initialize xHCI controller, continuing without USB");
+		host_controller = nullptr;
+		return;
+	}
 
 	for (int i = 1; i < xhc.max_ports(); i++) {
 		auto p = xhc.port_at(i);
@@ -500,6 +621,10 @@ void initialize()
 
 void process_events()
 {
+	if (host_controller == nullptr) {
+		return;
+	}
+
 	while (host_controller->primary_event_ring()->has_front()) {
 		process_event(*host_controller);
 	}

--- a/kernel/hardware/usb/xhci/xhci.hpp
+++ b/kernel/hardware/usb/xhci/xhci.hpp
@@ -24,8 +24,20 @@ class Controller
 {
 public:
 	Controller(uintptr_t mmio_base);
-	void initialize();
-	void run();
+
+	/**
+	 * @brief Reset and set up the controller
+	 * @return true on success, false when the hardware does not respond in
+	 * time or a required allocation fails
+	 */
+	bool initialize();
+
+	/**
+	 * @brief Start the controller
+	 * @return true on success, false when the controller does not leave the
+	 * halted state in time
+	 */
+	bool run();
 	Ring* command_ring() { return &command_ring_; }
 	EventRing* primary_event_ring() { return &event_ring_; }
 	DoorbellRegister* doorbell_register_at(uint8_t index);

--- a/kernel/interrupt/irq_guard.hpp
+++ b/kernel/interrupt/irq_guard.hpp
@@ -1,0 +1,45 @@
+/**
+ * @file interrupt/irq_guard.hpp
+ * @brief Scoped interrupt disabling for short critical sections
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kernel::interrupt
+{
+
+/**
+ * @brief Disable interrupts for a scope, restoring the previous IF state
+ *
+ * Protects data shared with interrupt handlers (message queues, the run
+ * queue) on this single-processor kernel. Safe to nest and safe to use in
+ * interrupt context: the destructor re-enables interrupts only if they
+ * were enabled on entry.
+ */
+class IrqGuard
+{
+public:
+	IrqGuard()
+	{
+		uint64_t rflags;
+		asm volatile("pushfq\n\tpopq %0\n\tcli" : "=r"(rflags) : : "memory");
+		were_enabled_ = (rflags & 0x200) != 0;
+	}
+
+	~IrqGuard()
+	{
+		if (were_enabled_) {
+			asm volatile("sti" : : : "memory");
+		}
+	}
+
+	IrqGuard(const IrqGuard&) = delete;
+	IrqGuard& operator=(const IrqGuard&) = delete;
+
+private:
+	bool were_enabled_; ///< IF state on entry
+};
+
+} // namespace kernel::interrupt

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -50,7 +50,7 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	kernel::memory::initialize_memory_manager();
 
-	kernel::memory::disable();
+	kernel::memory::release_bootstrap();
 
 	kernel::memory::initialize_slab_allocator();
 

--- a/kernel/memory/bootstrap_allocator.cpp
+++ b/kernel/memory/bootstrap_allocator.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include "../../UchLoaderPkg/memory_map.hpp"
 #include "graphics/log.hpp"
-#include "memory/buddy_system.hpp"
 #include "memory/page.hpp"
 
 #include <sys/types.h>
@@ -148,16 +147,13 @@ void initialize_heap()
 	program_break_end = program_break + heap_size;
 }
 
-void disable()
+void release_bootstrap()
 {
-	if (kernel::memory::boot_allocator != nullptr) {
-		kernel::memory::memory_manager->free(
-				kernel::memory::boot_allocator,
-				sizeof(kernel::memory::BootstrapAllocator));
-		kernel::memory::boot_allocator = nullptr;
-	}
+	// The allocator lives in a static buffer inside the kernel BSS, so its
+	// pages must never be handed to the buddy system; just drop the pointer.
+	kernel::memory::boot_allocator = nullptr;
 
-	LOG_INFO("Bootstrap allocator disabled.");
+	LOG_INFO("Bootstrap allocator released.");
 }
 
 } // namespace kernel::memory

--- a/kernel/memory/bootstrap_allocator.hpp
+++ b/kernel/memory/bootstrap_allocator.hpp
@@ -49,8 +49,20 @@ private:
 
 extern BootstrapAllocator* boot_allocator;
 
+/**
+ * @brief Backing storage for the bootstrap allocator (kernel BSS)
+ * @note Exposed for regression tests only; do not use directly
+ */
+extern char bootstrap_allocator_buffer[sizeof(BootstrapAllocator)];
+
 void initialize(const MemoryMap& mem_map);
 void initialize_heap();
-void disable();
+
+/**
+ * @brief Retire the bootstrap allocator once the buddy system is up
+ * @note Only drops the global pointer. The allocator's static BSS buffer
+ * must never be freed into the buddy system.
+ */
+void release_bootstrap();
 
 } // namespace kernel::memory

--- a/kernel/memory/buddy_system.cpp
+++ b/kernel/memory/buddy_system.cpp
@@ -11,15 +11,18 @@ namespace kernel::memory
 
 BuddySystem* memory_manager;
 
-size_t BuddySystem::calculate_order(size_t num_pages)
+int BuddySystem::calculate_order(size_t num_pages)
 {
-	const size_t order = bit_width_ceil(num_pages);
-
-	if (order > MAX_ORDER) {
-		return MAX_ORDER;
+	if (num_pages == 0) {
+		return -1;
 	}
 
-	return order;
+	const size_t order = bit_width_ceil(num_pages);
+	if (order > MAX_ORDER) {
+		return -1;
+	}
+
+	return static_cast<int>(order);
 }
 
 void BuddySystem::split_memory_block(int order)
@@ -140,12 +143,16 @@ void BuddySystem::register_memory_blocks(size_t num_total_pages, Page* start_pag
 	}
 
 	auto calc_max_order_in_total_pages = [](size_t num_total_pages) -> size_t {
-		size_t order = calculate_order(num_total_pages);
-		if (num_total_pages < (1 << order)) {
-			--order;
+		if (num_total_pages == 0) {
+			return 0;
 		}
 
-		return order;
+		// floor(log2(num_total_pages)), clamped so that regions larger than
+		// the biggest buddy block are chunked into MAX_ORDER blocks
+		const size_t order = bit_width(num_total_pages) - 1;
+		return order > static_cast<size_t>(MAX_ORDER)
+					   ? static_cast<size_t>(MAX_ORDER)
+					   : order;
 	};
 
 	size_t order = calc_max_order_in_total_pages(num_total_pages);

--- a/kernel/memory/buddy_system.hpp
+++ b/kernel/memory/buddy_system.hpp
@@ -84,11 +84,12 @@ private:
 	 * -1 is returned if the size is too large to be allocated by the buddy
 	 * system.
 	 *
-	 * \param size The size of the memory block.
-	 * \return The order of the memory block.
+	 * \param num_pages The number of pages of the memory block.
+	 * \return The order of the memory block, or -1 if num_pages is 0 or
+	 * exceeds the largest block the buddy system can manage.
 	 */
 
-	static size_t calculate_order(size_t num_pages);
+	static int calculate_order(size_t num_pages);
 
 	std::array<std::list<Page*, PoolAllocator<Page*, PAGE_SIZE>>, MAX_ORDER + 1>
 			free_lists_;

--- a/kernel/memory/page.cpp
+++ b/kernel/memory/page.cpp
@@ -30,12 +30,16 @@ void initialize_pages()
 
 Page* get_page(void* ptr)
 {
-	if (ptr == nullptr ||
-		pages.size() < reinterpret_cast<uintptr_t>(ptr) / PAGE_SIZE) {
+	if (ptr == nullptr) {
 		return nullptr;
 	}
 
-	return &pages[reinterpret_cast<uintptr_t>(ptr) / PAGE_SIZE];
+	const size_t index = reinterpret_cast<uintptr_t>(ptr) / PAGE_SIZE;
+	if (index >= pages.size()) {
+		return nullptr;
+	}
+
+	return &pages[index];
 }
 
 void get_memory_usage(size_t* total_mem, size_t* used_mem)

--- a/kernel/memory/page.hpp
+++ b/kernel/memory/page.hpp
@@ -37,7 +37,14 @@ public:
 	 *
 	 * Initializes a page as free with no associated pointer.
 	 */
-	Page() : status_{ 0 }, cache_{ nullptr }, slab_{ nullptr }, ptr_{ nullptr } {}
+	Page()
+		: status_{ 0 },
+		  cache_{ nullptr },
+		  slab_{ nullptr },
+		  ref_count_{ 0 },
+		  ptr_{ nullptr }
+	{
+	}
 
 	/**
 	 * @brief Get the page index based on its memory address
@@ -114,11 +121,39 @@ public:
 	 */
 	MSlab* slab() const { return slab_; }
 
+	/**
+	 * @brief Add a reference to this page (shared user mapping)
+	 */
+	void inc_ref() { ++ref_count_; }
+
+	/**
+	 * @brief Drop a reference to this page
+	 *
+	 * @return size_t Remaining reference count (0 means the page is free
+	 * to release)
+	 */
+	size_t dec_ref()
+	{
+		if (ref_count_ > 0) {
+			--ref_count_;
+		}
+
+		return ref_count_;
+	}
+
+	/**
+	 * @brief Get the current reference count
+	 *
+	 * @return size_t Number of user mappings referencing this page
+	 */
+	size_t ref_count() const { return ref_count_; }
+
 private:
-	int status_;	///< Page status: 0 = free, 1 = used
-	MCache* cache_; ///< Associated cache (for slab allocator)
-	MSlab* slab_;	///< Associated slab (for slab allocator)
-	void* ptr_;		///< Pointer to the page's memory
+	int status_;	   ///< Page status: 0 = free, 1 = used
+	MCache* cache_;	   ///< Associated cache (for slab allocator)
+	MSlab* slab_;	   ///< Associated slab (for slab allocator)
+	size_t ref_count_; ///< Number of user mappings (CoW sharing)
+	void* ptr_;		   ///< Pointer to the page's memory
 };
 
 /**

--- a/kernel/memory/page.hpp
+++ b/kernel/memory/page.hpp
@@ -37,7 +37,7 @@ public:
 	 *
 	 * Initializes a page as free with no associated pointer.
 	 */
-	Page() : status_{ 0 }, ptr_{ nullptr } {}
+	Page() : status_{ 0 }, cache_{ nullptr }, slab_{ nullptr }, ptr_{ nullptr } {}
 
 	/**
 	 * @brief Get the page index based on its memory address

--- a/kernel/memory/paging.cpp
+++ b/kernel/memory/paging.cpp
@@ -124,6 +124,7 @@ int setup_page_table(page_table_entry* page_table,
 {
 	while (num_pages > 0) {
 		const int page_table_index = addr.part(page_table_level);
+		const bool was_present = page_table[page_table_index].bits.present;
 		auto* child_table = set_new_page_table(page_table[page_table_index]);
 		if (child_table == nullptr) {
 			LOG_ERROR("Failed to setup page table: level=%d", page_table_level);
@@ -132,6 +133,14 @@ int setup_page_table(page_table_entry* page_table,
 
 		if (page_table_level == 1) {
 			page_table[page_table_index].bits.writable = writable;
+			if (!was_present) {
+				// Freshly allocated user data page: this mapping owns it
+				page_table[page_table_index].bits.owned = 1;
+				Page* page = get_page(child_table);
+				if (page != nullptr) {
+					page->inc_ref();
+				}
+			}
 			--num_pages;
 		} else {
 			page_table[page_table_index].bits.writable = 1;
@@ -194,15 +203,27 @@ void clean_page_table(page_table_entry* table, int page_table_level)
 		}
 
 		if (page_table_level > 1) {
+			// Intermediate tables are exclusively owned by this address
+			// space (clones deep-copy them), so always free them.
 			clean_page_table(entry.get_next_level_table(), page_table_level - 1);
-		}
-
-		// skip CoW pages
-		if (!table[i].bits.writable && page_table_level == 1) {
+			kernel::memory::free(entry.get_next_level_table());
+			table[i].data = 0;
 			continue;
 		}
 
-		kernel::memory::free(entry.get_next_level_table());
+		// Level 1: leaf data page
+		if (!entry.bits.owned) {
+			// Foreign frame mapping (e.g. IPC shared memory): unmap only
+			table[i].data = 0;
+			continue;
+		}
+
+		void* data_page = entry.get_next_level_table();
+		Page* page = get_page(data_page);
+		if (page == nullptr || page->dec_ref() == 0) {
+			// Last reference (or untracked page): release it
+			kernel::memory::free(data_page);
+		}
 		table[i].data = 0;
 	}
 }
@@ -234,6 +255,14 @@ void copy_page_tables(page_table_entry* dst,
 			if (src[i].bits.present) {
 				dst[i] = src[i];
 				dst[i].bits.writable = writable;
+
+				if (src[i].bits.owned) {
+					// The new address space shares this data page (CoW)
+					Page* page = get_page(src[i].get_next_level_table());
+					if (page != nullptr) {
+						page->inc_ref();
+					}
+				}
 			}
 		}
 	} else {
@@ -259,6 +288,7 @@ void set_page_table_entry(page_table_entry* table,
 	const size_t pt_index = addr.part(1);
 	pt[pt_index].set_next_level_table(entry);
 	pt[pt_index].bits.writable = 1;
+	pt[pt_index].bits.owned = 1;
 	pt[pt_index].bits.present = 1;
 
 	flush_tlb(addr.data);
@@ -275,7 +305,26 @@ error_t copy_target_page(uint64_t addr)
 	const auto aligned_addr = addr & ~0xfff;
 	memcpy(page, reinterpret_cast<void*>(aligned_addr), kernel::memory::PAGE_SIZE);
 
+	// This address space stops referencing the shared CoW page
+	void* shared_page = nullptr;
+	auto* pte = get_pte(get_active_page_table(), vaddr_t{ addr }, 1);
+	if (pte != nullptr && pte->bits.present && pte->bits.owned) {
+		shared_page = pte->get_next_level_table();
+	}
+
+	Page* new_page = get_page(page);
+	if (new_page != nullptr) {
+		new_page->inc_ref();
+	}
+
 	set_page_table_entry(get_active_page_table(), vaddr_t{ addr }, page);
+
+	if (shared_page != nullptr) {
+		Page* old_page = get_page(shared_page);
+		if (old_page == nullptr || old_page->dec_ref() == 0) {
+			kernel::memory::free(shared_page);
+		}
+	}
 
 	return OK;
 }

--- a/kernel/memory/paging.hpp
+++ b/kernel/memory/paging.hpp
@@ -83,7 +83,9 @@ union page_table_entry {
 		uint64_t dirty : 1;
 		uint64_t huge_page : 1;
 		uint64_t global : 1;
-		uint64_t : 3;
+		uint64_t owned : 1; ///< OS bit: leaf page is owned (slab-backed user
+							///< page freed via ref count on clean)
+		uint64_t : 2;
 		uint64_t address : 40;
 		uint64_t : 11;
 		uint64_t no_execute : 1;
@@ -109,6 +111,21 @@ paddr_t get_paddr(page_table_entry* table, vaddr_t addr);
 void dump_page_tables(vaddr_t addr);
 
 page_table_entry* new_page_table();
+
+/**
+ * @brief Map num_pages of newly allocated user memory at addr in a table
+ * @param page_table Root (PML4) table to build the mapping in
+ * @param page_table_level Table level of page_table (4 for a root table)
+ * @param addr Start virtual address
+ * @param num_pages Number of pages to map
+ * @param writable Whether the leaf mappings are writable
+ * @return Number of pages left unmapped (0 on success), or -1 on failure
+ */
+int setup_page_table(page_table_entry* page_table,
+					 int page_table_level,
+					 vaddr_t addr,
+					 size_t num_pages,
+					 bool writable);
 
 void setup_page_tables(vaddr_t addr, size_t num_pages, bool writable);
 

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -15,7 +15,7 @@
 namespace kernel::memory
 {
 
-MCache* get_cache_in_chain(char* name)
+MCache* get_cache_in_chain(const char* name)
 {
 	if (cache_chain.empty()) {
 		return nullptr;
@@ -30,7 +30,7 @@ MCache* get_cache_in_chain(char* name)
 	return nullptr;
 }
 
-MCache::MCache(char name[20], size_t object_size)
+MCache::MCache(const char* name, size_t object_size)
 	: object_size_(object_size),
 	  num_active_objects_(0),
 	  num_total_objects_(0),
@@ -39,7 +39,7 @@ MCache::MCache(char name[20], size_t object_size)
 	  num_pages_per_slab_(0)
 {
 	strncpy(name_, name, sizeof(name_) - 1);
-	name[sizeof(name_) - 1] = '\0';
+	name_[sizeof(name_) - 1] = '\0';
 
 	if (object_size <= kernel::memory::PAGE_SIZE) {
 		num_pages_per_slab_ = 1;
@@ -60,7 +60,7 @@ MSlab::MSlab(void* base_addr, size_t num_objs)
 
 MCache& m_cache_create(const char* name, size_t obj_size)
 {
-	obj_size = 1 << bit_width_ceil(obj_size);
+	obj_size = 1UL << bit_width_ceil(obj_size);
 
 	char temp_name[20];
 	if (name == nullptr) {
@@ -68,8 +68,8 @@ MCache& m_cache_create(const char* name, size_t obj_size)
 		name = temp_name;
 	}
 
-	cache_chain.push_back(std::make_unique<kernel::memory::MCache>(
-			const_cast<char*>(name), obj_size));
+	cache_chain.push_back(
+			std::make_unique<kernel::memory::MCache>(name, obj_size));
 
 	return *cache_chain.back();
 }
@@ -86,9 +86,20 @@ bool MCache::grow()
 	size_t const num_objs = bytes_per_slab / object_size_;
 	auto slab = std::make_unique<MSlab>(addr, num_objs);
 
-	Page* page = get_page(addr);
-	page->set_cache(this);
-	page->set_slab(slab.get());
+	// Mark every page of the slab so that free() can resolve the owning
+	// cache/slab from any object address.
+	for (size_t i = 0; i < num_pages_per_slab_; ++i) {
+		Page* page = get_page(reinterpret_cast<char*>(addr) +
+							  i * kernel::memory::PAGE_SIZE);
+		if (page == nullptr) {
+			LOG_ERROR("failed to look up page for slab at %p", addr);
+			kernel::memory::memory_manager->free(addr, bytes_per_slab);
+			return false;
+		}
+
+		page->set_cache(this);
+		page->set_slab(slab.get());
+	}
 
 	++num_total_slabs_;
 	num_total_objects_ += num_objs;
@@ -181,6 +192,7 @@ void* MSlab::alloc_object(size_t obj_size)
 	free_objects_index_.pop_front();
 
 	objects_[obj_index].increase_usage_count();
+	objects_[obj_index].set_in_use(true);
 
 	num_in_use_++;
 
@@ -188,14 +200,47 @@ void* MSlab::alloc_object(size_t obj_size)
 								   obj_index * obj_size);
 }
 
-void MSlab::free_object(void* addr, size_t obj_size)
+bool MSlab::free_object(void* addr, size_t obj_size)
 {
-	const size_t objs_index = (reinterpret_cast<uintptr_t>(addr) -
-							   reinterpret_cast<uintptr_t>(base_addr_)) /
-							  obj_size;
+	const uintptr_t offset = reinterpret_cast<uintptr_t>(addr) -
+							 reinterpret_cast<uintptr_t>(base_addr_);
+	if (offset % obj_size != 0) {
+		LOG_ERROR("free: %p is not an object boundary", addr);
+		return false;
+	}
 
+	const size_t objs_index = offset / obj_size;
+	if (objs_index >= objects_.size()) {
+		LOG_ERROR("free: %p is out of slab range", addr);
+		return false;
+	}
+
+	if (!objects_[objs_index].is_in_use()) {
+		LOG_ERROR("double free detected at address: %p", addr);
+		return false;
+	}
+
+	objects_[objs_index].set_in_use(false);
 	free_objects_index_.push_back(objs_index);
 	--num_in_use_;
+
+	return true;
+}
+
+bool MSlab::is_object_in_use(void* addr, size_t obj_size) const
+{
+	const uintptr_t offset = reinterpret_cast<uintptr_t>(addr) -
+							 reinterpret_cast<uintptr_t>(base_addr_);
+	if (offset % obj_size != 0) {
+		return false;
+	}
+
+	const size_t objs_index = offset / obj_size;
+	if (objs_index >= objects_.size()) {
+		return false;
+	}
+
+	return objects_[objs_index].is_in_use();
 }
 
 } // namespace kernel::memory
@@ -205,14 +250,28 @@ std::unordered_map<void*, void*> aligned_to_raw_addr_map;
 namespace kernel::memory
 {
 
+// Largest single allocation: the biggest block the buddy system can back
+// a slab with.
+constexpr size_t MAX_ALLOC_SIZE = (1UL << MAX_ORDER) * PAGE_SIZE;
+
 void* alloc(size_t size, unsigned flags, int align)
 {
+	if (size == 0) {
+		LOG_ERROR("alloc: size must be non-zero");
+		return nullptr;
+	}
+
 	if (align != 1 && (align & (align - 1)) != 0) {
 		LOG_ERROR("align must be a power of 2");
 		return nullptr;
 	}
 
-	size = 1 << bit_width_ceil(size + align - 1);
+	if (size > MAX_ALLOC_SIZE - (static_cast<size_t>(align) - 1)) {
+		LOG_ERROR("alloc: size %lu is too large", size);
+		return nullptr;
+	}
+
+	size = 1UL << bit_width_ceil(size + align - 1);
 	char name[20];
 	sprintf(name, "cache-%d", static_cast<int>(size));
 
@@ -247,6 +306,10 @@ void* alloc(size_t size, unsigned flags, int align)
 
 void free(void* addr)
 {
+	if (addr == nullptr) {
+		return;
+	}
+
 	auto it = aligned_to_raw_addr_map.find(addr);
 	if (it != aligned_to_raw_addr_map.end()) {
 		addr = it->second;
@@ -261,8 +324,15 @@ void free(void* addr)
 
 	MCache* cache = p->cache();
 	MSlab* slab = p->slab();
+	if (cache == nullptr || slab == nullptr) {
+		LOG_ERROR("free: %p was not allocated by the slab allocator", addr);
+		return;
+	}
 
-	slab->free_object(addr, cache->object_size());
+	if (!slab->free_object(addr, cache->object_size())) {
+		return;
+	}
+
 	cache->decrease_num_active_objects();
 
 	if (slab->status() == SlabStatus::FULL) {
@@ -273,6 +343,25 @@ void free(void* addr)
 		slab->move_list(*cache, SlabStatus::FREE);
 		cache->decrease_num_active_slabs();
 	}
+}
+
+bool is_slab_object_in_use(void* addr)
+{
+	if (addr == nullptr) {
+		return false;
+	}
+
+	auto it = aligned_to_raw_addr_map.find(addr);
+	if (it != aligned_to_raw_addr_map.end()) {
+		addr = it->second;
+	}
+
+	Page* p = get_page(addr);
+	if (p == nullptr || p->cache() == nullptr || p->slab() == nullptr) {
+		return false;
+	}
+
+	return p->slab()->is_object_in_use(addr, p->cache()->object_size());
 }
 
 std::list<std::unique_ptr<MCache>> cache_chain;

--- a/kernel/memory/slab.hpp
+++ b/kernel/memory/slab.hpp
@@ -38,8 +38,13 @@ public:
 
 	void increase_usage_count() { usage_count_++; }
 
+	bool is_in_use() const { return in_use_; }
+
+	void set_in_use(bool in_use) { in_use_ = in_use; }
+
 private:
-	unsigned int usage_count_;
+	unsigned int usage_count_ = 0;
+	bool in_use_ = false;
 };
 
 class MCache;
@@ -64,7 +69,22 @@ public:
 
 	void* alloc_object(size_t obj_size);
 
-	void free_object(void* addr, size_t obj_size);
+	/**
+	 * @brief Return an object to this slab
+	 * @param addr Address previously returned by alloc_object
+	 * @param obj_size Object size of the owning cache
+	 * @return true on success, false if addr is not a live object of this
+	 * slab (out of range, misaligned, or already freed)
+	 */
+	bool free_object(void* addr, size_t obj_size);
+
+	/**
+	 * @brief Check whether addr is a live (allocated) object of this slab
+	 * @param addr Object address to check
+	 * @param obj_size Object size of the owning cache
+	 * @return true if addr is currently allocated
+	 */
+	bool is_object_in_use(void* addr, size_t obj_size) const;
 
 	void move_list(MCache& cache, SlabStatus to);
 
@@ -80,7 +100,7 @@ private:
 class MCache
 {
 public:
-	MCache(char name[20], size_t object_size);
+	MCache(const char* name, size_t object_size);
 
 	char* name() { return name_; }
 	size_t object_size() const { return object_size_; }
@@ -112,7 +132,7 @@ extern std::list<std::unique_ptr<MCache>> cache_chain;
  * @param name Name of the cache to retrieve
  * @return Pointer to the found cache, or nullptr if not found
  */
-MCache* get_cache_in_chain(char* name);
+MCache* get_cache_in_chain(const char* name);
 
 /**
  * @brief Create a new memory cache
@@ -138,6 +158,14 @@ void* alloc(size_t size, unsigned flags, int align = 1);
  * @note Does nothing if addr is nullptr
  */
 void free(void* addr);
+
+/**
+ * @brief Check whether addr points to a live slab allocation
+ * @param addr Address previously returned by alloc()
+ * @return true if addr is currently allocated by the slab allocator
+ * @note Intended for tests and debugging
+ */
+bool is_slab_object_in_use(void* addr);
 
 struct FreeDeleter {
 	void operator()(void* p) { free(p); }

--- a/kernel/memory/user.cpp
+++ b/kernel/memory/user.cpp
@@ -48,3 +48,28 @@ size_t copy_from_user(void* to, const void __user* from, size_t n)
 
 	return n;
 }
+
+ssize_t copy_string_from_user(char* to, const char __user* from, size_t max_len)
+{
+	if (to == nullptr || from == nullptr || max_len == 0) {
+		return -1;
+	}
+
+	const char* src = static_cast<const char*>(from);
+	for (size_t i = 0; i < max_len; ++i) {
+		if (!is_user_address(&src[i], 1)) {
+			LOG_ERROR("invalid address for copy_string_from_user: %p", &src[i]);
+			to[0] = '\0';
+			return -1;
+		}
+
+		to[i] = src[i];
+		if (src[i] == '\0') {
+			return static_cast<ssize_t>(i);
+		}
+	}
+
+	// No terminator within max_len: the string does not fit
+	to[max_len - 1] = '\0';
+	return -1;
+}

--- a/kernel/memory/user.hpp
+++ b/kernel/memory/user.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <sys/types.h>
 #include <cstddef>
 
 /**
@@ -45,9 +46,9 @@ bool is_user_address(const void* addr, size_t n);
  * @param to User space destination buffer
  * @param from Kernel space source buffer
  * @param n Number of bytes to copy
- * @return Number of bytes NOT copied (0 on success)
+ * @return Number of bytes copied: n on success, 0 on failure
  *
- * @note Returns non-zero if the copy fails (e.g., invalid user address)
+ * @note Callers must treat a return value different from n as a failure
  * @warning The user space buffer must be writable
  */
 size_t copy_to_user(void __user* to, const void* from, size_t n);
@@ -61,9 +62,23 @@ size_t copy_to_user(void __user* to, const void* from, size_t n);
  * @param to Kernel space destination buffer
  * @param from User space source buffer
  * @param n Number of bytes to copy
- * @return Number of bytes NOT copied (0 on success)
+ * @return Number of bytes copied: n on success, 0 on failure
  *
- * @note Returns non-zero if the copy fails (e.g., invalid user address)
+ * @note Callers must treat a return value different from n as a failure
  * @warning The kernel buffer must be large enough to hold n bytes
  */
 size_t copy_from_user(void* to, const void __user* from, size_t n);
+
+/**
+ * @brief Copy a NUL-terminated string from user space
+ *
+ * Validates every byte as a user-space address and always leaves a
+ * NUL-terminated string in the destination buffer.
+ *
+ * @param to Kernel destination buffer of at least max_len bytes
+ * @param from User space string
+ * @param max_len Destination buffer size in bytes (must be > 0)
+ * @return Length of the copied string (excluding the terminator), or -1
+ * if the pointer is invalid or the string does not fit in max_len bytes
+ */
+ssize_t copy_string_from_user(char* to, const char __user* from, size_t max_len);

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -256,12 +256,12 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 			kernel::task::wait_for_message(MsgType::IPC_READ_FILE_DATA);
 	kernel::memory::free(entry);
 
-	// Save current FD table before cleaning page tables
-	auto saved_fd_table = kernel::task::CURRENT_TASK->fd_table;
-
-	kernel::memory::page_table_entry* current_page_table =
+	// Build the new address space and switch CR3 to it BEFORE releasing the
+	// old one: config_new_page_table() copies the kernel space out of the
+	// active table, and the CPU keeps translating through the old table
+	// until the switch (issue #313 use-after-free).
+	kernel::memory::page_table_entry* old_page_table =
 			kernel::memory::get_active_page_table();
-	kernel::memory::clean_page_tables(current_page_table);
 
 	kernel::memory::page_table_entry* new_page_table =
 			kernel::memory::config_new_page_table();
@@ -271,8 +271,7 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 
 	kernel::task::CURRENT_TASK->ctx.cr3 = reinterpret_cast<uint64_t>(new_page_table);
 
-	// Restore FD table after page table switch
-	kernel::task::CURRENT_TASK->fd_table = saved_fd_table;
+	kernel::memory::clean_page_tables(old_page_table);
 
 	// TODO: fix this
 	kernel::fs::fat::execute_file(data_m.data.fs.buf, "", copy_args.data());

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -7,7 +7,6 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <vector>
 #include "fs/fat/fat.hpp"
 #include "graphics/font.hpp"
 #include "graphics/log.hpp"
@@ -115,14 +114,21 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 
 size_t sys_draw_text(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
 {
-	const char* text = reinterpret_cast<const char*>(arg1);
+	const char __user* text = reinterpret_cast<const char*>(arg1);
 	const int x = arg2;
 	const int y = arg3;
 	const uint32_t color = arg4;
 
-	write_string(*kernel::graphics::kscreen, { x, y }, text, color);
+	// Copy the string out of user space before touching it (issue #313)
+	char buf[256];
+	const ssize_t len = copy_string_from_user(buf, text, sizeof(buf));
+	if (len < 0) {
+		return 0;
+	}
 
-	return strlen(text);
+	write_string(*kernel::graphics::kscreen, { x, y }, buf, color);
+
+	return len;
 }
 
 error_t sys_fill_rect(uint64_t arg1,
@@ -162,30 +168,37 @@ error_t sys_time(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
 error_t sys_ipc(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
 {
 	const int dest = arg1;
-	Message __user& m = *reinterpret_cast<Message*>(arg3);
+	Message __user* m = reinterpret_cast<Message*>(arg3);
 	const int flags = arg4;
 
 	kernel::task::Task* t = kernel::task::CURRENT_TASK;
-	t->state = kernel::task::TASK_WAITING;
 
 	if (flags == IPC_RECV) {
-		if (t->messages.empty()) {
-			m = {};
-			m.type = MsgType::NO_TASK;
-			return OK;
+		Message received{};
+		received.type = MsgType::NO_TASK;
+
+		__asm__("cli");
+		if (!t->messages.empty()) {
+			received = t->messages.front();
+			t->messages.pop_front();
 		}
+		__asm__("sti");
 
-		t->state = kernel::task::TASK_RUNNING;
-
-		copy_to_user(&m, &t->messages.front(), sizeof(m));
-		t->messages.pop();
+		// The task stays RUNNING even when the queue is empty: returning
+		// to user space as WAITING would drop the task from the run queue
+		// on the next preemption (issue #313).
+		if (copy_to_user(m, &received, sizeof(*m)) != sizeof(*m)) {
+			return ERR_INVALID_ARG;
+		}
 
 		return OK;
 	}
 
 	if (flags == IPC_SEND) {
 		Message copy_m;
-		copy_from_user(&copy_m, &m, sizeof(m));
+		if (copy_from_user(&copy_m, m, sizeof(copy_m)) != sizeof(copy_m)) {
+			return ERR_INVALID_ARG;
+		}
 
 		if (copy_m.type == MsgType::INITIALIZE_TASK) {
 			copy_m.sender = t->id;
@@ -224,19 +237,23 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	const char __user* path = reinterpret_cast<const char*>(arg1);
 	const char __user* args = reinterpret_cast<const char*>(arg2);
 
-	const size_t path_len = strlen(path);
-	std::vector<char> copy_path(path_len + 1);
-	copy_from_user(copy_path.data(), path, path_len);
-	copy_path[path_len] = '\0';
-
-	const size_t args_len = strlen(args);
-	std::vector<char> copy_args(args_len + 1);
-	copy_from_user(copy_args.data(), args, args_len);
-	copy_args[args_len] = '\0';
-
 	Message msg{ .type = MsgType::IPC_GET_FILE_INFO,
 				 .sender = kernel::task::CURRENT_TASK->id };
-	memcpy(msg.data.fs.name, copy_path.data(), path_len + 1);
+
+	// Copy the strings out of user space with bounds checks before using
+	// them; the path must also fit the fixed-size Message name field
+	// (issue #313)
+	if (copy_string_from_user(msg.data.fs.name, path, sizeof(msg.data.fs.name)) <
+		0) {
+		return ERR_INVALID_ARG;
+	}
+
+	char copy_args[256] = "";
+	if (args != nullptr &&
+		copy_string_from_user(copy_args, args, sizeof(copy_args)) < 0) {
+		return ERR_INVALID_ARG;
+	}
+
 	kernel::task::send_message(process_ids::FS_FAT32, msg);
 
 	const Message info_m =
@@ -274,7 +291,7 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	kernel::memory::clean_page_tables(old_page_table);
 
 	// TODO: fix this
-	kernel::fs::fat::execute_file(data_m.data.fs.buf, "", copy_args.data());
+	kernel::fs::fat::execute_file(data_m.data.fs.buf, "", copy_args);
 
 	return OK;
 }
@@ -285,32 +302,17 @@ ProcessId sys_wait(uint64_t arg1)
 {
 	auto __user* status = reinterpret_cast<int*>(arg1);
 
-	kernel::task::Task* t = kernel::task::CURRENT_TASK;
+	// Sleep until the child exits instead of busy-waiting (issue #313)
+	Message m = kernel::task::wait_for_message(MsgType::IPC_EXIT_TASK);
 
-	while (true) {
-		if (t->messages.empty()) {
-			t->state = kernel::task::TASK_WAITING;
-			asm("pause");
-			continue;
-		}
+	task::send_message(process_ids::SHELL, m);
 
-		t->state = kernel::task::TASK_RUNNING;
-
-		Message m = t->messages.front();
-		t->messages.pop();
-
-		if (m.type == MsgType::IPC_EXIT_TASK) {
-			task::send_message(process_ids::SHELL, m);
-			copy_to_user(status, &m.data.exit_task.status, sizeof(int));
-			return m.sender;
-		}
-
-		__asm__("cli");
-		t->messages.push(m);
-		__asm__("sti");
+	if (copy_to_user(status, &m.data.exit_task.status, sizeof(int)) !=
+		sizeof(int)) {
+		return ProcessId::from_raw(-1);
 	}
 
-	return ProcessId::from_raw(-1);
+	return m.sender;
 }
 
 ProcessId sys_getpid(void) { return kernel::task::CURRENT_TASK->id; }

--- a/kernel/task/ipc.cpp
+++ b/kernel/task/ipc.cpp
@@ -5,6 +5,8 @@
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 #include "error.hpp"
+#include "graphics/log.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "memory/paging.hpp"
 #include "memory/user.hpp"
 #include "task.hpp"
@@ -74,11 +76,21 @@ error_t send_message(ProcessId dst_id, Message& m)
 		RETURN_IF_ERROR(handle_ool_memory_alloc(m, dst));
 	}
 
+	// The queue is shared with interrupt handlers; keep the wakeup check
+	// and the push atomic so a receiver going to sleep cannot miss it
+	const kernel::interrupt::IrqGuard guard;
+
+	if (dst->messages.size() >= MAX_QUEUED_MESSAGES) {
+		LOG_ERROR_CODE(ERR_QUEUE_FULL, "message queue full: dest = %d, type = %d",
+					   dst_raw, static_cast<int>(m.type));
+		return ERR_QUEUE_FULL;
+	}
+
 	if (dst->state == TASK_WAITING) {
 		schedule_task(dst_id);
 	}
 
-	dst->messages.push(m);
+	dst->messages.push_back(m);
 
 	return OK;
 }

--- a/kernel/task/ipc.hpp
+++ b/kernel/task/ipc.hpp
@@ -18,6 +18,15 @@ namespace kernel::task
 {
 
 /**
+ * @brief Maximum number of messages queued per task
+ *
+ * Backstop against unbounded queue growth (and thus unbounded heap
+ * allocation from interrupt context) when a receiver never drains its
+ * queue. A fixed-size ring buffer is planned for Phase 2 (issue #313).
+ */
+constexpr size_t MAX_QUEUED_MESSAGES = 1024;
+
+/**
  * @brief Send a message to the specified task
  * @param dst Destination task ID
  * @param m Message to send (may be modified during sending)
@@ -25,9 +34,13 @@ namespace kernel::task
  * @retval OK Message sent successfully
  * @retval ERR_INVALID_ARG Invalid destination ID (-1 or same as sender)
  * @retval ERR_INVALID_TASK Destination task does not exist
+ * @retval ERR_QUEUE_FULL Destination queue reached MAX_QUEUED_MESSAGES
  * @note Supports out-of-line memory transfer
- * @note [[gnu::no_caller_saved_registers]] attribute optimizes register saving on
- * call
+ * @note [[gnu::no_caller_saved_registers]] lets interrupt handlers call this
+ * without spilling every register
+ * @warning Because of that attribute the return value is NOT reliable at the
+ * call site (RAX is restored by the epilogue); treat errors as diagnostics
+ * (they are logged) rather than branching on them
  */
 [[gnu::no_caller_saved_registers]] error_t send_message(ProcessId dst, Message& m);
 

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -138,16 +138,32 @@ error_t Task::copy_parent_page_table()
 		return ERR_NO_TASK;
 	}
 
-	parent->page_table_snapshot =
+	kernel::memory::page_table_entry* snapshot =
 			reinterpret_cast<kernel::memory::page_table_entry*>(parent->ctx.cr3);
 
 	kernel::memory::page_table_entry* parent_table =
-			kernel::memory::clone_page_table(parent->page_table_snapshot, false);
+			kernel::memory::clone_page_table(snapshot, false);
+	if (parent_table == nullptr) {
+		return ERR_NO_MEMORY;
+	}
+
+	// Move the running parent onto its CoW clone. Update ctx.cr3 too so an
+	// exit before the next context save does not tear down the wrong table.
 	set_cr3(reinterpret_cast<uint64_t>(parent_table));
+	parent->ctx.cr3 = reinterpret_cast<uint64_t>(parent_table);
 
 	kernel::memory::page_table_entry* child_table =
-			kernel::memory::clone_page_table(parent->page_table_snapshot, false);
+			kernel::memory::clone_page_table(snapshot, false);
+	if (child_table == nullptr) {
+		return ERR_NO_MEMORY;
+	}
+
 	ctx.cr3 = reinterpret_cast<uint64_t>(child_table);
+
+	// Both clones hold their own references to the CoW data pages now, and
+	// nothing runs on the pre-fork table anymore; release it (issue #313
+	// page table leak).
+	kernel::memory::clean_page_tables(snapshot);
 
 	return OK;
 }

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -225,8 +225,13 @@ void schedule_task(ProcessId id)
 void switch_task(const Context& current_ctx)
 {
 	if (CURRENT_TASK->state == TASK_EXITED) {
-		delete tasks[CURRENT_TASK->id.raw()];
-		tasks[CURRENT_TASK->id.raw()] = nullptr;
+		// ~Task frees the kernel stack we are still running on; keep
+		// interrupts off until restore_context switches to the next
+		// task's stack so nothing can reuse it in between.
+		asm volatile("cli");
+		const pid_t exited_id = CURRENT_TASK->id.raw();
+		delete tasks[exited_id];
+		tasks[exited_id] = nullptr;
 	} else {
 		memcpy(&CURRENT_TASK->ctx, &current_ctx, sizeof(Context));
 		if (CURRENT_TASK->state != TASK_WAITING) {

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -5,12 +5,12 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <queue>
 #include "fs/fat/fat.hpp"
 #include "fs/path.hpp"
 #include "graphics/log.hpp"
 #include "hardware/virtio/blk.hpp"
 #include "hardware/virtio/net.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "interrupt/vector.hpp"
 #include "list.hpp"
 #include "memory/page.hpp"
@@ -224,10 +224,14 @@ Task* get_scheduled_task()
 void schedule_task(ProcessId id)
 {
 	const pid_t raw_id = id.raw();
-	if (tasks.size() <= raw_id || tasks[raw_id] == nullptr) {
+	if (raw_id < 0 || tasks.size() <= static_cast<size_t>(raw_id) ||
+		tasks[raw_id] == nullptr) {
 		LOG_ERROR("schedule_task: task %d is not found", raw_id);
 		return;
 	}
+
+	// The run queue is shared with interrupt handlers
+	const kernel::interrupt::IrqGuard guard;
 
 	tasks[raw_id]->state = TASK_READY;
 
@@ -287,15 +291,22 @@ void exit_task(int status)
 [[noreturn]] void process_messages(Task* t)
 {
 	while (true) {
+		__asm__("cli");
 		if (t->messages.empty()) {
-			switch_next_task(true);
+			// Declare WAITING while interrupts are off so a sender cannot
+			// slip in between the emptiness check and the sleep (lost
+			// wakeup). The INT in switch_next_task is not blocked by IF.
+			t->state = TASK_WAITING;
+			__asm__("sti");
+			switch_next_task(false);
 			continue;
 		}
 
 		t->state = TASK_RUNNING;
 
 		const Message m = t->messages.front();
-		t->messages.pop();
+		t->messages.pop_front();
+		__asm__("sti");
 
 		if (m.type == MsgType::NO_TASK || m.type >= MsgType::MAX_MESSAGE_TYPE) {
 			continue;
@@ -339,7 +350,7 @@ Task::Task(int raw_id,
 	  state{ state },
 	  fs_path({ nullptr, nullptr, nullptr }),
 	  stack{ nullptr },
-	  messages{ std::queue<Message>() },
+	  messages{},
 	  message_handlers({ std::array<message_handler_t, TOTAL_MESSAGE_TYPES>() }),
 	  fd_table()
 {
@@ -384,24 +395,27 @@ Message wait_for_message(MsgType type)
 	Task* t = CURRENT_TASK;
 
 	while (true) {
-		if (t->messages.empty()) {
-			switch_next_task(true);
-			continue;
-		}
+		__asm__("cli");
+		for (auto it = t->messages.begin(); it != t->messages.end(); ++it) {
+			if (it->type != type) {
+				continue;
+			}
 
-		t->state = TASK_RUNNING;
-
-		Message m = t->messages.front();
-		t->messages.pop();
-
-		if (m.type != type) {
-			__asm__("cli");
-			t->messages.push(m);
+			const Message m = *it;
+			t->messages.erase(it);
+			t->state = TASK_RUNNING;
 			__asm__("sti");
-			continue;
+
+			return m;
 		}
 
-		return m;
+		// No matching message yet: sleep instead of spinning, and leave
+		// the other queued messages untouched (issue #313 livelock).
+		// WAITING is declared while interrupts are off so a sender cannot
+		// slip in between the scan and the sleep.
+		t->state = TASK_WAITING;
+		__asm__("sti");
+		switch_next_task(false);
 	}
 }
 

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -50,8 +50,13 @@ struct Task {
 
 	~Task()
 	{
-		kernel::memory::clean_page_tables(
-				reinterpret_cast<kernel::memory::page_table_entry*>(ctx.cr3));
+		if (ctx.cr3 != 0) {
+			kernel::memory::clean_page_tables(
+					reinterpret_cast<kernel::memory::page_table_entry*>(
+							ctx.cr3));
+		}
+
+		kernel::memory::free(stack);
 	}
 
 	static void* operator new(size_t size)

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -3,10 +3,10 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <queue>
 #include "fs/file_descriptor.hpp"
 #include "fs/path.hpp"
 #include "list.hpp"
@@ -36,7 +36,7 @@ struct Task {
 	uint64_t kernel_stack_ptr;
 	alignas(16) Context ctx;
 	list_elem_t run_queue_elem;
-	std::queue<Message> messages;
+	std::deque<Message> messages;
 	std::array<message_handler_t, TOTAL_MESSAGE_TYPES> message_handlers;
 	std::array<kernel::fs::FileDescriptor, MAX_FDS_PER_PROCESS> fd_table;
 

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -35,7 +35,6 @@ struct Task {
 	size_t stack_size;
 	uint64_t kernel_stack_ptr;
 	alignas(16) Context ctx;
-	kernel::memory::page_table_entry* page_table_snapshot;
 	list_elem_t run_queue_elem;
 	std::queue<Message> messages;
 	std::array<message_handler_t, TOTAL_MESSAGE_TYPES> message_handlers;

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include "task/task.hpp"
 #include "tests/framework.hpp"
+#include "tests/test_cases/bit_utils_test.hpp"
 #include "tests/test_cases/fd_test.hpp"
 #include "tests/test_cases/fs_test.hpp"
 #include "tests/test_cases/memory_test.hpp"
@@ -66,6 +67,7 @@ namespace kernel::tests
 
 void run_bootstrap_stage_tests()
 {
+	run_test_suite(register_bit_utils_tests);
 	run_test_suite(register_bootstrap_allocator_tests);
 }
 

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -15,6 +15,7 @@
 #include "tests/test_cases/stdio_test.hpp"
 #include "tests/test_cases/task_test.hpp"
 #include "tests/test_cases/timer_test.hpp"
+#include "tests/test_cases/user_test.hpp"
 #include "tests/test_cases/virtio_blk_test.hpp"
 
 #ifdef KERNEL_TEST_EXIT_ENABLED
@@ -80,6 +81,7 @@ void run_main_stage_tests()
 	run_test_suite(register_slab_tests);
 	run_test_suite(register_alloc_macro_tests);
 	run_test_suite(register_paging_tests);
+	run_test_suite(register_user_copy_tests);
 
 	snapshot_task_slots();
 	run_test_suite(register_task_tests);

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -11,6 +11,7 @@
 #include "tests/test_cases/fd_test.hpp"
 #include "tests/test_cases/fs_test.hpp"
 #include "tests/test_cases/memory_test.hpp"
+#include "tests/test_cases/paging_test.hpp"
 #include "tests/test_cases/stdio_test.hpp"
 #include "tests/test_cases/task_test.hpp"
 #include "tests/test_cases/timer_test.hpp"
@@ -78,6 +79,7 @@ void run_main_stage_tests()
 	run_test_suite(register_buddy_system_tests);
 	run_test_suite(register_slab_tests);
 	run_test_suite(register_alloc_macro_tests);
+	run_test_suite(register_paging_tests);
 
 	snapshot_task_slots();
 	run_test_suite(register_task_tests);

--- a/kernel/tests/runner.hpp
+++ b/kernel/tests/runner.hpp
@@ -18,8 +18,8 @@ namespace kernel::tests
  * @brief Run suites that need the bootstrap allocator to be alive
  *
  * Must be called after kernel::memory::initialize() and before
- * kernel::memory::disable(), because the bootstrap allocator suite
- * exercises the global boot_allocator directly.
+ * kernel::memory::release_bootstrap(), because the bootstrap allocator
+ * suite exercises the global boot_allocator directly.
  */
 void run_bootstrap_stage_tests();
 

--- a/kernel/tests/test_cases/CMakeLists.txt
+++ b/kernel/tests/test_cases/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TESTCASES_SOURCE_FILES
         bit_utils_test.cpp
         memory_test.cpp
+        paging_test.cpp
         task_test.cpp
         timer_test.cpp
         virtio_blk_test.cpp

--- a/kernel/tests/test_cases/CMakeLists.txt
+++ b/kernel/tests/test_cases/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TESTCASES_SOURCE_FILES
+        bit_utils_test.cpp
         memory_test.cpp
         task_test.cpp
         timer_test.cpp

--- a/kernel/tests/test_cases/CMakeLists.txt
+++ b/kernel/tests/test_cases/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TESTCASES_SOURCE_FILES
         bit_utils_test.cpp
         memory_test.cpp
         paging_test.cpp
+        user_test.cpp
         task_test.cpp
         timer_test.cpp
         virtio_blk_test.cpp

--- a/kernel/tests/test_cases/bit_utils_test.cpp
+++ b/kernel/tests/test_cases/bit_utils_test.cpp
@@ -1,0 +1,30 @@
+#include "tests/test_cases/bit_utils_test.hpp"
+#include "bit_utils.hpp"
+#include "tests/framework.hpp"
+#include "tests/macros.hpp"
+
+void test_bit_width()
+{
+	ASSERT_EQ(bit_width(0), 0U);
+	ASSERT_EQ(bit_width(1), 1U);
+	ASSERT_EQ(bit_width(4), 3U);
+	ASSERT_EQ(bit_width(5), 3U);
+	ASSERT_EQ(bit_width(8), 4U);
+}
+
+void test_bit_width_ceil()
+{
+	// bit_width_ceil(0) used to underflow and return a huge value (issue #313)
+	ASSERT_EQ(bit_width_ceil(0), 0U);
+	ASSERT_EQ(bit_width_ceil(1), 0U);
+	ASSERT_EQ(bit_width_ceil(2), 1U);
+	ASSERT_EQ(bit_width_ceil(5), 3U);
+	ASSERT_EQ(bit_width_ceil(8), 3U);
+	ASSERT_EQ(bit_width_ceil(9), 4U);
+}
+
+void register_bit_utils_tests()
+{
+	test_register("bit_width", test_bit_width);
+	test_register("bit_width_ceil", test_bit_width_ceil);
+}

--- a/kernel/tests/test_cases/bit_utils_test.hpp
+++ b/kernel/tests/test_cases/bit_utils_test.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void register_bit_utils_tests();

--- a/kernel/tests/test_cases/memory_test.cpp
+++ b/kernel/tests/test_cases/memory_test.cpp
@@ -1,6 +1,7 @@
 #include "tests/test_cases/memory_test.hpp"
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include "memory/bootstrap_allocator.hpp"
 #include "memory/buddy_system.hpp"
 #include "memory/page.hpp"
@@ -138,12 +139,46 @@ void test_buddy_system_error_handling()
 	ASSERT_NULL(too_large);
 }
 
+void test_get_page_bounds()
+{
+	// nullptr is rejected
+	ASSERT_NULL(kernel::memory::get_page(nullptr));
+
+	// the last valid page resolves
+	const size_t num_pages = kernel::memory::pages.size();
+	void* last_page_addr = reinterpret_cast<void*>((num_pages - 1) *
+												   kernel::memory::PAGE_SIZE);
+	ASSERT_NOT_NULL(kernel::memory::get_page(last_page_addr));
+
+	// one page past the end must not resolve (used to be an off-by-one)
+	void* out_of_range =
+			reinterpret_cast<void*>(num_pages * kernel::memory::PAGE_SIZE);
+	ASSERT_NULL(kernel::memory::get_page(out_of_range));
+}
+
+void test_bootstrap_buffer_stays_reserved()
+{
+	// The bootstrap allocator's static BSS buffer must stay marked used
+	// after release_bootstrap(); handing it to the buddy system would let
+	// kernel BSS pages be reallocated (issue #313)
+	char* buffer = kernel::memory::bootstrap_allocator_buffer;
+	for (size_t offset = 0; offset < sizeof(kernel::memory::BootstrapAllocator);
+		 offset += kernel::memory::PAGE_SIZE) {
+		kernel::memory::Page* page = kernel::memory::get_page(buffer + offset);
+		ASSERT_NOT_NULL(page);
+		ASSERT_TRUE(page->is_used());
+	}
+}
+
 void register_buddy_system_tests()
 {
 	test_register("buddy_system_basic", test_buddy_system_basic);
 	test_register("buddy_system_multi_page", test_buddy_system_multi_page);
 	test_register("buddy_system_split_and_merge", test_buddy_system_split_and_merge);
 	test_register("buddy_system_error_handling", test_buddy_system_error_handling);
+	test_register("get_page_bounds", test_get_page_bounds);
+	test_register("bootstrap_buffer_stays_reserved",
+				  test_bootstrap_buffer_stays_reserved);
 }
 
 void test_slab_basic()
@@ -165,8 +200,7 @@ void test_slab_cache_creation()
 	ASSERT_NOT_NULL(obj);
 
 	// Get the cache by name and verify it exists
-	auto* found_cache =
-			kernel::memory::get_cache_in_chain(const_cast<char*>("test-cache"));
+	auto* found_cache = kernel::memory::get_cache_in_chain("test-cache");
 	ASSERT_NOT_NULL(found_cache);
 	ASSERT_EQ(found_cache->object_size(), obj_size);
 }
@@ -209,6 +243,60 @@ void test_slab_error_handling()
 	ASSERT_NULL(ptr);
 }
 
+void test_slab_double_free_detected()
+{
+	// Use a size class of its own so the slab holds exactly one object
+	constexpr size_t size = 100000; // rounds up to a 128 KiB cache
+	void* ptr = kernel::memory::alloc(size, kernel::memory::ALLOC_UNINITIALIZED);
+	ASSERT_NOT_NULL(ptr);
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(ptr));
+
+	kernel::memory::free(ptr);
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(ptr));
+
+	// A second free must be detected and ignored (issue #313)
+	kernel::memory::free(ptr);
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(ptr));
+
+	// The object is handed out exactly once afterwards
+	void* again = kernel::memory::alloc(size, kernel::memory::ALLOC_UNINITIALIZED);
+	ASSERT_EQ(again, ptr);
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(again));
+	kernel::memory::free(again);
+}
+
+void test_slab_free_rejects_foreign_pointer()
+{
+	// A page owned by the buddy system was never a slab object; freeing it
+	// through the slab allocator must be rejected, not dereference garbage
+	void* raw = kernel::memory::memory_manager->allocate(kernel::memory::PAGE_SIZE);
+	ASSERT_NOT_NULL(raw);
+
+	kernel::memory::free(raw);
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(raw));
+
+	// The page still belongs to the buddy system
+	kernel::memory::Page* page = kernel::memory::get_page(raw);
+	ASSERT_NOT_NULL(page);
+	ASSERT_TRUE(page->is_used());
+
+	kernel::memory::memory_manager->free(raw, kernel::memory::PAGE_SIZE);
+}
+
+void test_slab_cache_name_truncation()
+{
+	// A name longer than the cache's 20-byte buffer must be truncated inside
+	// the cache and must not write a terminator into the caller's buffer
+	char long_name[32] = "0123456789012345678901234567890";
+	kernel::memory::m_cache_create(long_name, 512);
+
+	ASSERT_EQ(long_name[19], '9');
+
+	auto* cache = kernel::memory::get_cache_in_chain("0123456789012345678");
+	ASSERT_NOT_NULL(cache);
+	ASSERT_EQ(strlen(cache->name()), 19UL);
+}
+
 void register_slab_tests()
 {
 	test_register("slab_basic", test_slab_basic);
@@ -216,6 +304,10 @@ void register_slab_tests()
 	test_register("slab_aligned_allocation", test_slab_aligned_allocation);
 	test_register("slab_zeroed_allocation", test_slab_zeroed_allocation);
 	test_register("slab_error_handling", test_slab_error_handling);
+	test_register("slab_double_free_detected", test_slab_double_free_detected);
+	test_register("slab_free_rejects_foreign_pointer",
+				  test_slab_free_rejects_foreign_pointer);
+	test_register("slab_cache_name_truncation", test_slab_cache_name_truncation);
 }
 
 static void helper_alloc_or_return_void()

--- a/kernel/tests/test_cases/paging_test.cpp
+++ b/kernel/tests/test_cases/paging_test.cpp
@@ -1,0 +1,114 @@
+#include "tests/test_cases/paging_test.hpp"
+#include <cstdint>
+#include "memory/buddy_system.hpp"
+#include "memory/page.hpp"
+#include "memory/paging.hpp"
+#include "memory/slab.hpp"
+#include "tests/framework.hpp"
+#include "tests/macros.hpp"
+
+namespace
+{
+// PML4 index 256 = start of the user half of the address space
+constexpr uint64_t TEST_USER_VADDR = 0xffff'8000'1234'5000;
+} // namespace
+
+void test_clean_page_tables_frees_user_pages()
+{
+	using namespace kernel::memory;
+
+	page_table_entry* table = new_page_table();
+	ASSERT_NOT_NULL(table);
+
+	const vaddr_t addr{ TEST_USER_VADDR };
+	ASSERT_EQ(setup_page_table(table, 4, addr, 2, true), 0);
+
+	auto* pte = get_pte(table, addr, 1);
+	ASSERT_NOT_NULL(pte);
+	ASSERT_EQ(pte->bits.owned, 1UL);
+	void* data_page = pte->get_next_level_table();
+	ASSERT_TRUE(is_slab_object_in_use(data_page));
+
+	clean_page_tables(table);
+
+	// Owned data pages and the table pages themselves are released
+	ASSERT_FALSE(is_slab_object_in_use(data_page));
+	ASSERT_FALSE(is_slab_object_in_use(table));
+}
+
+void test_cow_pages_freed_with_last_reference()
+{
+	using namespace kernel::memory;
+
+	page_table_entry* origin = new_page_table();
+	ASSERT_NOT_NULL(origin);
+
+	const vaddr_t addr{ TEST_USER_VADDR };
+	ASSERT_EQ(setup_page_table(origin, 4, addr, 1, true), 0);
+	void* data_page = get_pte(origin, addr, 1)->get_next_level_table();
+
+	// Fork-style CoW: two clones sharing the same data page read-only
+	page_table_entry* clone_a = clone_page_table(origin, false);
+	page_table_entry* clone_b = clone_page_table(origin, false);
+	ASSERT_NOT_NULL(clone_a);
+	ASSERT_NOT_NULL(clone_b);
+
+	auto* pte_a = get_pte(clone_a, addr, 1);
+	ASSERT_NOT_NULL(pte_a);
+	ASSERT_EQ(pte_a->get_next_level_table(), data_page);
+	ASSERT_EQ(pte_a->bits.writable, 0UL);
+	ASSERT_EQ(pte_a->bits.owned, 1UL);
+
+	// Releasing the pre-fork snapshot keeps the shared page alive
+	clean_page_tables(origin);
+	ASSERT_TRUE(is_slab_object_in_use(data_page));
+
+	clean_page_tables(clone_a);
+	ASSERT_TRUE(is_slab_object_in_use(data_page));
+
+	// The last reference frees it (issue #313 CoW page leak)
+	clean_page_tables(clone_b);
+	ASSERT_FALSE(is_slab_object_in_use(data_page));
+}
+
+void test_clean_page_tables_skips_foreign_frames()
+{
+	using namespace kernel::memory;
+
+	page_table_entry* table = new_page_table();
+	ASSERT_NOT_NULL(table);
+
+	const vaddr_t addr{ TEST_USER_VADDR };
+	ASSERT_EQ(setup_page_table(table, 4, addr, 1, true), 0);
+
+	// Map a buddy-owned frame the way IPC shared memory does
+	void* frame = memory_manager->allocate(PAGE_SIZE);
+	ASSERT_NOT_NULL(frame);
+	vaddr_t mapped{ 0 };
+	ASSERT_EQ(map_frame_to_vaddr(table, reinterpret_cast<uint64_t>(frame), 1,
+								 &mapped),
+			  OK);
+
+	auto* pte = get_pte(table, mapped, 1);
+	ASSERT_NOT_NULL(pte);
+	ASSERT_EQ(pte->bits.owned, 0UL);
+
+	clean_page_tables(table);
+
+	// The foreign frame is only unmapped, never freed
+	Page* page = get_page(frame);
+	ASSERT_NOT_NULL(page);
+	ASSERT_TRUE(page->is_used());
+
+	memory_manager->free(frame, PAGE_SIZE);
+}
+
+void register_paging_tests()
+{
+	test_register("clean_page_tables_frees_user_pages",
+				  test_clean_page_tables_frees_user_pages);
+	test_register("cow_pages_freed_with_last_reference",
+				  test_cow_pages_freed_with_last_reference);
+	test_register("clean_page_tables_skips_foreign_frames",
+				  test_clean_page_tables_skips_foreign_frames);
+}

--- a/kernel/tests/test_cases/paging_test.hpp
+++ b/kernel/tests/test_cases/paging_test.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void register_paging_tests();

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -8,6 +8,7 @@
 #include "task/task.hpp"
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
+#include "tests/test_utils.hpp"
 
 using kernel::task::create_task;
 using kernel::task::CURRENT_TASK;
@@ -21,32 +22,7 @@ extern ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 extern ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 } // namespace kernel::syscall
 
-namespace
-{
-// Impersonate `t` as CURRENT_TASK for a scope. The impersonated task must
-// be RUNNING while it is current: if a timer preemption hits while
-// CURRENT_TASK is WAITING, switch_task() does not requeue it and the test
-// runner's execution context is lost for good — the boot hangs with no
-// output (issue #313). RAII also restores CURRENT_TASK when an ASSERT
-// macro returns early.
-class ScopedCurrentTask
-{
-public:
-	explicit ScopedCurrentTask(Task* t) : prev_(CURRENT_TASK)
-	{
-		t->state = kernel::task::TASK_RUNNING;
-		CURRENT_TASK = t;
-	}
-
-	~ScopedCurrentTask() { CURRENT_TASK = prev_; }
-
-	ScopedCurrentTask(const ScopedCurrentTask&) = delete;
-	ScopedCurrentTask& operator=(const ScopedCurrentTask&) = delete;
-
-private:
-	Task* prev_;
-};
-} // namespace
+using kernel::tests::ScopedCurrentTask;
 
 void test_fd_table_init()
 {
@@ -203,7 +179,7 @@ void test_stdout_redirection()
 
 	// Clear any existing messages
 	while (!t->messages.empty()) {
-		t->messages.pop();
+		t->messages.pop_front();
 	}
 
 	// Test writing to redirected stdout

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -21,6 +21,33 @@ extern ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 extern ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 } // namespace kernel::syscall
 
+namespace
+{
+// Impersonate `t` as CURRENT_TASK for a scope. The impersonated task must
+// be RUNNING while it is current: if a timer preemption hits while
+// CURRENT_TASK is WAITING, switch_task() does not requeue it and the test
+// runner's execution context is lost for good — the boot hangs with no
+// output (issue #313). RAII also restores CURRENT_TASK when an ASSERT
+// macro returns early.
+class ScopedCurrentTask
+{
+public:
+	explicit ScopedCurrentTask(Task* t) : prev_(CURRENT_TASK)
+	{
+		t->state = kernel::task::TASK_RUNNING;
+		CURRENT_TASK = t;
+	}
+
+	~ScopedCurrentTask() { CURRENT_TASK = prev_; }
+
+	ScopedCurrentTask(const ScopedCurrentTask&) = delete;
+	ScopedCurrentTask& operator=(const ScopedCurrentTask&) = delete;
+
+private:
+	Task* prev_;
+};
+} // namespace
+
 void test_fd_table_init()
 {
 	// Create a test task
@@ -49,8 +76,7 @@ void test_write_to_stdout()
 	Task* t = create_task("write_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test writing to stdout
 	const char* test_msg = "Hello, stdout!";
@@ -61,8 +87,6 @@ void test_write_to_stdout()
 	ASSERT_GT(result, 0);
 	ASSERT_EQ(result, strlen(test_msg));
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_write_to_stderr()
@@ -71,8 +95,7 @@ void test_write_to_stderr()
 	Task* t = create_task("stderr_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test writing to stderr
 	const char* test_msg = "Error message";
@@ -83,8 +106,6 @@ void test_write_to_stderr()
 	ASSERT_GT(result, 0);
 	ASSERT_EQ(result, strlen(test_msg));
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_read_from_stdin()
@@ -93,8 +114,7 @@ void test_read_from_stdin()
 	Task* t = create_task("read_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test reading from stdin (currently returns 0)
 	char buffer[128];
@@ -104,8 +124,6 @@ void test_read_from_stdin()
 	// Currently stdin returns 0 (no data available)
 	ASSERT_EQ(result, 0);
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_invalid_fd()
@@ -114,8 +132,7 @@ void test_invalid_fd()
 	Task* t = create_task("invalid_fd_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Test invalid file descriptor (negative)
 	char buffer[128];
@@ -134,8 +151,6 @@ void test_invalid_fd()
 			10, reinterpret_cast<uint64_t>(buffer), sizeof(buffer));
 	ASSERT_EQ(result3, ERR_INVALID_FD);
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_fd_inheritance()
@@ -151,8 +166,7 @@ void test_fd_inheritance()
 	ASSERT_GT(fd, -1);
 
 	// Set parent as current task for copy_task
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = parent;
+	const ScopedCurrentTask scoped_task(parent);
 
 	// Create child task (this would normally be done by fork)
 	kernel::task::Context dummy_ctx = {};
@@ -169,8 +183,6 @@ void test_fd_inheritance()
 	ASSERT_EQ(strcmp(child->fd_table[fd].name, "test.txt"), 0);
 	ASSERT_EQ(child->fd_table[fd].size, 100);
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_stdout_redirection()
@@ -179,8 +191,7 @@ void test_stdout_redirection()
 	Task* t = create_task("redirect_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Allocate a file descriptor to redirect to
 	fd_t file_fd = kernel::fs::allocate_process_fd(
@@ -210,8 +221,6 @@ void test_stdout_redirection()
 	// Restore stdout
 	// t->fd_table[STDOUT_FILENO].redirect_to = NO_FD;
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_stderr_redirection()
@@ -220,8 +229,7 @@ void test_stderr_redirection()
 	Task* t = create_task("stderr_redirect_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Allocate a file descriptor to redirect to
 	fd_t file_fd = kernel::fs::allocate_process_fd(
@@ -242,8 +250,6 @@ void test_stderr_redirection()
 	// Restore stderr
 	// t->fd_table[STDERR_FILENO].redirect_to = NO_FD;
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void test_large_write_redirection()
@@ -252,8 +258,7 @@ void test_large_write_redirection()
 	Task* t = create_task("large_redirect_test", 0, true, true);
 	ASSERT_NOT_NULL(t);
 
-	Task* prev_task = CURRENT_TASK;
-	CURRENT_TASK = t;
+	const ScopedCurrentTask scoped_task(t);
 
 	// Allocate a file descriptor to redirect to
 	fd_t file_fd = kernel::fs::allocate_process_fd(
@@ -276,8 +281,6 @@ void test_large_write_redirection()
 	// Restore stdout
 	// t->fd_table[STDOUT_FILENO].redirect_to = NO_FD;
 
-	// Restore previous task
-	CURRENT_TASK = prev_task;
 }
 
 void register_stdio_tests()

--- a/kernel/tests/test_cases/task_test.cpp
+++ b/kernel/tests/test_cases/task_test.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
+#include "memory/slab.hpp"
 #include "task/context.hpp"
 #include "task/task.hpp"
 #include "tests/framework.hpp"
@@ -133,10 +134,15 @@ void test_task_memory_management()
 	ASSERT_EQ(t->state, TASK_WAITING);
 	ASSERT_TRUE(t->is_initilized);
 
+	void* stack = t->stack;
+	ASSERT_NOT_NULL(stack);
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(stack));
+
 	// Test task deallocation with operator delete
 	delete t;
-	// Note: We can't verify the deletion directly, but the destructor should have
-	// cleaned up the page tables
+
+	// ~Task must free the kernel stack along with the page tables (issue #313)
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(stack));
 }
 
 void register_task_tests()

--- a/kernel/tests/test_cases/task_test.cpp
+++ b/kernel/tests/test_cases/task_test.cpp
@@ -5,9 +5,17 @@
 #include <libs/common/process_id.hpp>
 #include "memory/slab.hpp"
 #include "task/context.hpp"
+#include "task/ipc.hpp"
 #include "task/task.hpp"
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
+#include "tests/test_utils.hpp"
+
+// Forward declaration for the syscall under test
+namespace kernel::syscall
+{
+extern error_t sys_ipc(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);
+} // namespace kernel::syscall
 
 using kernel::task::create_task;
 using kernel::task::get_available_task_id;
@@ -88,7 +96,7 @@ void test_task_message_handling()
 	ASSERT_TRUE(t->messages.empty());
 	const Message test_msg = { .type = MsgType::IPC_EXIT_TASK,
 							   .sender = ProcessId::from_raw(0) };
-	t->messages.push(test_msg);
+	t->messages.push_back(test_msg);
 	ASSERT_FALSE(t->messages.empty());
 
 	// Test message handling
@@ -145,6 +153,72 @@ void test_task_memory_management()
 	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(stack));
 }
 
+void test_wait_for_message_preserves_other_messages()
+{
+	Task* t = create_task("wait_msg_test", 0, true, true);
+	ASSERT_NOT_NULL(t);
+
+	Message other = { .type = MsgType::NOTIFY_WRITE,
+					  .sender = ProcessId::from_raw(1) };
+	Message target = { .type = MsgType::IPC_EXIT_TASK,
+					   .sender = ProcessId::from_raw(2) };
+	t->messages.push_back(other);
+	t->messages.push_back(target);
+
+	const kernel::tests::ScopedCurrentTask scoped_task(t);
+
+	// The matching message is extracted even when it is not at the front
+	const Message m = kernel::task::wait_for_message(MsgType::IPC_EXIT_TASK);
+	ASSERT_TRUE(m.type == MsgType::IPC_EXIT_TASK);
+	ASSERT_EQ(m.sender.raw(), 2);
+
+	// The unrelated message is still queued (issue #313: the old
+	// implementation spun on and reordered non-matching messages)
+	ASSERT_EQ(t->messages.size(), 1UL);
+	ASSERT_TRUE(t->messages.front().type == MsgType::NOTIFY_WRITE);
+	t->messages.clear();
+}
+
+void test_send_message_queue_cap()
+{
+	Task* t = create_task("queue_cap_test", 0, true, true);
+	ASSERT_NOT_NULL(t);
+
+	// Keep the receiver off the run queue while flooding it
+	t->state = kernel::task::TASK_RUNNING;
+
+	Message m = { .type = MsgType::NOTIFY_WRITE,
+				  .sender = kernel::task::CURRENT_TASK->id };
+
+	// NOTE: send_message is [[gnu::no_caller_saved_registers]], so its
+	// return value is not reliable at the call site; assert on the queue
+	// size instead.
+	for (size_t i = 0; i < kernel::task::MAX_QUEUED_MESSAGES + 8; ++i) {
+		kernel::task::send_message(t->id, m);
+	}
+
+	// The queue is capped instead of growing without bound (issue #313)
+	ASSERT_EQ(t->messages.size(), kernel::task::MAX_QUEUED_MESSAGES);
+	t->messages.clear();
+}
+
+void test_ipc_recv_empty_keeps_task_runnable()
+{
+	Task* t = create_task("ipc_recv_test", 0, true, true);
+	ASSERT_NOT_NULL(t);
+	ASSERT_TRUE(t->messages.empty());
+
+	const kernel::tests::ScopedCurrentTask scoped_task(t);
+
+	Message m;
+	kernel::syscall::sys_ipc(0, 0, reinterpret_cast<uint64_t>(&m), IPC_RECV);
+
+	// An empty queue must not leave the task WAITING while it returns to
+	// the caller; it would be dropped from the run queue on the next
+	// preemption (issue #313)
+	ASSERT_EQ(t->state, kernel::task::TASK_RUNNING);
+}
+
 void register_task_tests()
 {
 	test_register("task_creation_basic", test_task_creation_basic);
@@ -152,4 +226,9 @@ void register_task_tests()
 	test_register("task_message_handling", test_task_message_handling);
 	test_register("task_copy", test_task_copy);
 	test_register("task_memory_management", test_task_memory_management);
+	test_register("wait_for_message_preserves_other_messages",
+				  test_wait_for_message_preserves_other_messages);
+	test_register("send_message_queue_cap", test_send_message_queue_cap);
+	test_register("ipc_recv_empty_keeps_task_runnable",
+				  test_ipc_recv_empty_keeps_task_runnable);
 }

--- a/kernel/tests/test_cases/user_test.cpp
+++ b/kernel/tests/test_cases/user_test.cpp
@@ -1,0 +1,51 @@
+#include "tests/test_cases/user_test.hpp"
+#include <string.h> // NOLINT(misc-include-cleaner) - for strlcpy
+#include <cstdint>
+#include <cstring>
+#include "memory/paging.hpp"
+#include "memory/user.hpp"
+#include "tests/framework.hpp"
+#include "tests/macros.hpp"
+
+namespace
+{
+// A user-half address (PML4 index >= 256) reserved for these tests
+constexpr uint64_t TEST_USER_STR_VADDR = 0xffff'8000'2000'0000;
+} // namespace
+
+void test_copy_string_from_user_rejects_invalid_pointers()
+{
+	char buf[16];
+
+	// Kernel addresses and null pointers are rejected
+	const char* kernel_str = "kernel";
+	ASSERT_EQ(copy_string_from_user(buf, kernel_str, sizeof(buf)), -1);
+	ASSERT_EQ(copy_string_from_user(buf, nullptr, sizeof(buf)), -1);
+}
+
+void test_copy_string_from_user_roundtrip()
+{
+	// Map one user page in the active address space and place a string
+	const kernel::memory::vaddr_t addr{ TEST_USER_STR_VADDR };
+	kernel::memory::setup_page_tables(addr, 1, true);
+
+	char* user_buf = reinterpret_cast<char*>(addr.data);
+	strlcpy(user_buf, "hello", 6); // NOLINT(misc-include-cleaner)
+
+	char buf[16];
+	ASSERT_EQ(copy_string_from_user(buf, user_buf, sizeof(buf)), 5);
+	ASSERT_EQ(strcmp(buf, "hello"), 0);
+
+	// A string that does not fit the destination is rejected but the
+	// buffer is still NUL-terminated
+	ASSERT_EQ(copy_string_from_user(buf, user_buf, 3), -1);
+	ASSERT_EQ(buf[2], '\0');
+}
+
+void register_user_copy_tests()
+{
+	test_register("copy_string_from_user_rejects_invalid_pointers",
+				  test_copy_string_from_user_rejects_invalid_pointers);
+	test_register("copy_string_from_user_roundtrip",
+				  test_copy_string_from_user_roundtrip);
+}

--- a/kernel/tests/test_cases/user_test.hpp
+++ b/kernel/tests/test_cases/user_test.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void register_user_copy_tests();

--- a/kernel/tests/test_utils.hpp
+++ b/kernel/tests/test_utils.hpp
@@ -1,0 +1,40 @@
+/**
+ * @file tests/test_utils.hpp
+ * @brief Shared helpers for kernel test cases
+ */
+
+#pragma once
+
+#include "task/task.hpp"
+
+namespace kernel::tests
+{
+
+/**
+ * @brief Impersonate a task as CURRENT_TASK for a scope
+ *
+ * The impersonated task must be RUNNING while it is current: if a timer
+ * preemption hits while CURRENT_TASK is WAITING, switch_task() does not
+ * requeue it and the test runner's execution context is lost for good —
+ * the boot hangs with no output (issue #313). RAII also restores
+ * CURRENT_TASK when an ASSERT macro returns early.
+ */
+class ScopedCurrentTask
+{
+public:
+	explicit ScopedCurrentTask(kernel::task::Task* t) : prev_(CURRENT_TASK)
+	{
+		t->state = kernel::task::TASK_RUNNING;
+		CURRENT_TASK = t;
+	}
+
+	~ScopedCurrentTask() { CURRENT_TASK = prev_; }
+
+	ScopedCurrentTask(const ScopedCurrentTask&) = delete;
+	ScopedCurrentTask& operator=(const ScopedCurrentTask&) = delete;
+
+private:
+	kernel::task::Task* prev_; ///< CURRENT_TASK on entry
+};
+
+} // namespace kernel::tests

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -29,6 +29,7 @@ constexpr int ERR_NO_FILE = -8;
 constexpr int ERR_NO_DEVICE = -9;
 constexpr int ERR_FAILED_INIT_DEVICE = -10;
 constexpr int ERR_FAILED_WRITE_TO_DEVICE = -11;
+constexpr int ERR_QUEUE_FULL = -12;
 
 // file descriptor
 constexpr int NO_FD = -1;


### PR DESCRIPTION
> [!IMPORTANT]
> #323 → #325 → #326 の上に積んだスタック PR。先にそれらをマージすること。

## 概要

#313 のドライバ項目(PCI 列挙の上書きバグ、xHCI のコマンド完了コード未検査・初期化ループの永久ハング・TRB リング満杯チェックなし)を修正する。

## 修正内容

### PCI(`kernel/hardware/pci.cpp`)
- `read_function` が `devices[dev] = d`(デバイス番号を添字に使用)で格納していたため、多機能デバイスで function 同士が上書きされ、非連続なデバイス番号では連番走査する全消費側(xhci / virtio / builtin)から検出できなかった → `devices[num_devices++] = d` の連番格納に修正
- `devices` 配列(32 要素)の容量超過時は `LOG_ERROR` を出して当該デバイスを無視するチェックを追加

### xHCI: コマンド完了コードの検査(`xhci.cpp`)
- `command_completion_event_trb` の completion code を検査せず enable_slot / address_device / configure_endpoint の失敗を成功扱いしていた → 失敗時は `LOG_ERROR` を出し、当該ポートの初期化のみ中止(`abort_port_initialization`)。コントローラと他ポートの処理は継続し、`WAITING_ADDRESSED` の次ポートへ進む

### xHCI: 初期化ループのタイムアウト(`xhci.cpp` / `port.cpp`)
- halt 待ち・リセット完了待ち・ready 待ち・run 開始待ち・BIOS ownership 引き渡し待ち・ポートリセット待ちの無限ループを、有界スピン(`pause` 付き)+タイムアウトに変更
- タイムアウト時は `LOG_ERROR` を出して xHCI 無効のまま起動継続(`Controller::initialize()` / `run()` は `bool` を返し、失敗時は `host_controller = nullptr`。`process_events()` に null ガードを追加)
- `Controller::initialize()` の bool 化に伴い、`void` 前提だった `ALLOC_OR_RETURN` を明示的な alloc + null チェックに置き換え

### xHCI: `Ring::push` の満杯チェック(`ring.cpp` / `ring.hpp`)
- 満杯検出なしで未消費 TRB を上書きし得た → 完了イベントが報告する消費済み TRB ポインタから consumer index を進める `Ring::on_consumed` を追加し、push 時に満杯なら `LOG_ERROR` して `nullptr` を返すように変更
  - コマンドリング: コマンド完了イベント受信時に `on_consumed` を呼ぶ
  - 転送リング: `Device::on_transfer_event_received` の先頭で `on_consumed` を呼ぶ(IOC が TD 途中の TRB に付く場合は 1 スロット分保守的に遅れるだけで安全側)
- 全呼び出し元(コマンド発行 3 箇所、`device.cpp` の control_in / control_out / interrupt_in)で `nullptr` を処理し、失敗時はドアベルを鳴らさず中断。従来 `nullptr` を `trb_dynamic_cast` に渡すと null deref になる箇所もガード

## テストについて

xHCI は HW 依存でカーネル内テストが困難なため、issue の完了条件どおり「タイムアウト+エラーログでの縮退動作」の実装で対応した(`kernel/tests/` は変更していない)。ビルド検証は CI に委ねる。

Closes 対象: #313 のドライバ項目

🤖 Generated with [Claude Code](https://claude.com/claude-code)