### PR TITLE
fix: put_pixel の境界クリップと画面ログの折り返し (issue #313)

### DIFF
--- a/kernel/fs/fat/directory.cpp
+++ b/kernel/fs/fat/directory.cpp
@@ -136,6 +136,17 @@ void handle_virtio_response(const Message& m)
 		return;
 	}
 
+	if (IS_ERR(m.data.blk_io.result) || m.data.blk_io.buf == nullptr) {
+		// Device read failed: keep the current directory instead of
+		// pointing it at a null buffer.
+		LOG_ERROR("failed to read directory cluster: result=%d",
+				  m.data.blk_io.result);
+		change_dir_names.erase(m.data.blk_io.request_id);
+		parent_dir_names.erase(m.data.blk_io.request_id);
+		change_dir_requests.erase(m.data.blk_io.request_id);
+		return;
+	}
+
 	update_directory_entry(task,
 						   reinterpret_cast<DirectoryEntry*>(m.data.blk_io.buf));
 	finalize_directory_change(m, task);
@@ -184,12 +195,11 @@ void request_parent_directory_load(const Message& m,
 
 	Message reply = { .type = MsgType::FS_CHANGE_DIR,
 					  .sender = process_ids::FS_FAT32 };
-	if (parent_dir_names[request_id] == "/") {
-		memcpy(reply.data.fs.name, "/", 2);
-	} else {
-		memcpy(reply.data.fs.name, parent_dir_names[request_id].c_str(),
-			   parent_dir_names[request_id].length() + 1);
-	}
+	// Truncate to the reply buffer: full_path can be far longer than
+	// data.fs.name and an unchecked memcpy corrupts the Message (issue #313).
+	strncpy(reply.data.fs.name, parent_dir_names[request_id].c_str(),
+			sizeof(reply.data.fs.name) - 1);
+	reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
 	reply.data.fs.result = 0;
 	kernel::task::send_message(m.sender, reply);
 }
@@ -240,7 +250,8 @@ void handle_normal_directory_change(const Message& m,
 
 	Message reply = { .type = MsgType::FS_CHANGE_DIR,
 					  .sender = process_ids::FS_FAT32 };
-	memcpy(reply.data.fs.name, upper_name, strlen(upper_name) + 1);
+	strncpy(reply.data.fs.name, upper_name, sizeof(reply.data.fs.name) - 1);
+	reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
 	reply.data.fs.result = 0;
 	kernel::task::send_message(m.sender, reply);
 }
@@ -291,11 +302,27 @@ void handle_get_directory_contents(const Message& m)
 	}
 
 	auto* t = kernel::task::get_task(m.sender);
+	if (t == nullptr) {
+		// Requester is gone; there is no one to reply to.
+		LOG_ERROR("Task %d not found", m.sender.raw());
+		return;
+	}
+
 	if (t->parent_id != process_ids::INVALID) {
-		t = kernel::task::get_task(t->parent_id);
+		kernel::task::Task* parent = kernel::task::get_task(t->parent_id);
+		if (parent != nullptr) {
+			t = parent;
+		}
 	}
 
 	DirectoryEntry* current_dir = t->fs_path.current_dir;
+	if (current_dir == nullptr) {
+		LOG_ERROR("current directory not set");
+		Message sm = { .type = MsgType::GET_DIRECTORY_CONTENTS,
+					   .sender = process_ids::FS_FAT32 };
+		kernel::task::send_message(m.sender, sm);
+		return;
+	}
 	std::vector<char> entries(ENTRIES_PER_CLUSTER * sizeof(DirectoryEntry));
 	int entries_count = 0;
 	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
@@ -316,16 +343,25 @@ void handle_get_directory_contents(const Message& m)
 		++entries_count;
 	}
 
-	void* buf;
-	ALLOC_OR_RETURN(buf, entries_count * sizeof(Stat), kernel::memory::ALLOC_ZEROED);
+	void* buf = nullptr;
+	if (entries_count > 0) {
+		buf = kernel::memory::alloc(entries_count * sizeof(Stat),
+									kernel::memory::ALLOC_ZEROED);
+		if (buf == nullptr) {
+			// Reply with an empty listing so the requester is not left
+			// blocking forever.
+			LOG_ERROR("failed to allocate stat buffer");
+			entries_count = 0;
+		}
+	}
 
 	for (int i = 0; i < entries_count; ++i) {
 		Stat* s = reinterpret_cast<Stat*>(buf) + i;
-		read_dir_entry_name(*reinterpret_cast<DirectoryEntry*>(
-									&entries[i * sizeof(DirectoryEntry)]),
-							s->name);
-		s->size = current_dir[i].file_size;
-		s->type = current_dir[i].attribute == entry_attribute::DIRECTORY
+		const DirectoryEntry* e = reinterpret_cast<const DirectoryEntry*>(
+				&entries[i * sizeof(DirectoryEntry)]);
+		read_dir_entry_name(*e, s->name);
+		s->size = e->file_size;
+		s->type = e->attribute == entry_attribute::DIRECTORY
 						  ? StatType::DIRECTORY
 						  : StatType::REGULAR_FILE;
 	}
@@ -334,7 +370,7 @@ void handle_get_directory_contents(const Message& m)
 				   .sender = process_ids::FS_FAT32 };
 	sm.tool_desc.addr = buf;
 	sm.tool_desc.size = entries_count * sizeof(Stat);
-	sm.tool_desc.present = true;
+	sm.tool_desc.present = buf != nullptr;
 
 	kernel::task::send_message(m.sender, sm);
 }
@@ -344,8 +380,17 @@ void handle_fs_pwd(const Message& m)
 	Message reply = { .type = MsgType::FS_PWD, .sender = process_ids::FS_FAT32 };
 
 	kernel::task::Task* t = kernel::task::get_task(m.sender);
+	if (t == nullptr) {
+		// Requester is gone; there is no one to reply to.
+		LOG_ERROR("Task %d not found", m.sender.raw());
+		return;
+	}
+
 	if (t->parent_id != process_ids::INVALID) {
-		t = kernel::task::get_task(t->parent_id);
+		kernel::task::Task* parent = kernel::task::get_task(t->parent_id);
+		if (parent != nullptr) {
+			t = parent;
+		}
 	}
 
 	if (t->fs_path.current_dir == nullptr) {
@@ -353,8 +398,9 @@ void handle_fs_pwd(const Message& m)
 		return;
 	}
 
-	memcpy(reply.data.fs.name, t->fs_path.current_dir_name,
-		   strlen(t->fs_path.current_dir_name) + 1);
+	strncpy(reply.data.fs.name, t->fs_path.current_dir_name,
+			sizeof(reply.data.fs.name) - 1);
+	reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
 
 	kernel::task::send_message(m.sender, reply);
 }

--- a/kernel/fs/fat/file.cpp
+++ b/kernel/fs/fat/file.cpp
@@ -9,6 +9,7 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
+#include <map>
 #include <vector>
 #include "elf.hpp"
 #include "fat.hpp"
@@ -24,15 +25,89 @@
 namespace kernel::fs::fat
 {
 
+namespace
+{
+
+/// In-flight file data writes waiting for a block device completion,
+/// keyed by request id.
+struct PendingWrite {
+	ProcessId requester; ///< Process waiting for the FS_WRITE reply
+	size_t write_len;	 ///< Bytes to report on success
+};
+
+std::map<fs_id_t, PendingWrite> pending_writes;
+
+/// Reply with an empty payload so the requester blocked in
+/// wait_for_message() is always released, even on failure.
+void send_empty_reply(MsgType type, ProcessId requester)
+{
+	Message reply = { .type = type, .sender = process_ids::FS_FAT32 };
+	reply.data.fs.buf = nullptr;
+	reply.data.fs.len = 0;
+	kernel::task::send_message(requester, reply);
+}
+
+/// Build the cache key used by the file cache: the raw 11-byte 8.3 name.
+void entry_cache_key(const DirectoryEntry* entry, char (&key)[12])
+{
+	memcpy(key, entry->name, 11);
+	key[11] = '\0';
+}
+
+void process_write_completion(const Message& m)
+{
+	auto it = pending_writes.find(m.data.blk_io.request_id);
+	if (it == pending_writes.end()) {
+		// Metadata writes (FAT table, directory entries) are not tracked;
+		// still surface device errors instead of dropping them silently.
+		if (IS_ERR(m.data.blk_io.result)) {
+			LOG_ERROR("block write failed: result=%d sector=%u",
+					  m.data.blk_io.result, m.data.blk_io.sector);
+		}
+		return;
+	}
+
+	Message reply = { .type = MsgType::FS_WRITE, .sender = process_ids::FS_FAT32 };
+	if (IS_ERR(m.data.blk_io.result)) {
+		LOG_ERROR("block write failed: result=%d sector=%u", m.data.blk_io.result,
+				  m.data.blk_io.sector);
+		reply.data.fs.len = 0;
+	} else {
+		reply.data.fs.len = it->second.write_len;
+	}
+
+	kernel::task::send_message(it->second.requester, reply);
+	pending_writes.erase(it);
+}
+
+} // namespace
+
 error_t process_read_data_response(const Message& m, bool for_user)
 {
 	auto it = file_caches.find(m.data.blk_io.request_id);
 	if (it == file_caches.end()) {
-		LOG_ERROR("request id not found");
+		LOG_ERROR("request id not found: %lu", m.data.blk_io.request_id);
+		if (m.data.blk_io.buf != nullptr) {
+			kernel::memory::free(m.data.blk_io.buf);
+		}
 		return ERR_INVALID_ARG;
 	}
 
 	auto& ctx = it->second;
+
+	if (IS_ERR(m.data.blk_io.result) || m.data.blk_io.buf == nullptr) {
+		// Device read failed: release the requester with an error reply and
+		// drop the partially filled cache so it never serves stale data.
+		LOG_ERROR("block read failed: result=%d sector=%u", m.data.blk_io.result,
+				  m.data.blk_io.sector);
+		send_empty_reply(m.type, ctx.requester);
+		if (m.data.blk_io.buf != nullptr) {
+			kernel::memory::free(m.data.blk_io.buf);
+		}
+		file_caches.erase(it);
+		return ERR_FAILED_READ_FROM_DEVICE;
+	}
+
 	const size_t offset = m.data.blk_io.sequence * BYTES_PER_CLUSTER;
 
 	// オフセットがファイルサイズを超えている場合は無視
@@ -60,9 +135,8 @@ error_t process_file_read_request(const Message& m,
 								  DirectoryEntry* entry,
 								  bool for_user)
 {
-	char file_name[12] = { 0 };
-	memcpy(file_name, entry->name, 11);
-	file_name[11] = 0;
+	char file_name[12];
+	entry_cache_key(entry, file_name);
 
 	FileCache* c = find_file_cache_by_path(file_name);
 	if (c != nullptr) {
@@ -71,11 +145,20 @@ error_t process_file_read_request(const Message& m,
 		return OK;
 	}
 
-	int target_cluster = entry->first_cluster();
+	// An empty file has no cluster chain to read; reply immediately so the
+	// requester does not block forever waiting for data that never arrives.
+	if (entry->file_size == 0 || entry->first_cluster() == 0) {
+		send_file_data(m.data.fs.request_id, nullptr, 0, m.sender, m.type,
+					   for_user);
+		return OK;
+	}
+
+	cluster_t target_cluster = entry->first_cluster();
 	size_t sequence = 0;
 	FileCache* cache = create_file_cache(file_name, entry->file_size, m.sender);
 	if (cache == nullptr) {
 		LOG_ERROR("failed to create file cache");
+		send_empty_reply(m.type, m.sender);
 		return ERR_NO_MEMORY;
 	}
 
@@ -123,9 +206,14 @@ void handle_get_file_info(const Message& m)
 		}
 
 		if (entry_name_is_equal(ROOT_DIR[i], name)) {
-			void* buf;
-			ALLOC_OR_RETURN(buf, sizeof(DirectoryEntry),
-							kernel::memory::ALLOC_ZEROED);
+			void* buf = kernel::memory::alloc(sizeof(DirectoryEntry),
+											  kernel::memory::ALLOC_ZEROED);
+			if (buf == nullptr) {
+				// Fall through and reply with buf == nullptr so the
+				// requester is not left blocking forever.
+				LOG_ERROR("failed to allocate directory entry buffer");
+				break;
+			}
 			memcpy(buf, &ROOT_DIR[i], sizeof(DirectoryEntry));
 			sm.data.fs.buf = buf;
 			break;
@@ -245,6 +333,12 @@ void handle_fs_close(const Message& m)
 
 void handle_fs_write(const Message& m)
 {
+	// Completion (or failure) notification from the block device
+	if (m.sender == process_ids::VIRTIO_BLK) {
+		process_write_completion(m);
+		return;
+	}
+
 	Message reply = { .type = MsgType::FS_WRITE, .sender = process_ids::FS_FAT32 };
 
 	kernel::task::Task* t = kernel::task::get_task(m.sender);
@@ -275,14 +369,14 @@ void handle_fs_write(const Message& m)
 	const size_t new_size = fd->offset + m.data.fs.len;
 
 	if (entry->first_cluster() == 0) {
-		if (count_free_clusters() < 1) {
+		cluster_t new_cluster = allocate_cluster_chain(1);
+		if (new_cluster == 0) {
 			LOG_ERROR("disk full: no free clusters available");
 			reply.data.fs.len = 0;
 			kernel::task::send_message(m.sender, reply);
 			return;
 		}
 
-		cluster_t new_cluster = allocate_cluster_chain(1);
 		entry->first_cluster_low = new_cluster & 0xFFFF;
 		entry->first_cluster_high = (new_cluster >> 16) & 0xFFFF;
 		write_fat_table_to_disk();
@@ -296,7 +390,7 @@ void handle_fs_write(const Message& m)
 	if (needed_clusters > current_clusters) {
 		const size_t clusters_to_add = needed_clusters - current_clusters;
 		if (count_free_clusters() < clusters_to_add) {
-			LOG_ERROR("disk full: need {} clusters but only {} free",
+			LOG_ERROR("disk full: need %lu clusters but only %lu free",
 					  clusters_to_add, count_free_clusters());
 			reply.data.fs.len = 0;
 			kernel::task::send_message(m.sender, reply);
@@ -309,7 +403,12 @@ void handle_fs_write(const Message& m)
 			last_cluster = next;
 		}
 
-		extend_cluster_chain(last_cluster, clusters_to_add);
+		if (extend_cluster_chain(last_cluster, clusters_to_add) == 0) {
+			LOG_ERROR("failed to extend cluster chain");
+			reply.data.fs.len = 0;
+			kernel::task::send_message(m.sender, reply);
+			return;
+		}
 		write_fat_table_to_disk();
 	}
 
@@ -331,8 +430,14 @@ void handle_fs_write(const Message& m)
 		return;
 	}
 
-	void* cluster_buffer;
-	ALLOC_OR_RETURN(cluster_buffer, BYTES_PER_CLUSTER, kernel::memory::ALLOC_ZEROED);
+	void* cluster_buffer =
+			kernel::memory::alloc(BYTES_PER_CLUSTER, kernel::memory::ALLOC_ZEROED);
+	if (cluster_buffer == nullptr) {
+		LOG_ERROR("failed to allocate cluster buffer");
+		reply.data.fs.len = 0;
+		kernel::task::send_message(m.sender, reply);
+		return;
+	}
 
 	// Handle partial cluster writes
 	if (offset_in_cluster != 0 || write_len < BYTES_PER_CLUSTER) {
@@ -362,9 +467,20 @@ void handle_fs_write(const Message& m)
 		memcpy(cluster_buffer, write_data, write_len);
 	}
 
+	// Invalidate the cached file contents so a read after this write does not
+	// return stale data (issue #313).
+	char cache_key[12];
+	entry_cache_key(entry, cache_key);
+	remove_file_cache_by_path(cache_key);
+
+	// Track the write and reply to the requester when the device reports
+	// completion, instead of claiming success before the write happened.
+	const fs_id_t write_request_id = generate_fs_id();
+	pending_writes[write_request_id] = PendingWrite{ m.sender, write_len };
+
 	send_write_req_to_blk_device(cluster_buffer, calc_start_sector(target_cluster),
 								 BYTES_PER_CLUSTER, MsgType::FS_WRITE,
-								 m.data.fs.request_id);
+								 write_request_id);
 
 	fd->offset += write_len;
 
@@ -405,9 +521,8 @@ void handle_fs_write(const Message& m)
 		update_directory_entry_on_disk(entry, fd->name);
 	}
 
-	// All writes completed successfully, send successful reply
-	reply.data.fs.len = write_len;
-	kernel::task::send_message(m.sender, reply);
+	// The FS_WRITE reply is sent from process_write_completion() once the
+	// block device acknowledges the data write.
 
 	if (m.tool_desc.present) {
 		kernel::memory::free(m.tool_desc.addr);
@@ -421,27 +536,33 @@ void handle_fs_mkfile(const Message& m)
 	const char* name = reinterpret_cast<const char*>(m.data.fs.name);
 	kernel::graphics::to_upper(const_cast<char*>(name));
 
+	kernel::task::Task* t = kernel::task::get_task(m.sender);
+	if (t == nullptr) {
+		// Requester is gone; there is no one to reply to.
+		LOG_ERROR("Task %d not found - likely already exited", m.sender.raw());
+		return;
+	}
+
 	DirectoryEntry* existing_entry = find_dir_entry(ROOT_DIR, name);
 	if (existing_entry != nullptr) {
 		LOG_ERROR("File already exists: %s", name);
+		reply.data.fs.fd = NO_FD;
+		kernel::task::send_message(m.sender, reply);
 		return;
 	}
 
 	DirectoryEntry* entry = find_empty_dir_entry();
 	if (entry == nullptr) {
 		LOG_ERROR("No empty directory entry found");
+		reply.data.fs.fd = NO_FD;
+		kernel::task::send_message(m.sender, reply);
 		return;
 	}
 
-	memcpy(entry->name, name, strlen(name));
+	const size_t name_len = std::min(strlen(name), sizeof(entry->name));
+	memcpy(entry->name, name, name_len);
 	entry->attribute = entry_attribute::ARCHIVE;
 	entry->file_size = 0;
-
-	kernel::task::Task* t = kernel::task::get_task(m.sender);
-	if (t == nullptr) {
-		LOG_ERROR("Task %d not found - likely already exited", m.sender.raw());
-		return;
-	}
 
 	fd_t fd = kernel::fs::allocate_process_fd(t->fd_table.data(),
 											  kernel::task::MAX_FDS_PER_PROCESS,

--- a/kernel/fs/fat/init.cpp
+++ b/kernel/fs/fat/init.cpp
@@ -11,6 +11,7 @@
 #include <queue>
 #include "fat.hpp"
 #include "fs/path.hpp"
+#include "graphics/log.hpp"
 #include "hardware/virtio/blk.hpp"
 #include "internal_common.hpp"
 #include "memory/slab.hpp"
@@ -30,6 +31,12 @@ std::queue<Message> pending_messages;
 
 void handle_initialize(const Message& m)
 {
+	if (IS_ERR(m.data.blk_io.result) || m.data.blk_io.buf == nullptr) {
+		LOG_ERROR("FAT32 init read failed: sector=%u result=%d",
+				  m.data.blk_io.sector, m.data.blk_io.result);
+		return;
+	}
+
 	if (m.data.blk_io.sector == BOOT_SECTOR) {
 		VOLUME_BPB =
 				reinterpret_cast<kernel::fs::BiosParameterBlock*>(m.data.blk_io.buf);

--- a/kernel/fs/fat/init.cpp
+++ b/kernel/fs/fat/init.cpp
@@ -58,7 +58,7 @@ void handle_initialize(const Message& m)
 		while (!pending_messages.empty()) {
 			auto msg = pending_messages.front();
 			pending_messages.pop();
-			kernel::task::CURRENT_TASK->messages.push(msg);
+			kernel::task::CURRENT_TASK->messages.push_back(msg);
 		}
 	}
 }

--- a/kernel/fs/fat/internal_common.hpp
+++ b/kernel/fs/fat/internal_common.hpp
@@ -49,6 +49,7 @@ cluster_t extend_cluster_chain(cluster_t last_cluster, int num_clusters);
 cluster_t allocate_cluster_chain(size_t num_clusters);
 void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster = 0);
 size_t count_free_clusters();
+size_t total_fat_clusters();
 
 // Communication with block device
 void send_read_req_to_blk_device(unsigned int sector,

--- a/kernel/fs/fat/utils.cpp
+++ b/kernel/fs/fat/utils.cpp
@@ -148,11 +148,27 @@ DirectoryEntry* find_empty_dir_entry()
 	return nullptr;
 }
 
+size_t total_fat_clusters()
+{
+	if (FAT_TABLE == nullptr || VOLUME_BPB == nullptr ||
+		VOLUME_BPB->sectors_per_cluster == 0) {
+		return 0;
+	}
+
+	const size_t total_clusters =
+			VOLUME_BPB->total_sectors_32 / VOLUME_BPB->sectors_per_cluster;
+
+	// Cluster numbers above 0x0FFFFFF7 are reserved in FAT32
+	return total_clusters < 0x0FFFFFF8UL ? total_clusters : 0x0FFFFFF8UL;
+}
+
 cluster_t extend_cluster_chain(cluster_t last_cluster, int num_clusters)
 {
+	const size_t total_clusters = total_fat_clusters();
+
 	cluster_t current_cluster = last_cluster;
-	size_t num_allocated = 0;
-	for (int i = 2; num_allocated < num_clusters; ++i) {
+	int num_allocated = 0;
+	for (size_t i = 2; i < total_clusters && num_allocated < num_clusters; ++i) {
 		if (FAT_TABLE[i] != 0) {
 			continue;
 		}
@@ -164,19 +180,37 @@ cluster_t extend_cluster_chain(cluster_t last_cluster, int num_clusters)
 
 	FAT_TABLE[current_cluster] = END_OF_CLUSTER_CHAIN;
 
+	if (num_allocated < num_clusters) {
+		LOG_ERROR("disk full: allocated %d of %d clusters", num_allocated,
+				  num_clusters);
+		return 0;
+	}
+
 	return current_cluster;
 }
 
 cluster_t allocate_cluster_chain(size_t num_clusters)
 {
+	const size_t total_clusters = total_fat_clusters();
+
 	cluster_t first_cluster = 2;
-	while (FAT_TABLE[first_cluster] != 0) {
+	while (first_cluster < total_clusters && FAT_TABLE[first_cluster] != 0) {
 		++first_cluster;
 	}
+
+	if (first_cluster >= total_clusters) {
+		LOG_ERROR("disk full: no free cluster found");
+		return 0;
+	}
+
 	FAT_TABLE[first_cluster] = END_OF_CLUSTER_CHAIN;
 
 	if (num_clusters > 1) {
-		extend_cluster_chain(first_cluster, num_clusters - 1);
+		if (extend_cluster_chain(first_cluster, num_clusters - 1) == 0) {
+			// Roll back the partially allocated chain
+			free_cluster_chain(first_cluster, 0);
+			return 0;
+		}
 	}
 
 	return first_cluster;
@@ -184,16 +218,11 @@ cluster_t allocate_cluster_chain(size_t num_clusters)
 
 size_t count_free_clusters()
 {
-	if (FAT_TABLE == nullptr || VOLUME_BPB == nullptr) {
-		return 0;
-	}
+	const size_t total_clusters = total_fat_clusters();
 
 	size_t free_count = 0;
-	const size_t total_clusters =
-			VOLUME_BPB->total_sectors_32 / VOLUME_BPB->sectors_per_cluster;
-
 	// Start from cluster 2 (0 and 1 are reserved)
-	for (size_t i = 2; i < total_clusters && i < 0x0FFFFFF8UL; i++) {
+	for (size_t i = 2; i < total_clusters; i++) {
 		if (FAT_TABLE[i] == 0) {
 			free_count++;
 		}
@@ -360,10 +389,20 @@ void send_file_data(fs_id_t id,
 	m.data.fs.request_id = id;
 
 	if (for_user) {
+		if (size == 0) {
+			// Nothing to transfer (e.g. empty file): reply without an OOL
+			// buffer so the requester is not left blocking forever.
+			m.data.fs.len = 0;
+			kernel::task::send_message(requester, m);
+			return;
+		}
+
 		void* user_buf = kernel::memory::alloc(size, kernel::memory::ALLOC_ZEROED,
 											   memory::PAGE_SIZE);
 		if (user_buf == nullptr) {
 			LOG_ERROR("failed to allocate memory");
+			m.data.fs.len = 0;
+			kernel::task::send_message(requester, m);
 			return;
 		}
 

--- a/kernel/fs/file_descriptor.cpp
+++ b/kernel/fs/file_descriptor.cpp
@@ -22,21 +22,24 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size)
 	// Set up standard file descriptors
 	// stdin
 	if (STDIN_FILENO < table_size) {
-		strncpy(fd_table[STDIN_FILENO].name, "stdin", 11);
+		strncpy(fd_table[STDIN_FILENO].name, "stdin",
+				sizeof(fd_table[STDIN_FILENO].name) - 1);
 		fd_table[STDIN_FILENO].size = 0;
 		fd_table[STDIN_FILENO].offset = 0;
 	}
 
 	// stdout
 	if (STDOUT_FILENO < table_size) {
-		strncpy(fd_table[STDOUT_FILENO].name, "stdout", 11);
+		strncpy(fd_table[STDOUT_FILENO].name, "stdout",
+				sizeof(fd_table[STDOUT_FILENO].name) - 1);
 		fd_table[STDOUT_FILENO].size = 0;
 		fd_table[STDOUT_FILENO].offset = 0;
 	}
 
 	// stderr
 	if (STDERR_FILENO < table_size) {
-		strncpy(fd_table[STDERR_FILENO].name, "stderr", 11);
+		strncpy(fd_table[STDERR_FILENO].name, "stderr",
+				sizeof(fd_table[STDERR_FILENO].name) - 1);
 		fd_table[STDERR_FILENO].size = 0;
 		fd_table[STDERR_FILENO].offset = 0;
 	}
@@ -58,8 +61,8 @@ fd_t allocate_process_fd(FileDescriptor* fd_table,
 		if (fd_table[i].is_unused()) {
 			fd_table[i].size = size;
 			fd_table[i].offset = 0;
-			strncpy(fd_table[i].name, name, 10);
-			fd_table[i].name[10] = '\0';
+			strncpy(fd_table[i].name, name, sizeof(fd_table[i].name) - 1);
+			fd_table[i].name[sizeof(fd_table[i].name) - 1] = '\0';
 			return i;
 		}
 	}

--- a/kernel/fs/file_descriptor.hpp
+++ b/kernel/fs/file_descriptor.hpp
@@ -21,7 +21,7 @@ namespace kernel::fs
  * read/write position.
  */
 struct FileDescriptor {
-	char name[11]; ///< File name (8.3 format for FAT compatibility)
+	char name[13]; ///< 8.3 file name: up to 12 characters plus null
 	size_t size;   ///< File size in bytes
 	size_t offset; ///< Current read/write position
 
@@ -81,7 +81,7 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size);
  *
  * @param fd_table Process's file descriptor table
  * @param table_size Size of the file descriptor table
- * @param name File name (max 10 characters for 8.3 format)
+ * @param name File name (max 12 characters for 8.3 format)
  * @param size File size in bytes
  * @param pid Process ID that owns this descriptor
  * @return fd_t The allocated file descriptor number, or NO_FD on failure

--- a/kernel/fs/file_info.cpp
+++ b/kernel/fs/file_info.cpp
@@ -8,14 +8,20 @@
 namespace kernel::fs
 {
 
-const size_t MAX_FILE_ID = 50;
+const size_t MAX_FILE_CACHES = 50;
 std::unordered_map<fs_id_t, FileCache> file_caches;
-size_t id_offset = 0;
+
+namespace
+{
+fs_id_t next_fs_id = 0;
+uint64_t lru_tick = 0;
+} // namespace
 
 FileCache* find_file_cache_by_path(const char* path)
 {
 	for (auto& [id, cache] : file_caches) {
 		if (strcmp(cache.path, path) == 0) {
+			cache.last_used = ++lru_tick;
 			return &cache;
 		}
 	}
@@ -27,28 +33,54 @@ FileCache* create_file_cache(const char* path,
 							 size_t total_size,
 							 ProcessId requester)
 {
-	const fs_id_t id = generate_fs_id();
-
-	if (file_caches.size() >= MAX_FILE_ID) {
-		int oldest_id = -1;
-		for (auto it = file_caches.begin(); it != file_caches.end();) {
-			if (oldest_id == -1 || it->first < oldest_id) {
-				oldest_id = it->first;
+	if (file_caches.size() >= MAX_FILE_CACHES) {
+		// Evict the least recently used entry to make room.
+		auto oldest = file_caches.begin();
+		for (auto it = file_caches.begin(); it != file_caches.end(); ++it) {
+			if (it->second.last_used < oldest->second.last_used) {
+				oldest = it;
 			}
 		}
 
-		file_caches.erase(oldest_id);
+		file_caches.erase(oldest);
 	}
 
+	const fs_id_t id = generate_fs_id();
+
 	FileCache cache(total_size, id, requester);
-	memcpy(cache.path, path, strlen(path));
+	strncpy(cache.path, path, sizeof(cache.path) - 1);
+	cache.path[sizeof(cache.path) - 1] = '\0';
+	cache.last_used = ++lru_tick;
+
 	auto result = file_caches.emplace(id, cache);
 
 	return &result.first->second;
 }
 
-// TODO: Handle overflow
-fs_id_t generate_fs_id() { return id_offset++ % MAX_FILE_ID; }
+bool remove_file_cache_by_path(const char* path)
+{
+	for (auto it = file_caches.begin(); it != file_caches.end(); ++it) {
+		if (strcmp(it->second.path, path) == 0) {
+			file_caches.erase(it);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+fs_id_t generate_fs_id()
+{
+	// Monotonically increasing so ids are never reused across the cache
+	// (the old modulo scheme recycled ids and returned another file's
+	// cache). 0 is skipped: it is the invalid/untracked request id.
+	++next_fs_id;
+	if (next_fs_id == 0) {
+		++next_fs_id;
+	}
+
+	return next_fs_id;
+}
 
 void init_read_contexts() { file_caches = std::unordered_map<fs_id_t, FileCache>(); }
 

--- a/kernel/fs/file_info.hpp
+++ b/kernel/fs/file_info.hpp
@@ -77,7 +77,7 @@ enum class file_system_type_t : uint8_t {
  * Contains all metadata about a file or directory entry.
  */
 struct FileInfo {
-	char name[11];				///< File name in 8.3 format
+	char name[13];				///< 8.3 name: up to 12 characters plus null
 	size_t size;				///< File size in bytes
 	uint32_t attributes;		///< File attributes (combination of ATTR_* flags)
 	uint64_t creation_time;		///< Creation timestamp
@@ -100,7 +100,8 @@ struct FileCache {
 	std::vector<uint8_t> buffer; ///< Buffer containing file data
 	size_t total_size;			 ///< Total size of the file
 	size_t read_size;			 ///< Bytes read so far
-	char path[11];				 ///< File path
+	uint64_t last_used;			 ///< LRU tick of the most recent access
+	char path[13];				 ///< 8.3 name: up to 12 characters plus null
 
 	/**
 	 * @brief Construct a new file cache
@@ -110,7 +111,8 @@ struct FileCache {
 	 * @param requester Process requesting the cache
 	 */
 	FileCache(size_t total_size, fs_id_t id, ProcessId requester)
-		: id(id), requester(requester), total_size(total_size), read_size(0)
+		: id(id), requester(requester), total_size(total_size), read_size(0),
+		  last_used(0)
 	{
 		buffer.resize(total_size);
 	}
@@ -152,7 +154,20 @@ FileCache* create_file_cache(const char* path,
 							 ProcessId requester);
 
 /**
+ * @brief Remove a file cache entry by file path
+ *
+ * Used to invalidate stale cached data after a file is written.
+ *
+ * @param path File path of the cache to remove
+ * @return true if an entry was removed, false if none matched
+ */
+bool remove_file_cache_by_path(const char* path);
+
+/**
  * @brief Generate a unique file system ID
+ *
+ * Monotonically increasing; never returns 0 (0 is reserved as the
+ * invalid/untracked request id).
  *
  * @return fs_id_t New unique identifier
  */

--- a/kernel/graphics/log.cpp
+++ b/kernel/graphics/log.cpp
@@ -12,6 +12,30 @@ namespace
 kernel::graphics::LogLevel current_log_level = kernel::graphics::LogLevel::ERROR;
 int kernel_cursor_x = 0;
 int kernel_cursor_y = 5;
+
+constexpr int GLYPH_WIDTH = 8;
+constexpr int GLYPH_HEIGHT = 16;
+
+// Advance the on-screen cursor to the next line, wrapping back to the top
+// when the bottom of the screen is reached. The kernel log used to keep
+// incrementing the row forever and write past the frame buffer
+// (issue #313); the serial log remains the full, unwrapped record.
+void advance_line()
+{
+	kernel_cursor_x = 0;
+	++kernel_cursor_y;
+
+	auto* screen = kernel::graphics::kscreen;
+	const int rows = screen->height() / GLYPH_HEIGHT;
+	if (kernel_cursor_y >= rows) {
+		kernel_cursor_y = 0;
+	}
+
+	// Erase whatever was on the line we are about to write
+	screen->fill_rectangle({ 0, kernel_cursor_y * GLYPH_HEIGHT },
+						   { screen->width(), GLYPH_HEIGHT },
+						   screen->bg_color().GetCode());
+}
 } // namespace
 
 namespace kernel::graphics
@@ -48,20 +72,18 @@ void printk(kernel::graphics::LogLevel level, const char* format, ...)
 	for (size_t i = 0; i < strlen(s) && s[i] != '\0'; ++i) {
 		kernel::graphics::write_ascii(
 				*kernel::graphics::kscreen,
-				{ kernel_cursor_x++ * 8, kernel_cursor_y * 16 }, s[i], 0xffff00);
+				{ kernel_cursor_x++ * GLYPH_WIDTH, kernel_cursor_y * GLYPH_HEIGHT },
+				s[i], 0xffff00);
 
 		if (s[i] == '\n') {
-			kernel_cursor_x = 0;
-			++kernel_cursor_y;
+			advance_line();
 			continue;
 		}
 
 		if (kernel_cursor_x >= 98) {
-			kernel_cursor_x = 0;
-			++kernel_cursor_y;
+			advance_line();
 		}
 	}
 
-	kernel_cursor_x = 0;
-	++kernel_cursor_y;
+	advance_line();
 }

--- a/kernel/graphics/screen.cpp
+++ b/kernel/graphics/screen.cpp
@@ -20,9 +20,16 @@ Screen::Screen(const FrameBufferConf& frame_buffer_conf, Color bg_color)
 
 void Screen::put_pixel(Point2D point, uint32_t color_code)
 {
-	const uint64_t pixel_position =
-			pixels_per_scan_line_ * point.GetY() + point.GetX();
-	frame_buffer_[pixel_position] = color_code;
+	const int x = point.GetX();
+	const int y = point.GetY();
+
+	// Clip silently: logging here would recurse back into put_pixel
+	if (x < 0 || y < 0 || x >= static_cast<int>(horizontal_resolution_) ||
+		y >= static_cast<int>(vertical_resolution_)) {
+		return;
+	}
+
+	frame_buffer_[pixels_per_scan_line_ * y + x] = color_code;
 }
 
 void Screen::fill_rectangle(Point2D position,

--- a/kernel/hardware/virtio/blk.cpp
+++ b/kernel/hardware/virtio/blk.cpp
@@ -12,47 +12,75 @@
 
 namespace
 {
-void handle_read_request(const Message& m)
+// Pre-fill a reply so error responses always carry the request id and the
+// error kind: an all-zero reply used to collide with cached request id 0 and
+// made the FS side memcpy from a null buffer (issue #313).
+Message make_blk_reply(const Message& m)
 {
 	Message reply = { .type = m.data.blk_io.dst_type,
 					  .sender = process_ids::VIRTIO_BLK };
+	reply.data.blk_io.buf = nullptr;
+	reply.data.blk_io.sector = m.data.blk_io.sector;
+	reply.data.blk_io.len = m.data.blk_io.len;
+	reply.data.blk_io.sequence = m.data.blk_io.sequence;
+	reply.data.blk_io.request_id = m.data.blk_io.request_id;
+	reply.data.blk_io.result = OK;
+
+	return reply;
+}
+
+void handle_read_request(const Message& m)
+{
+	Message reply = make_blk_reply(m);
 
 	const int sector = m.data.blk_io.sector;
 	const int len = m.data.blk_io.len;
 
-	void* buf_ptr;
-	ALLOC_OR_RETURN(buf_ptr, len, kernel::memory::ALLOC_ZEROED);
+	void* buf_ptr = kernel::memory::alloc(len, kernel::memory::ALLOC_ZEROED);
+	if (buf_ptr == nullptr) {
+		LOG_ERROR("failed to allocate read buffer: len=%d", len);
+		reply.data.blk_io.result = ERR_NO_MEMORY;
+		kernel::task::send_message(m.sender, reply);
+		return;
+	}
+
 	char* buf = static_cast<char*>(buf_ptr);
 
-	if (IS_ERR(kernel::hw::virtio::read_from_blk_device(buf, sector, len))) {
-		LOG_ERROR("failed to read from blk device");
+	const error_t err = kernel::hw::virtio::read_from_blk_device(buf, sector, len);
+	if (IS_ERR(err)) {
+		LOG_ERROR("failed to read from blk device: %d", err);
 		kernel::memory::free(buf);
+		reply.data.blk_io.result = err;
 		kernel::task::send_message(m.sender, reply);
 		return;
 	}
 
 	reply.data.blk_io.buf = buf;
-	reply.data.blk_io.sector = sector;
-	reply.data.blk_io.len = len;
-	reply.data.blk_io.sequence = m.data.blk_io.sequence;
-	reply.data.blk_io.request_id = m.data.blk_io.request_id;
 
 	kernel::task::send_message(m.sender, reply);
 }
 
 void handle_write_request(const Message& m)
 {
+	Message reply = make_blk_reply(m);
+
 	const int sector = m.data.blk_io.sector;
 	const int len = m.data.blk_io.len < kernel::hw::virtio::SECTOR_SIZE
 							? kernel::hw::virtio::SECTOR_SIZE
 							: m.data.blk_io.len;
 
-	if (IS_ERR(kernel::hw::virtio::write_to_blk_device(
-				static_cast<const char*>(m.data.blk_io.buf), sector, len))) {
-		LOG_ERROR("failed to write to blk device");
+	const error_t err = kernel::hw::virtio::write_to_blk_device(
+			static_cast<const char*>(m.data.blk_io.buf), sector, len);
+	if (IS_ERR(err)) {
+		LOG_ERROR("failed to write to blk device: %d", err);
+		reply.data.blk_io.result = err;
 	}
 
 	kernel::memory::free(m.data.blk_io.buf);
+
+	// Always report completion so the FS side can acknowledge the requester
+	// instead of claiming success before the device write finished.
+	kernel::task::send_message(m.sender, reply);
 }
 } // namespace
 
@@ -150,7 +178,7 @@ error_t read_from_blk_device(const char* buffer, uint64_t sector, uint32_t len)
 		LOG_ERROR("Failed to read from block device. status: %d", req->status);
 		kernel::memory::free(req);
 
-		return ERR_FAILED_WRITE_TO_DEVICE;
+		return ERR_FAILED_READ_FROM_DEVICE;
 	}
 
 	kernel::memory::free(req);

--- a/kernel/interrupt/irq_guard.hpp
+++ b/kernel/interrupt/irq_guard.hpp
@@ -1,0 +1,45 @@
+/**
+ * @file interrupt/irq_guard.hpp
+ * @brief Scoped interrupt disabling for short critical sections
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kernel::interrupt
+{
+
+/**
+ * @brief Disable interrupts for a scope, restoring the previous IF state
+ *
+ * Protects data shared with interrupt handlers (message queues, the run
+ * queue) on this single-processor kernel. Safe to nest and safe to use in
+ * interrupt context: the destructor re-enables interrupts only if they
+ * were enabled on entry.
+ */
+class IrqGuard
+{
+public:
+	IrqGuard()
+	{
+		uint64_t rflags;
+		asm volatile("pushfq\n\tpopq %0\n\tcli" : "=r"(rflags) : : "memory");
+		were_enabled_ = (rflags & 0x200) != 0;
+	}
+
+	~IrqGuard()
+	{
+		if (were_enabled_) {
+			asm volatile("sti" : : : "memory");
+		}
+	}
+
+	IrqGuard(const IrqGuard&) = delete;
+	IrqGuard& operator=(const IrqGuard&) = delete;
+
+private:
+	bool were_enabled_; ///< IF state on entry
+};
+
+} // namespace kernel::interrupt

--- a/kernel/memory/page.hpp
+++ b/kernel/memory/page.hpp
@@ -37,7 +37,14 @@ public:
 	 *
 	 * Initializes a page as free with no associated pointer.
 	 */
-	Page() : status_{ 0 }, cache_{ nullptr }, slab_{ nullptr }, ptr_{ nullptr } {}
+	Page()
+		: status_{ 0 },
+		  cache_{ nullptr },
+		  slab_{ nullptr },
+		  ref_count_{ 0 },
+		  ptr_{ nullptr }
+	{
+	}
 
 	/**
 	 * @brief Get the page index based on its memory address
@@ -114,11 +121,39 @@ public:
 	 */
 	MSlab* slab() const { return slab_; }
 
+	/**
+	 * @brief Add a reference to this page (shared user mapping)
+	 */
+	void inc_ref() { ++ref_count_; }
+
+	/**
+	 * @brief Drop a reference to this page
+	 *
+	 * @return size_t Remaining reference count (0 means the page is free
+	 * to release)
+	 */
+	size_t dec_ref()
+	{
+		if (ref_count_ > 0) {
+			--ref_count_;
+		}
+
+		return ref_count_;
+	}
+
+	/**
+	 * @brief Get the current reference count
+	 *
+	 * @return size_t Number of user mappings referencing this page
+	 */
+	size_t ref_count() const { return ref_count_; }
+
 private:
-	int status_;	///< Page status: 0 = free, 1 = used
-	MCache* cache_; ///< Associated cache (for slab allocator)
-	MSlab* slab_;	///< Associated slab (for slab allocator)
-	void* ptr_;		///< Pointer to the page's memory
+	int status_;	   ///< Page status: 0 = free, 1 = used
+	MCache* cache_;	   ///< Associated cache (for slab allocator)
+	MSlab* slab_;	   ///< Associated slab (for slab allocator)
+	size_t ref_count_; ///< Number of user mappings (CoW sharing)
+	void* ptr_;		   ///< Pointer to the page's memory
 };
 
 /**

--- a/kernel/memory/paging.cpp
+++ b/kernel/memory/paging.cpp
@@ -124,6 +124,7 @@ int setup_page_table(page_table_entry* page_table,
 {
 	while (num_pages > 0) {
 		const int page_table_index = addr.part(page_table_level);
+		const bool was_present = page_table[page_table_index].bits.present;
 		auto* child_table = set_new_page_table(page_table[page_table_index]);
 		if (child_table == nullptr) {
 			LOG_ERROR("Failed to setup page table: level=%d", page_table_level);
@@ -132,6 +133,14 @@ int setup_page_table(page_table_entry* page_table,
 
 		if (page_table_level == 1) {
 			page_table[page_table_index].bits.writable = writable;
+			if (!was_present) {
+				// Freshly allocated user data page: this mapping owns it
+				page_table[page_table_index].bits.owned = 1;
+				Page* page = get_page(child_table);
+				if (page != nullptr) {
+					page->inc_ref();
+				}
+			}
 			--num_pages;
 		} else {
 			page_table[page_table_index].bits.writable = 1;
@@ -194,15 +203,27 @@ void clean_page_table(page_table_entry* table, int page_table_level)
 		}
 
 		if (page_table_level > 1) {
+			// Intermediate tables are exclusively owned by this address
+			// space (clones deep-copy them), so always free them.
 			clean_page_table(entry.get_next_level_table(), page_table_level - 1);
-		}
-
-		// skip CoW pages
-		if (!table[i].bits.writable && page_table_level == 1) {
+			kernel::memory::free(entry.get_next_level_table());
+			table[i].data = 0;
 			continue;
 		}
 
-		kernel::memory::free(entry.get_next_level_table());
+		// Level 1: leaf data page
+		if (!entry.bits.owned) {
+			// Foreign frame mapping (e.g. IPC shared memory): unmap only
+			table[i].data = 0;
+			continue;
+		}
+
+		void* data_page = entry.get_next_level_table();
+		Page* page = get_page(data_page);
+		if (page == nullptr || page->dec_ref() == 0) {
+			// Last reference (or untracked page): release it
+			kernel::memory::free(data_page);
+		}
 		table[i].data = 0;
 	}
 }
@@ -234,6 +255,14 @@ void copy_page_tables(page_table_entry* dst,
 			if (src[i].bits.present) {
 				dst[i] = src[i];
 				dst[i].bits.writable = writable;
+
+				if (src[i].bits.owned) {
+					// The new address space shares this data page (CoW)
+					Page* page = get_page(src[i].get_next_level_table());
+					if (page != nullptr) {
+						page->inc_ref();
+					}
+				}
 			}
 		}
 	} else {
@@ -259,6 +288,7 @@ void set_page_table_entry(page_table_entry* table,
 	const size_t pt_index = addr.part(1);
 	pt[pt_index].set_next_level_table(entry);
 	pt[pt_index].bits.writable = 1;
+	pt[pt_index].bits.owned = 1;
 	pt[pt_index].bits.present = 1;
 
 	flush_tlb(addr.data);
@@ -275,7 +305,26 @@ error_t copy_target_page(uint64_t addr)
 	const auto aligned_addr = addr & ~0xfff;
 	memcpy(page, reinterpret_cast<void*>(aligned_addr), kernel::memory::PAGE_SIZE);
 
+	// This address space stops referencing the shared CoW page
+	void* shared_page = nullptr;
+	auto* pte = get_pte(get_active_page_table(), vaddr_t{ addr }, 1);
+	if (pte != nullptr && pte->bits.present && pte->bits.owned) {
+		shared_page = pte->get_next_level_table();
+	}
+
+	Page* new_page = get_page(page);
+	if (new_page != nullptr) {
+		new_page->inc_ref();
+	}
+
 	set_page_table_entry(get_active_page_table(), vaddr_t{ addr }, page);
+
+	if (shared_page != nullptr) {
+		Page* old_page = get_page(shared_page);
+		if (old_page == nullptr || old_page->dec_ref() == 0) {
+			kernel::memory::free(shared_page);
+		}
+	}
 
 	return OK;
 }

--- a/kernel/memory/paging.hpp
+++ b/kernel/memory/paging.hpp
@@ -83,7 +83,9 @@ union page_table_entry {
 		uint64_t dirty : 1;
 		uint64_t huge_page : 1;
 		uint64_t global : 1;
-		uint64_t : 3;
+		uint64_t owned : 1; ///< OS bit: leaf page is owned (slab-backed user
+							///< page freed via ref count on clean)
+		uint64_t : 2;
 		uint64_t address : 40;
 		uint64_t : 11;
 		uint64_t no_execute : 1;
@@ -109,6 +111,21 @@ paddr_t get_paddr(page_table_entry* table, vaddr_t addr);
 void dump_page_tables(vaddr_t addr);
 
 page_table_entry* new_page_table();
+
+/**
+ * @brief Map num_pages of newly allocated user memory at addr in a table
+ * @param page_table Root (PML4) table to build the mapping in
+ * @param page_table_level Table level of page_table (4 for a root table)
+ * @param addr Start virtual address
+ * @param num_pages Number of pages to map
+ * @param writable Whether the leaf mappings are writable
+ * @return Number of pages left unmapped (0 on success), or -1 on failure
+ */
+int setup_page_table(page_table_entry* page_table,
+					 int page_table_level,
+					 vaddr_t addr,
+					 size_t num_pages,
+					 bool writable);
 
 void setup_page_tables(vaddr_t addr, size_t num_pages, bool writable);
 

--- a/kernel/memory/user.cpp
+++ b/kernel/memory/user.cpp
@@ -48,3 +48,28 @@ size_t copy_from_user(void* to, const void __user* from, size_t n)
 
 	return n;
 }
+
+ssize_t copy_string_from_user(char* to, const char __user* from, size_t max_len)
+{
+	if (to == nullptr || from == nullptr || max_len == 0) {
+		return -1;
+	}
+
+	const char* src = static_cast<const char*>(from);
+	for (size_t i = 0; i < max_len; ++i) {
+		if (!is_user_address(&src[i], 1)) {
+			LOG_ERROR("invalid address for copy_string_from_user: %p", &src[i]);
+			to[0] = '\0';
+			return -1;
+		}
+
+		to[i] = src[i];
+		if (src[i] == '\0') {
+			return static_cast<ssize_t>(i);
+		}
+	}
+
+	// No terminator within max_len: the string does not fit
+	to[max_len - 1] = '\0';
+	return -1;
+}

--- a/kernel/memory/user.hpp
+++ b/kernel/memory/user.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <sys/types.h>
 #include <cstddef>
 
 /**
@@ -45,9 +46,9 @@ bool is_user_address(const void* addr, size_t n);
  * @param to User space destination buffer
  * @param from Kernel space source buffer
  * @param n Number of bytes to copy
- * @return Number of bytes NOT copied (0 on success)
+ * @return Number of bytes copied: n on success, 0 on failure
  *
- * @note Returns non-zero if the copy fails (e.g., invalid user address)
+ * @note Callers must treat a return value different from n as a failure
  * @warning The user space buffer must be writable
  */
 size_t copy_to_user(void __user* to, const void* from, size_t n);
@@ -61,9 +62,23 @@ size_t copy_to_user(void __user* to, const void* from, size_t n);
  * @param to Kernel space destination buffer
  * @param from User space source buffer
  * @param n Number of bytes to copy
- * @return Number of bytes NOT copied (0 on success)
+ * @return Number of bytes copied: n on success, 0 on failure
  *
- * @note Returns non-zero if the copy fails (e.g., invalid user address)
+ * @note Callers must treat a return value different from n as a failure
  * @warning The kernel buffer must be large enough to hold n bytes
  */
 size_t copy_from_user(void* to, const void __user* from, size_t n);
+
+/**
+ * @brief Copy a NUL-terminated string from user space
+ *
+ * Validates every byte as a user-space address and always leaves a
+ * NUL-terminated string in the destination buffer.
+ *
+ * @param to Kernel destination buffer of at least max_len bytes
+ * @param from User space string
+ * @param max_len Destination buffer size in bytes (must be > 0)
+ * @return Length of the copied string (excluding the terminator), or -1
+ * if the pointer is invalid or the string does not fit in max_len bytes
+ */
+ssize_t copy_string_from_user(char* to, const char __user* from, size_t max_len);

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -256,12 +256,12 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 			kernel::task::wait_for_message(MsgType::IPC_READ_FILE_DATA);
 	kernel::memory::free(entry);
 
-	// Save current FD table before cleaning page tables
-	auto saved_fd_table = kernel::task::CURRENT_TASK->fd_table;
-
-	kernel::memory::page_table_entry* current_page_table =
+	// Build the new address space and switch CR3 to it BEFORE releasing the
+	// old one: config_new_page_table() copies the kernel space out of the
+	// active table, and the CPU keeps translating through the old table
+	// until the switch (issue #313 use-after-free).
+	kernel::memory::page_table_entry* old_page_table =
 			kernel::memory::get_active_page_table();
-	kernel::memory::clean_page_tables(current_page_table);
 
 	kernel::memory::page_table_entry* new_page_table =
 			kernel::memory::config_new_page_table();
@@ -271,8 +271,7 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 
 	kernel::task::CURRENT_TASK->ctx.cr3 = reinterpret_cast<uint64_t>(new_page_table);
 
-	// Restore FD table after page table switch
-	kernel::task::CURRENT_TASK->fd_table = saved_fd_table;
+	kernel::memory::clean_page_tables(old_page_table);
 
 	// TODO: fix this
 	kernel::fs::fat::execute_file(data_m.data.fs.buf, "", copy_args.data());

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -7,7 +7,6 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <vector>
 #include "fs/fat/fat.hpp"
 #include "graphics/font.hpp"
 #include "graphics/log.hpp"
@@ -115,14 +114,21 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 
 size_t sys_draw_text(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
 {
-	const char* text = reinterpret_cast<const char*>(arg1);
+	const char __user* text = reinterpret_cast<const char*>(arg1);
 	const int x = arg2;
 	const int y = arg3;
 	const uint32_t color = arg4;
 
-	write_string(*kernel::graphics::kscreen, { x, y }, text, color);
+	// Copy the string out of user space before touching it (issue #313)
+	char buf[256];
+	const ssize_t len = copy_string_from_user(buf, text, sizeof(buf));
+	if (len < 0) {
+		return 0;
+	}
 
-	return strlen(text);
+	write_string(*kernel::graphics::kscreen, { x, y }, buf, color);
+
+	return len;
 }
 
 error_t sys_fill_rect(uint64_t arg1,
@@ -162,30 +168,37 @@ error_t sys_time(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
 error_t sys_ipc(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
 {
 	const int dest = arg1;
-	Message __user& m = *reinterpret_cast<Message*>(arg3);
+	Message __user* m = reinterpret_cast<Message*>(arg3);
 	const int flags = arg4;
 
 	kernel::task::Task* t = kernel::task::CURRENT_TASK;
-	t->state = kernel::task::TASK_WAITING;
 
 	if (flags == IPC_RECV) {
-		if (t->messages.empty()) {
-			m = {};
-			m.type = MsgType::NO_TASK;
-			return OK;
+		Message received{};
+		received.type = MsgType::NO_TASK;
+
+		__asm__("cli");
+		if (!t->messages.empty()) {
+			received = t->messages.front();
+			t->messages.pop_front();
 		}
+		__asm__("sti");
 
-		t->state = kernel::task::TASK_RUNNING;
-
-		copy_to_user(&m, &t->messages.front(), sizeof(m));
-		t->messages.pop();
+		// The task stays RUNNING even when the queue is empty: returning
+		// to user space as WAITING would drop the task from the run queue
+		// on the next preemption (issue #313).
+		if (copy_to_user(m, &received, sizeof(*m)) != sizeof(*m)) {
+			return ERR_INVALID_ARG;
+		}
 
 		return OK;
 	}
 
 	if (flags == IPC_SEND) {
 		Message copy_m;
-		copy_from_user(&copy_m, &m, sizeof(m));
+		if (copy_from_user(&copy_m, m, sizeof(copy_m)) != sizeof(copy_m)) {
+			return ERR_INVALID_ARG;
+		}
 
 		if (copy_m.type == MsgType::INITIALIZE_TASK) {
 			copy_m.sender = t->id;
@@ -224,19 +237,23 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	const char __user* path = reinterpret_cast<const char*>(arg1);
 	const char __user* args = reinterpret_cast<const char*>(arg2);
 
-	const size_t path_len = strlen(path);
-	std::vector<char> copy_path(path_len + 1);
-	copy_from_user(copy_path.data(), path, path_len);
-	copy_path[path_len] = '\0';
-
-	const size_t args_len = strlen(args);
-	std::vector<char> copy_args(args_len + 1);
-	copy_from_user(copy_args.data(), args, args_len);
-	copy_args[args_len] = '\0';
-
 	Message msg{ .type = MsgType::IPC_GET_FILE_INFO,
 				 .sender = kernel::task::CURRENT_TASK->id };
-	memcpy(msg.data.fs.name, copy_path.data(), path_len + 1);
+
+	// Copy the strings out of user space with bounds checks before using
+	// them; the path must also fit the fixed-size Message name field
+	// (issue #313)
+	if (copy_string_from_user(msg.data.fs.name, path, sizeof(msg.data.fs.name)) <
+		0) {
+		return ERR_INVALID_ARG;
+	}
+
+	char copy_args[256] = "";
+	if (args != nullptr &&
+		copy_string_from_user(copy_args, args, sizeof(copy_args)) < 0) {
+		return ERR_INVALID_ARG;
+	}
+
 	kernel::task::send_message(process_ids::FS_FAT32, msg);
 
 	const Message info_m =
@@ -274,7 +291,7 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	kernel::memory::clean_page_tables(old_page_table);
 
 	// TODO: fix this
-	kernel::fs::fat::execute_file(data_m.data.fs.buf, "", copy_args.data());
+	kernel::fs::fat::execute_file(data_m.data.fs.buf, "", copy_args);
 
 	return OK;
 }
@@ -285,32 +302,17 @@ ProcessId sys_wait(uint64_t arg1)
 {
 	auto __user* status = reinterpret_cast<int*>(arg1);
 
-	kernel::task::Task* t = kernel::task::CURRENT_TASK;
+	// Sleep until the child exits instead of busy-waiting (issue #313)
+	Message m = kernel::task::wait_for_message(MsgType::IPC_EXIT_TASK);
 
-	while (true) {
-		if (t->messages.empty()) {
-			t->state = kernel::task::TASK_WAITING;
-			asm("pause");
-			continue;
-		}
+	task::send_message(process_ids::SHELL, m);
 
-		t->state = kernel::task::TASK_RUNNING;
-
-		Message m = t->messages.front();
-		t->messages.pop();
-
-		if (m.type == MsgType::IPC_EXIT_TASK) {
-			task::send_message(process_ids::SHELL, m);
-			copy_to_user(status, &m.data.exit_task.status, sizeof(int));
-			return m.sender;
-		}
-
-		__asm__("cli");
-		t->messages.push(m);
-		__asm__("sti");
+	if (copy_to_user(status, &m.data.exit_task.status, sizeof(int)) !=
+		sizeof(int)) {
+		return ProcessId::from_raw(-1);
 	}
 
-	return ProcessId::from_raw(-1);
+	return m.sender;
 }
 
 ProcessId sys_getpid(void) { return kernel::task::CURRENT_TASK->id; }

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -273,6 +273,11 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 			kernel::task::wait_for_message(MsgType::IPC_READ_FILE_DATA);
 	kernel::memory::free(entry);
 
+	if (data_m.data.fs.buf == nullptr) {
+		LOG_ERROR("failed to read file data for exec");
+		return ERR_FAILED_READ_FROM_DEVICE;
+	}
+
 	// Build the new address space and switch CR3 to it BEFORE releasing the
 	// old one: config_new_page_table() copies the kernel space out of the
 	// active table, and the CPU keeps translating through the old table

--- a/kernel/task/builtin.cpp
+++ b/kernel/task/builtin.cpp
@@ -135,6 +135,13 @@ void shell_service()
 
 	const Message data_m =
 			kernel::task::wait_for_message(MsgType::IPC_READ_FILE_DATA);
+	if (data_m.data.fs.buf == nullptr) {
+		LOG_ERROR("failed to read shell binary");
+		while (true) {
+			__asm__("hlt");
+		}
+	}
+
 	CURRENT_TASK->is_initilized = true;
 	kernel::fs::fat::execute_file(data_m.data.fs.buf, "shell", nullptr);
 }

--- a/kernel/task/ipc.cpp
+++ b/kernel/task/ipc.cpp
@@ -5,6 +5,8 @@
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 #include "error.hpp"
+#include "graphics/log.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "memory/paging.hpp"
 #include "memory/user.hpp"
 #include "task.hpp"
@@ -74,11 +76,21 @@ error_t send_message(ProcessId dst_id, Message& m)
 		RETURN_IF_ERROR(handle_ool_memory_alloc(m, dst));
 	}
 
+	// The queue is shared with interrupt handlers; keep the wakeup check
+	// and the push atomic so a receiver going to sleep cannot miss it
+	const kernel::interrupt::IrqGuard guard;
+
+	if (dst->messages.size() >= MAX_QUEUED_MESSAGES) {
+		LOG_ERROR_CODE(ERR_QUEUE_FULL, "message queue full: dest = %d, type = %d",
+					   dst_raw, static_cast<int>(m.type));
+		return ERR_QUEUE_FULL;
+	}
+
 	if (dst->state == TASK_WAITING) {
 		schedule_task(dst_id);
 	}
 
-	dst->messages.push(m);
+	dst->messages.push_back(m);
 
 	return OK;
 }

--- a/kernel/task/ipc.hpp
+++ b/kernel/task/ipc.hpp
@@ -18,6 +18,15 @@ namespace kernel::task
 {
 
 /**
+ * @brief Maximum number of messages queued per task
+ *
+ * Backstop against unbounded queue growth (and thus unbounded heap
+ * allocation from interrupt context) when a receiver never drains its
+ * queue. A fixed-size ring buffer is planned for Phase 2 (issue #313).
+ */
+constexpr size_t MAX_QUEUED_MESSAGES = 1024;
+
+/**
  * @brief Send a message to the specified task
  * @param dst Destination task ID
  * @param m Message to send (may be modified during sending)
@@ -25,9 +34,13 @@ namespace kernel::task
  * @retval OK Message sent successfully
  * @retval ERR_INVALID_ARG Invalid destination ID (-1 or same as sender)
  * @retval ERR_INVALID_TASK Destination task does not exist
+ * @retval ERR_QUEUE_FULL Destination queue reached MAX_QUEUED_MESSAGES
  * @note Supports out-of-line memory transfer
- * @note [[gnu::no_caller_saved_registers]] attribute optimizes register saving on
- * call
+ * @note [[gnu::no_caller_saved_registers]] lets interrupt handlers call this
+ * without spilling every register
+ * @warning Because of that attribute the return value is NOT reliable at the
+ * call site (RAX is restored by the epilogue); treat errors as diagnostics
+ * (they are logged) rather than branching on them
  */
 [[gnu::no_caller_saved_registers]] error_t send_message(ProcessId dst, Message& m);
 

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -138,16 +138,32 @@ error_t Task::copy_parent_page_table()
 		return ERR_NO_TASK;
 	}
 
-	parent->page_table_snapshot =
+	kernel::memory::page_table_entry* snapshot =
 			reinterpret_cast<kernel::memory::page_table_entry*>(parent->ctx.cr3);
 
 	kernel::memory::page_table_entry* parent_table =
-			kernel::memory::clone_page_table(parent->page_table_snapshot, false);
+			kernel::memory::clone_page_table(snapshot, false);
+	if (parent_table == nullptr) {
+		return ERR_NO_MEMORY;
+	}
+
+	// Move the running parent onto its CoW clone. Update ctx.cr3 too so an
+	// exit before the next context save does not tear down the wrong table.
 	set_cr3(reinterpret_cast<uint64_t>(parent_table));
+	parent->ctx.cr3 = reinterpret_cast<uint64_t>(parent_table);
 
 	kernel::memory::page_table_entry* child_table =
-			kernel::memory::clone_page_table(parent->page_table_snapshot, false);
+			kernel::memory::clone_page_table(snapshot, false);
+	if (child_table == nullptr) {
+		return ERR_NO_MEMORY;
+	}
+
 	ctx.cr3 = reinterpret_cast<uint64_t>(child_table);
+
+	// Both clones hold their own references to the CoW data pages now, and
+	// nothing runs on the pre-fork table anymore; release it (issue #313
+	// page table leak).
+	kernel::memory::clean_page_tables(snapshot);
 
 	return OK;
 }

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -5,12 +5,12 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <queue>
 #include "fs/fat/fat.hpp"
 #include "fs/path.hpp"
 #include "graphics/log.hpp"
 #include "hardware/virtio/blk.hpp"
 #include "hardware/virtio/net.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "interrupt/vector.hpp"
 #include "list.hpp"
 #include "memory/page.hpp"
@@ -224,10 +224,14 @@ Task* get_scheduled_task()
 void schedule_task(ProcessId id)
 {
 	const pid_t raw_id = id.raw();
-	if (tasks.size() <= raw_id || tasks[raw_id] == nullptr) {
+	if (raw_id < 0 || tasks.size() <= static_cast<size_t>(raw_id) ||
+		tasks[raw_id] == nullptr) {
 		LOG_ERROR("schedule_task: task %d is not found", raw_id);
 		return;
 	}
+
+	// The run queue is shared with interrupt handlers
+	const kernel::interrupt::IrqGuard guard;
 
 	tasks[raw_id]->state = TASK_READY;
 
@@ -287,15 +291,22 @@ void exit_task(int status)
 [[noreturn]] void process_messages(Task* t)
 {
 	while (true) {
+		__asm__("cli");
 		if (t->messages.empty()) {
-			switch_next_task(true);
+			// Declare WAITING while interrupts are off so a sender cannot
+			// slip in between the emptiness check and the sleep (lost
+			// wakeup). The INT in switch_next_task is not blocked by IF.
+			t->state = TASK_WAITING;
+			__asm__("sti");
+			switch_next_task(false);
 			continue;
 		}
 
 		t->state = TASK_RUNNING;
 
 		const Message m = t->messages.front();
-		t->messages.pop();
+		t->messages.pop_front();
+		__asm__("sti");
 
 		if (m.type == MsgType::NO_TASK || m.type >= MsgType::MAX_MESSAGE_TYPE) {
 			continue;
@@ -339,7 +350,7 @@ Task::Task(int raw_id,
 	  state{ state },
 	  fs_path({ nullptr, nullptr, nullptr }),
 	  stack{ nullptr },
-	  messages{ std::queue<Message>() },
+	  messages{},
 	  message_handlers({ std::array<message_handler_t, TOTAL_MESSAGE_TYPES>() }),
 	  fd_table()
 {
@@ -384,24 +395,27 @@ Message wait_for_message(MsgType type)
 	Task* t = CURRENT_TASK;
 
 	while (true) {
-		if (t->messages.empty()) {
-			switch_next_task(true);
-			continue;
-		}
+		__asm__("cli");
+		for (auto it = t->messages.begin(); it != t->messages.end(); ++it) {
+			if (it->type != type) {
+				continue;
+			}
 
-		t->state = TASK_RUNNING;
-
-		Message m = t->messages.front();
-		t->messages.pop();
-
-		if (m.type != type) {
-			__asm__("cli");
-			t->messages.push(m);
+			const Message m = *it;
+			t->messages.erase(it);
+			t->state = TASK_RUNNING;
 			__asm__("sti");
-			continue;
+
+			return m;
 		}
 
-		return m;
+		// No matching message yet: sleep instead of spinning, and leave
+		// the other queued messages untouched (issue #313 livelock).
+		// WAITING is declared while interrupts are off so a sender cannot
+		// slip in between the scan and the sleep.
+		t->state = TASK_WAITING;
+		__asm__("sti");
+		switch_next_task(false);
 	}
 }
 

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -3,10 +3,10 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <queue>
 #include "fs/file_descriptor.hpp"
 #include "fs/path.hpp"
 #include "list.hpp"
@@ -36,7 +36,7 @@ struct Task {
 	uint64_t kernel_stack_ptr;
 	alignas(16) Context ctx;
 	list_elem_t run_queue_elem;
-	std::queue<Message> messages;
+	std::deque<Message> messages;
 	std::array<message_handler_t, TOTAL_MESSAGE_TYPES> message_handlers;
 	std::array<kernel::fs::FileDescriptor, MAX_FDS_PER_PROCESS> fd_table;
 

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -35,7 +35,6 @@ struct Task {
 	size_t stack_size;
 	uint64_t kernel_stack_ptr;
 	alignas(16) Context ctx;
-	kernel::memory::page_table_entry* page_table_snapshot;
 	list_elem_t run_queue_elem;
 	std::queue<Message> messages;
 	std::array<message_handler_t, TOTAL_MESSAGE_TYPES> message_handlers;

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -15,6 +15,7 @@
 #include "tests/test_cases/stdio_test.hpp"
 #include "tests/test_cases/task_test.hpp"
 #include "tests/test_cases/timer_test.hpp"
+#include "tests/test_cases/user_test.hpp"
 #include "tests/test_cases/virtio_blk_test.hpp"
 
 #ifdef KERNEL_TEST_EXIT_ENABLED
@@ -80,6 +81,7 @@ void run_main_stage_tests()
 	run_test_suite(register_slab_tests);
 	run_test_suite(register_alloc_macro_tests);
 	run_test_suite(register_paging_tests);
+	run_test_suite(register_user_copy_tests);
 
 	snapshot_task_slots();
 	run_test_suite(register_task_tests);

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -10,6 +10,7 @@
 #include "tests/test_cases/bit_utils_test.hpp"
 #include "tests/test_cases/fd_test.hpp"
 #include "tests/test_cases/fs_test.hpp"
+#include "tests/test_cases/graphics_test.hpp"
 #include "tests/test_cases/memory_test.hpp"
 #include "tests/test_cases/paging_test.hpp"
 #include "tests/test_cases/stdio_test.hpp"
@@ -82,6 +83,7 @@ void run_main_stage_tests()
 	run_test_suite(register_alloc_macro_tests);
 	run_test_suite(register_paging_tests);
 	run_test_suite(register_user_copy_tests);
+	run_test_suite(register_graphics_tests);
 
 	snapshot_task_slots();
 	run_test_suite(register_task_tests);

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -11,6 +11,7 @@
 #include "tests/test_cases/fd_test.hpp"
 #include "tests/test_cases/fs_test.hpp"
 #include "tests/test_cases/memory_test.hpp"
+#include "tests/test_cases/paging_test.hpp"
 #include "tests/test_cases/stdio_test.hpp"
 #include "tests/test_cases/task_test.hpp"
 #include "tests/test_cases/timer_test.hpp"
@@ -78,6 +79,7 @@ void run_main_stage_tests()
 	run_test_suite(register_buddy_system_tests);
 	run_test_suite(register_slab_tests);
 	run_test_suite(register_alloc_macro_tests);
+	run_test_suite(register_paging_tests);
 
 	snapshot_task_slots();
 	run_test_suite(register_task_tests);

--- a/kernel/tests/test_cases/CMakeLists.txt
+++ b/kernel/tests/test_cases/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TESTCASES_SOURCE_FILES
         bit_utils_test.cpp
         memory_test.cpp
+        paging_test.cpp
         task_test.cpp
         timer_test.cpp
         virtio_blk_test.cpp

--- a/kernel/tests/test_cases/CMakeLists.txt
+++ b/kernel/tests/test_cases/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TESTCASES_SOURCE_FILES
         stdio_test.cpp
         fs_test.cpp
         fd_test.cpp
+        graphics_test.cpp
 )
 
 add_library(UchosTestCases ${TESTCASES_SOURCE_FILES})

--- a/kernel/tests/test_cases/CMakeLists.txt
+++ b/kernel/tests/test_cases/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TESTCASES_SOURCE_FILES
         bit_utils_test.cpp
         memory_test.cpp
         paging_test.cpp
+        user_test.cpp
         task_test.cpp
         timer_test.cpp
         virtio_blk_test.cpp

--- a/kernel/tests/test_cases/fs_test.cpp
+++ b/kernel/tests/test_cases/fs_test.cpp
@@ -4,11 +4,15 @@
  */
 
 #include "tests/test_cases/fs_test.hpp"
+#include <cstdio>
 #include <cstring>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
+#include <libs/common/stat.hpp>
 #include "fs/fat/fat.hpp"
 #include "fs/fat/internal_common.hpp"
+#include "fs/file_descriptor.hpp"
+#include "fs/file_info.hpp"
 #include "task/task.hpp"
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
@@ -21,6 +25,16 @@ extern uint32_t* FAT_TABLE;
 } // namespace kernel::fs::fat
 
 using namespace kernel::fs::fat;
+
+// 8.3 names are up to 12 characters ("ABCDEFGH.EXT") plus a null terminator;
+// these buffers used to be 11 bytes and overflowed (issue #313).
+static_assert(sizeof(Stat::name) >= 13, "Stat::name must hold an 8.3 name");
+static_assert(sizeof(kernel::fs::FileInfo::name) >= 13,
+			  "FileInfo::name must hold an 8.3 name");
+static_assert(sizeof(kernel::fs::FileDescriptor::name) >= 13,
+			  "FileDescriptor::name must hold an 8.3 name");
+static_assert(sizeof(kernel::fs::FileCache::path) >= 13,
+			  "FileCache::path must hold an 8.3 name");
 
 /**
  * @brief Test basic file write within existing cluster
@@ -146,6 +160,191 @@ void test_fat_table_persistence()
 }
 
 /**
+ * @brief Test that generated fs ids are monotonically increasing and nonzero
+ *
+ * The old implementation cycled ids modulo the cache capacity, so ids
+ * collided and reads were served from another file's cache (issue #313).
+ */
+void test_fs_id_monotonic_and_nonzero()
+{
+	fs_id_t prev = kernel::fs::generate_fs_id();
+	ASSERT_TRUE(prev != 0);
+
+	for (int i = 0; i < 200; ++i) {
+		const fs_id_t id = kernel::fs::generate_fs_id();
+		ASSERT_TRUE(id != 0);
+		ASSERT_TRUE(id > prev);
+		prev = id;
+	}
+}
+
+/**
+ * @brief Test that filling the cache beyond capacity terminates and evicts
+ *
+ * The old eviction loop had no iterator increment and spun forever once the
+ * cache reached 50 entries (issue #313).
+ */
+void test_file_cache_eviction_terminates()
+{
+	// Run against a private map so in-flight caches of the live FS task are
+	// not disturbed; restore the original map before asserting.
+	auto saved_caches = std::move(kernel::fs::file_caches);
+	kernel::fs::file_caches.clear();
+
+	bool all_created = true;
+	char path[13];
+	for (int i = 0; i < 60; ++i) {
+		snprintf(path, sizeof(path), "F%d", i);
+		kernel::fs::FileCache* c = kernel::fs::create_file_cache(
+				path, 16, ProcessId::from_raw(1));
+		all_created = all_created && c != nullptr && c->id != 0;
+	}
+
+	const size_t cache_count = kernel::fs::file_caches.size();
+	const bool oldest_evicted =
+			kernel::fs::find_file_cache_by_path("F0") == nullptr;
+	const bool newest_present =
+			kernel::fs::find_file_cache_by_path("F59") != nullptr;
+
+	kernel::fs::file_caches = std::move(saved_caches);
+
+	ASSERT_TRUE(all_created);
+	ASSERT_TRUE(cache_count <= 50);
+	ASSERT_TRUE(oldest_evicted);
+	ASSERT_TRUE(newest_present);
+}
+
+/**
+ * @brief Test that eviction removes the least recently used entry
+ */
+void test_file_cache_lru_order()
+{
+	auto saved_caches = std::move(kernel::fs::file_caches);
+	kernel::fs::file_caches.clear();
+
+	char path[13];
+	for (int i = 0; i < 50; ++i) {
+		snprintf(path, sizeof(path), "L%d", i);
+		kernel::fs::create_file_cache(path, 16, ProcessId::from_raw(1));
+	}
+
+	// Touch the oldest entry so "L1" becomes the least recently used one
+	const bool touched = kernel::fs::find_file_cache_by_path("L0") != nullptr;
+
+	// Cache is full: this create must evict exactly the LRU entry ("L1")
+	kernel::fs::create_file_cache("L50", 16, ProcessId::from_raw(1));
+
+	const bool touched_survived =
+			kernel::fs::find_file_cache_by_path("L0") != nullptr;
+	const bool lru_evicted = kernel::fs::find_file_cache_by_path("L1") == nullptr;
+	const bool new_present = kernel::fs::find_file_cache_by_path("L50") != nullptr;
+
+	kernel::fs::file_caches = std::move(saved_caches);
+
+	ASSERT_TRUE(touched);
+	ASSERT_TRUE(touched_survived);
+	ASSERT_TRUE(lru_evicted);
+	ASSERT_TRUE(new_present);
+}
+
+/**
+ * @brief Test 8.3 name conversion at the maximum length boundary
+ *
+ * A full 8.3 name ("ABCDEFGH.EXT") is 12 characters plus null terminator and
+ * used to overflow the 11-byte destination buffers (issue #313).
+ */
+void test_read_dir_entry_name_boundary()
+{
+	kernel::fs::DirectoryEntry entry;
+	memset(&entry, 0, sizeof(entry));
+	memcpy(entry.name, "ABCDEFGHEXT", 11);
+
+	char dest[16];
+	memset(dest, 0x7F, sizeof(dest));
+	read_dir_entry_name_raw(entry, dest);
+
+	ASSERT_EQ(strcmp(dest, "ABCDEFGH.EXT"), 0);
+	ASSERT_EQ(strlen(dest), 12UL);
+	// Nothing may be written past the 13 bytes an 8.3 name needs
+	ASSERT_EQ(dest[13], 0x7F);
+	ASSERT_TRUE(entry_name_is_equal(entry, "ABCDEFGH.EXT"));
+
+	// A converted name must fit into Stat::name without truncation
+	Stat s;
+	memset(&s, 0, sizeof(s));
+	read_dir_entry_name(entry, s.name);
+	ASSERT_EQ(strcmp(s.name, "abcdefgh.ext"), 0);
+
+	// Name without extension keeps trailing spaces trimmed
+	kernel::fs::DirectoryEntry no_ext;
+	memset(&no_ext, 0, sizeof(no_ext));
+	memcpy(no_ext.name, "NOEXT      ", 11);
+	read_dir_entry_name_raw(no_ext, dest);
+	ASSERT_EQ(strcmp(dest, "NOEXT"), 0);
+}
+
+/**
+ * @brief Test cluster chain allocation against a full disk
+ *
+ * allocate_cluster_chain / extend_cluster_chain used to scan past the end of
+ * the FAT when no free cluster existed (issue #313).
+ */
+void test_cluster_chain_disk_full()
+{
+	auto* saved_fat = FAT_TABLE;
+	auto* saved_bpb = VOLUME_BPB;
+
+	// Tiny fake volume: clusters 0-7 (2-7 usable), canaries after the table
+	constexpr size_t total_test_clusters = 8;
+	constexpr uint32_t canary_value = 0xDEADBEEF;
+	uint32_t fake_fat[total_test_clusters + 4];
+	memset(fake_fat, 0, sizeof(fake_fat));
+	fake_fat[0] = 0x0FFFFFF8;
+	fake_fat[1] = 0x0FFFFFFF;
+	for (size_t i = total_test_clusters; i < total_test_clusters + 4; ++i) {
+		fake_fat[i] = canary_value;
+	}
+
+	kernel::fs::BiosParameterBlock fake_bpb;
+	memset(&fake_bpb, 0, sizeof(fake_bpb));
+	fake_bpb.total_sectors_32 = total_test_clusters;
+	fake_bpb.sectors_per_cluster = 1;
+
+	FAT_TABLE = fake_fat;
+	VOLUME_BPB = &fake_bpb;
+
+	const size_t free_before = count_free_clusters();
+	const cluster_t first_chain = allocate_cluster_chain(4);
+	const size_t free_mid = count_free_clusters();
+
+	// Only 2 clusters left: this must fail and roll back, not scan past the
+	// end of the FAT
+	const cluster_t failed_chain = allocate_cluster_chain(4);
+	const size_t free_after = count_free_clusters();
+
+	// Fully exhaust the remaining clusters, then fail again
+	const cluster_t second_chain = allocate_cluster_chain(2);
+	const cluster_t exhausted_chain = allocate_cluster_chain(1);
+
+	bool canaries_intact = true;
+	for (size_t i = total_test_clusters; i < total_test_clusters + 4; ++i) {
+		canaries_intact = canaries_intact && fake_fat[i] == canary_value;
+	}
+
+	FAT_TABLE = saved_fat;
+	VOLUME_BPB = saved_bpb;
+
+	ASSERT_EQ(free_before, 6UL);
+	ASSERT_EQ(first_chain, 2UL);
+	ASSERT_EQ(free_mid, 2UL);
+	ASSERT_EQ(failed_chain, 0UL);
+	ASSERT_EQ(free_after, 2UL);
+	ASSERT_TRUE(second_chain != 0);
+	ASSERT_EQ(exhausted_chain, 0UL);
+	ASSERT_TRUE(canaries_intact);
+}
+
+/**
  * @brief Register all file system test cases
  */
 void register_fs_tests()
@@ -156,4 +355,12 @@ void register_fs_tests()
 	test_register("test_fat_table_update", test_fat_table_update);
 	test_register("test_write_extend_file", test_write_extend_file);
 	test_register("test_fat_table_persistence", test_fat_table_persistence);
+	test_register("test_fs_id_monotonic_and_nonzero",
+				  test_fs_id_monotonic_and_nonzero);
+	test_register("test_file_cache_eviction_terminates",
+				  test_file_cache_eviction_terminates);
+	test_register("test_file_cache_lru_order", test_file_cache_lru_order);
+	test_register("test_read_dir_entry_name_boundary",
+				  test_read_dir_entry_name_boundary);
+	test_register("test_cluster_chain_disk_full", test_cluster_chain_disk_full);
 }

--- a/kernel/tests/test_cases/graphics_test.cpp
+++ b/kernel/tests/test_cases/graphics_test.cpp
@@ -1,0 +1,30 @@
+#include "tests/test_cases/graphics_test.hpp"
+#include "graphics/screen.hpp"
+#include "tests/framework.hpp"
+#include "tests/macros.hpp"
+
+void test_put_pixel_out_of_bounds_is_ignored()
+{
+	using kernel::graphics::kscreen;
+
+	ASSERT_NOT_NULL(kscreen);
+
+	// Out-of-range coordinates used to write straight past the frame
+	// buffer (issue #313); they must be clipped without touching memory
+	kscreen->put_pixel({ -1, 0 }, 0xff0000);
+	kscreen->put_pixel({ 0, -1 }, 0xff0000);
+	kscreen->put_pixel({ kscreen->width(), 0 }, 0xff0000);
+	kscreen->put_pixel({ 0, kscreen->height() }, 0xff0000);
+	kscreen->put_pixel({ 1'000'000, 1'000'000 }, 0xff0000);
+
+	// In-range corners are still valid
+	kscreen->put_pixel({ 0, 0 }, 0x000000);
+	kscreen->put_pixel({ kscreen->width() - 1, kscreen->height() - 1 },
+					   0x000000);
+}
+
+void register_graphics_tests()
+{
+	test_register("put_pixel_out_of_bounds_is_ignored",
+				  test_put_pixel_out_of_bounds_is_ignored);
+}

--- a/kernel/tests/test_cases/graphics_test.hpp
+++ b/kernel/tests/test_cases/graphics_test.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void register_graphics_tests();

--- a/kernel/tests/test_cases/paging_test.cpp
+++ b/kernel/tests/test_cases/paging_test.cpp
@@ -1,0 +1,114 @@
+#include "tests/test_cases/paging_test.hpp"
+#include <cstdint>
+#include "memory/buddy_system.hpp"
+#include "memory/page.hpp"
+#include "memory/paging.hpp"
+#include "memory/slab.hpp"
+#include "tests/framework.hpp"
+#include "tests/macros.hpp"
+
+namespace
+{
+// PML4 index 256 = start of the user half of the address space
+constexpr uint64_t TEST_USER_VADDR = 0xffff'8000'1234'5000;
+} // namespace
+
+void test_clean_page_tables_frees_user_pages()
+{
+	using namespace kernel::memory;
+
+	page_table_entry* table = new_page_table();
+	ASSERT_NOT_NULL(table);
+
+	const vaddr_t addr{ TEST_USER_VADDR };
+	ASSERT_EQ(setup_page_table(table, 4, addr, 2, true), 0);
+
+	auto* pte = get_pte(table, addr, 1);
+	ASSERT_NOT_NULL(pte);
+	ASSERT_EQ(pte->bits.owned, 1UL);
+	void* data_page = pte->get_next_level_table();
+	ASSERT_TRUE(is_slab_object_in_use(data_page));
+
+	clean_page_tables(table);
+
+	// Owned data pages and the table pages themselves are released
+	ASSERT_FALSE(is_slab_object_in_use(data_page));
+	ASSERT_FALSE(is_slab_object_in_use(table));
+}
+
+void test_cow_pages_freed_with_last_reference()
+{
+	using namespace kernel::memory;
+
+	page_table_entry* origin = new_page_table();
+	ASSERT_NOT_NULL(origin);
+
+	const vaddr_t addr{ TEST_USER_VADDR };
+	ASSERT_EQ(setup_page_table(origin, 4, addr, 1, true), 0);
+	void* data_page = get_pte(origin, addr, 1)->get_next_level_table();
+
+	// Fork-style CoW: two clones sharing the same data page read-only
+	page_table_entry* clone_a = clone_page_table(origin, false);
+	page_table_entry* clone_b = clone_page_table(origin, false);
+	ASSERT_NOT_NULL(clone_a);
+	ASSERT_NOT_NULL(clone_b);
+
+	auto* pte_a = get_pte(clone_a, addr, 1);
+	ASSERT_NOT_NULL(pte_a);
+	ASSERT_EQ(pte_a->get_next_level_table(), data_page);
+	ASSERT_EQ(pte_a->bits.writable, 0UL);
+	ASSERT_EQ(pte_a->bits.owned, 1UL);
+
+	// Releasing the pre-fork snapshot keeps the shared page alive
+	clean_page_tables(origin);
+	ASSERT_TRUE(is_slab_object_in_use(data_page));
+
+	clean_page_tables(clone_a);
+	ASSERT_TRUE(is_slab_object_in_use(data_page));
+
+	// The last reference frees it (issue #313 CoW page leak)
+	clean_page_tables(clone_b);
+	ASSERT_FALSE(is_slab_object_in_use(data_page));
+}
+
+void test_clean_page_tables_skips_foreign_frames()
+{
+	using namespace kernel::memory;
+
+	page_table_entry* table = new_page_table();
+	ASSERT_NOT_NULL(table);
+
+	const vaddr_t addr{ TEST_USER_VADDR };
+	ASSERT_EQ(setup_page_table(table, 4, addr, 1, true), 0);
+
+	// Map a buddy-owned frame the way IPC shared memory does
+	void* frame = memory_manager->allocate(PAGE_SIZE);
+	ASSERT_NOT_NULL(frame);
+	vaddr_t mapped{ 0 };
+	ASSERT_EQ(map_frame_to_vaddr(table, reinterpret_cast<uint64_t>(frame), 1,
+								 &mapped),
+			  OK);
+
+	auto* pte = get_pte(table, mapped, 1);
+	ASSERT_NOT_NULL(pte);
+	ASSERT_EQ(pte->bits.owned, 0UL);
+
+	clean_page_tables(table);
+
+	// The foreign frame is only unmapped, never freed
+	Page* page = get_page(frame);
+	ASSERT_NOT_NULL(page);
+	ASSERT_TRUE(page->is_used());
+
+	memory_manager->free(frame, PAGE_SIZE);
+}
+
+void register_paging_tests()
+{
+	test_register("clean_page_tables_frees_user_pages",
+				  test_clean_page_tables_frees_user_pages);
+	test_register("cow_pages_freed_with_last_reference",
+				  test_cow_pages_freed_with_last_reference);
+	test_register("clean_page_tables_skips_foreign_frames",
+				  test_clean_page_tables_skips_foreign_frames);
+}

--- a/kernel/tests/test_cases/paging_test.hpp
+++ b/kernel/tests/test_cases/paging_test.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void register_paging_tests();

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -8,6 +8,7 @@
 #include "task/task.hpp"
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
+#include "tests/test_utils.hpp"
 
 using kernel::task::create_task;
 using kernel::task::CURRENT_TASK;
@@ -21,32 +22,7 @@ extern ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 extern ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3);
 } // namespace kernel::syscall
 
-namespace
-{
-// Impersonate `t` as CURRENT_TASK for a scope. The impersonated task must
-// be RUNNING while it is current: if a timer preemption hits while
-// CURRENT_TASK is WAITING, switch_task() does not requeue it and the test
-// runner's execution context is lost for good — the boot hangs with no
-// output (issue #313). RAII also restores CURRENT_TASK when an ASSERT
-// macro returns early.
-class ScopedCurrentTask
-{
-public:
-	explicit ScopedCurrentTask(Task* t) : prev_(CURRENT_TASK)
-	{
-		t->state = kernel::task::TASK_RUNNING;
-		CURRENT_TASK = t;
-	}
-
-	~ScopedCurrentTask() { CURRENT_TASK = prev_; }
-
-	ScopedCurrentTask(const ScopedCurrentTask&) = delete;
-	ScopedCurrentTask& operator=(const ScopedCurrentTask&) = delete;
-
-private:
-	Task* prev_;
-};
-} // namespace
+using kernel::tests::ScopedCurrentTask;
 
 void test_fd_table_init()
 {
@@ -203,7 +179,7 @@ void test_stdout_redirection()
 
 	// Clear any existing messages
 	while (!t->messages.empty()) {
-		t->messages.pop();
+		t->messages.pop_front();
 	}
 
 	// Test writing to redirected stdout

--- a/kernel/tests/test_cases/task_test.cpp
+++ b/kernel/tests/test_cases/task_test.cpp
@@ -5,9 +5,17 @@
 #include <libs/common/process_id.hpp>
 #include "memory/slab.hpp"
 #include "task/context.hpp"
+#include "task/ipc.hpp"
 #include "task/task.hpp"
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
+#include "tests/test_utils.hpp"
+
+// Forward declaration for the syscall under test
+namespace kernel::syscall
+{
+extern error_t sys_ipc(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);
+} // namespace kernel::syscall
 
 using kernel::task::create_task;
 using kernel::task::get_available_task_id;
@@ -88,7 +96,7 @@ void test_task_message_handling()
 	ASSERT_TRUE(t->messages.empty());
 	const Message test_msg = { .type = MsgType::IPC_EXIT_TASK,
 							   .sender = ProcessId::from_raw(0) };
-	t->messages.push(test_msg);
+	t->messages.push_back(test_msg);
 	ASSERT_FALSE(t->messages.empty());
 
 	// Test message handling
@@ -145,6 +153,72 @@ void test_task_memory_management()
 	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(stack));
 }
 
+void test_wait_for_message_preserves_other_messages()
+{
+	Task* t = create_task("wait_msg_test", 0, true, true);
+	ASSERT_NOT_NULL(t);
+
+	Message other = { .type = MsgType::NOTIFY_WRITE,
+					  .sender = ProcessId::from_raw(1) };
+	Message target = { .type = MsgType::IPC_EXIT_TASK,
+					   .sender = ProcessId::from_raw(2) };
+	t->messages.push_back(other);
+	t->messages.push_back(target);
+
+	const kernel::tests::ScopedCurrentTask scoped_task(t);
+
+	// The matching message is extracted even when it is not at the front
+	const Message m = kernel::task::wait_for_message(MsgType::IPC_EXIT_TASK);
+	ASSERT_TRUE(m.type == MsgType::IPC_EXIT_TASK);
+	ASSERT_EQ(m.sender.raw(), 2);
+
+	// The unrelated message is still queued (issue #313: the old
+	// implementation spun on and reordered non-matching messages)
+	ASSERT_EQ(t->messages.size(), 1UL);
+	ASSERT_TRUE(t->messages.front().type == MsgType::NOTIFY_WRITE);
+	t->messages.clear();
+}
+
+void test_send_message_queue_cap()
+{
+	Task* t = create_task("queue_cap_test", 0, true, true);
+	ASSERT_NOT_NULL(t);
+
+	// Keep the receiver off the run queue while flooding it
+	t->state = kernel::task::TASK_RUNNING;
+
+	Message m = { .type = MsgType::NOTIFY_WRITE,
+				  .sender = kernel::task::CURRENT_TASK->id };
+
+	// NOTE: send_message is [[gnu::no_caller_saved_registers]], so its
+	// return value is not reliable at the call site; assert on the queue
+	// size instead.
+	for (size_t i = 0; i < kernel::task::MAX_QUEUED_MESSAGES + 8; ++i) {
+		kernel::task::send_message(t->id, m);
+	}
+
+	// The queue is capped instead of growing without bound (issue #313)
+	ASSERT_EQ(t->messages.size(), kernel::task::MAX_QUEUED_MESSAGES);
+	t->messages.clear();
+}
+
+void test_ipc_recv_empty_keeps_task_runnable()
+{
+	Task* t = create_task("ipc_recv_test", 0, true, true);
+	ASSERT_NOT_NULL(t);
+	ASSERT_TRUE(t->messages.empty());
+
+	const kernel::tests::ScopedCurrentTask scoped_task(t);
+
+	Message m;
+	kernel::syscall::sys_ipc(0, 0, reinterpret_cast<uint64_t>(&m), IPC_RECV);
+
+	// An empty queue must not leave the task WAITING while it returns to
+	// the caller; it would be dropped from the run queue on the next
+	// preemption (issue #313)
+	ASSERT_EQ(t->state, kernel::task::TASK_RUNNING);
+}
+
 void register_task_tests()
 {
 	test_register("task_creation_basic", test_task_creation_basic);
@@ -152,4 +226,9 @@ void register_task_tests()
 	test_register("task_message_handling", test_task_message_handling);
 	test_register("task_copy", test_task_copy);
 	test_register("task_memory_management", test_task_memory_management);
+	test_register("wait_for_message_preserves_other_messages",
+				  test_wait_for_message_preserves_other_messages);
+	test_register("send_message_queue_cap", test_send_message_queue_cap);
+	test_register("ipc_recv_empty_keeps_task_runnable",
+				  test_ipc_recv_empty_keeps_task_runnable);
 }

--- a/kernel/tests/test_cases/user_test.cpp
+++ b/kernel/tests/test_cases/user_test.cpp
@@ -1,0 +1,51 @@
+#include "tests/test_cases/user_test.hpp"
+#include <string.h> // NOLINT(misc-include-cleaner) - for strlcpy
+#include <cstdint>
+#include <cstring>
+#include "memory/paging.hpp"
+#include "memory/user.hpp"
+#include "tests/framework.hpp"
+#include "tests/macros.hpp"
+
+namespace
+{
+// A user-half address (PML4 index >= 256) reserved for these tests
+constexpr uint64_t TEST_USER_STR_VADDR = 0xffff'8000'2000'0000;
+} // namespace
+
+void test_copy_string_from_user_rejects_invalid_pointers()
+{
+	char buf[16];
+
+	// Kernel addresses and null pointers are rejected
+	const char* kernel_str = "kernel";
+	ASSERT_EQ(copy_string_from_user(buf, kernel_str, sizeof(buf)), -1);
+	ASSERT_EQ(copy_string_from_user(buf, nullptr, sizeof(buf)), -1);
+}
+
+void test_copy_string_from_user_roundtrip()
+{
+	// Map one user page in the active address space and place a string
+	const kernel::memory::vaddr_t addr{ TEST_USER_STR_VADDR };
+	kernel::memory::setup_page_tables(addr, 1, true);
+
+	char* user_buf = reinterpret_cast<char*>(addr.data);
+	strlcpy(user_buf, "hello", 6); // NOLINT(misc-include-cleaner)
+
+	char buf[16];
+	ASSERT_EQ(copy_string_from_user(buf, user_buf, sizeof(buf)), 5);
+	ASSERT_EQ(strcmp(buf, "hello"), 0);
+
+	// A string that does not fit the destination is rejected but the
+	// buffer is still NUL-terminated
+	ASSERT_EQ(copy_string_from_user(buf, user_buf, 3), -1);
+	ASSERT_EQ(buf[2], '\0');
+}
+
+void register_user_copy_tests()
+{
+	test_register("copy_string_from_user_rejects_invalid_pointers",
+				  test_copy_string_from_user_rejects_invalid_pointers);
+	test_register("copy_string_from_user_roundtrip",
+				  test_copy_string_from_user_roundtrip);
+}

--- a/kernel/tests/test_cases/user_test.hpp
+++ b/kernel/tests/test_cases/user_test.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void register_user_copy_tests();

--- a/kernel/tests/test_utils.hpp
+++ b/kernel/tests/test_utils.hpp
@@ -1,0 +1,40 @@
+/**
+ * @file tests/test_utils.hpp
+ * @brief Shared helpers for kernel test cases
+ */
+
+#pragma once
+
+#include "task/task.hpp"
+
+namespace kernel::tests
+{
+
+/**
+ * @brief Impersonate a task as CURRENT_TASK for a scope
+ *
+ * The impersonated task must be RUNNING while it is current: if a timer
+ * preemption hits while CURRENT_TASK is WAITING, switch_task() does not
+ * requeue it and the test runner's execution context is lost for good —
+ * the boot hangs with no output (issue #313). RAII also restores
+ * CURRENT_TASK when an ASSERT macro returns early.
+ */
+class ScopedCurrentTask
+{
+public:
+	explicit ScopedCurrentTask(kernel::task::Task* t) : prev_(CURRENT_TASK)
+	{
+		t->state = kernel::task::TASK_RUNNING;
+		CURRENT_TASK = t;
+	}
+
+	~ScopedCurrentTask() { CURRENT_TASK = prev_; }
+
+	ScopedCurrentTask(const ScopedCurrentTask&) = delete;
+	ScopedCurrentTask& operator=(const ScopedCurrentTask&) = delete;
+
+private:
+	kernel::task::Task* prev_; ///< CURRENT_TASK on entry
+};
+
+} // namespace kernel::tests

--- a/libs/common/message.hpp
+++ b/libs/common/message.hpp
@@ -112,6 +112,7 @@ struct Message {
 			size_t len;
 			size_t sequence;
 			MsgType dst_type;
+			int result; ///< OK on success, negative error code on failure
 		} blk_io;
 
 		struct {

--- a/libs/common/stat.hpp
+++ b/libs/common/stat.hpp
@@ -14,7 +14,7 @@ enum class StatType : uint8_t {
 };
 
 struct Stat {
-	char name[11];
+	char name[13]; ///< 8.3 name: up to 12 characters plus null terminator
 	size_t size;
 	StatType type;
 	uint64_t fs_id;

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -29,6 +29,7 @@ constexpr int ERR_NO_FILE = -8;
 constexpr int ERR_NO_DEVICE = -9;
 constexpr int ERR_FAILED_INIT_DEVICE = -10;
 constexpr int ERR_FAILED_WRITE_TO_DEVICE = -11;
+constexpr int ERR_QUEUE_FULL = -12;
 
 // file descriptor
 constexpr int NO_FD = -1;

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -30,6 +30,8 @@ constexpr int ERR_NO_DEVICE = -9;
 constexpr int ERR_FAILED_INIT_DEVICE = -10;
 constexpr int ERR_FAILED_WRITE_TO_DEVICE = -11;
 constexpr int ERR_QUEUE_FULL = -12;
+constexpr int ERR_FAILED_READ_FROM_DEVICE = -13;
+constexpr int ERR_NO_SPACE = -14;
 
 // file descriptor
 constexpr int NO_FD = -1;


### PR DESCRIPTION
## 概要

[#313](https://github.com/junyaU/uchos/issues/313) のコメントで追加報告された graphics のバグ修正。**#323 → #325 → #326 → #328 の上に積んだスタック PR。先にそれらをマージしてください。**

## 修正内容

- **`Screen::put_pixel`**: 座標の境界チェックなしに `frame_buffer_[pitch * y + x]` へ書き込んでいた → 範囲外は黙ってクリップ(ここでログを出すと put_pixel に再帰するため)
- **`printk`**: `kernel_cursor_y` を増やし続けるだけでスクロールせず、数十行のログで**画面下端を越えてフレームバッファ外のメモリへ書き込んでいた** → 下端到達で先頭行へ折り返し、上書きする行は背景色でクリア。シリアルログは従来どおり全量・折り返しなしの完全な記録のまま

## テスト

- 新規 graphics スイート: `put_pixel_out_of_bounds_is_ignored`(負座標・解像度ちょうど・巨大座標のクリップ、四隅の正常書き込み)
- printk の折り返し自体は CI 実行(数百行のテストログ)が実地検証になる(旧コードではフレームバッファ外書き込みが発生していた)

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)