### PR TITLE
fix: fs テストによる稼働中グローバルの差し替えを撤廃(実機ブラックスクリーン修正)

### DIFF
--- a/kernel/fs/fat/internal_common.hpp
+++ b/kernel/fs/fat/internal_common.hpp
@@ -45,9 +45,24 @@ cluster_t next_cluster(cluster_t cluster_id);
 kernel::fs::DirectoryEntry* find_dir_entry(kernel::fs::DirectoryEntry* parent_dir,
 										   const char* name);
 kernel::fs::DirectoryEntry* find_empty_dir_entry();
+// The (fat, total_clusters) overloads operate on an explicit FAT so tests
+// can use a private table; the parameterless-FAT overloads wrap the live
+// globals. Tests must never swap the globals themselves: the FS task uses
+// them concurrently (issue #313 regression).
+cluster_t extend_cluster_chain(uint32_t* fat,
+							   size_t total_clusters,
+							   cluster_t last_cluster,
+							   int num_clusters);
 cluster_t extend_cluster_chain(cluster_t last_cluster, int num_clusters);
+cluster_t allocate_cluster_chain(uint32_t* fat,
+								 size_t total_clusters,
+								 size_t num_clusters);
 cluster_t allocate_cluster_chain(size_t num_clusters);
+void free_cluster_chain(uint32_t* fat,
+						cluster_t start_cluster,
+						cluster_t keep_until_cluster = 0);
 void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster = 0);
+size_t count_free_clusters(const uint32_t* fat, size_t total_clusters);
 size_t count_free_clusters();
 size_t total_fat_clusters();
 

--- a/kernel/fs/fat/utils.cpp
+++ b/kernel/fs/fat/utils.cpp
@@ -162,23 +162,24 @@ size_t total_fat_clusters()
 	return total_clusters < 0x0FFFFFF8UL ? total_clusters : 0x0FFFFFF8UL;
 }
 
-cluster_t extend_cluster_chain(cluster_t last_cluster, int num_clusters)
+cluster_t extend_cluster_chain(uint32_t* fat,
+							   size_t total_clusters,
+							   cluster_t last_cluster,
+							   int num_clusters)
 {
-	const size_t total_clusters = total_fat_clusters();
-
 	cluster_t current_cluster = last_cluster;
 	int num_allocated = 0;
 	for (size_t i = 2; i < total_clusters && num_allocated < num_clusters; ++i) {
-		if (FAT_TABLE[i] != 0) {
+		if (fat[i] != 0) {
 			continue;
 		}
 
-		FAT_TABLE[current_cluster] = i;
+		fat[current_cluster] = i;
 		current_cluster = i;
 		++num_allocated;
 	}
 
-	FAT_TABLE[current_cluster] = END_OF_CLUSTER_CHAIN;
+	fat[current_cluster] = END_OF_CLUSTER_CHAIN;
 
 	if (num_allocated < num_clusters) {
 		LOG_ERROR("disk full: allocated %d of %d clusters", num_allocated,
@@ -189,12 +190,18 @@ cluster_t extend_cluster_chain(cluster_t last_cluster, int num_clusters)
 	return current_cluster;
 }
 
-cluster_t allocate_cluster_chain(size_t num_clusters)
+cluster_t extend_cluster_chain(cluster_t last_cluster, int num_clusters)
 {
-	const size_t total_clusters = total_fat_clusters();
+	return extend_cluster_chain(FAT_TABLE, total_fat_clusters(), last_cluster,
+								num_clusters);
+}
 
+cluster_t allocate_cluster_chain(uint32_t* fat,
+								 size_t total_clusters,
+								 size_t num_clusters)
+{
 	cluster_t first_cluster = 2;
-	while (first_cluster < total_clusters && FAT_TABLE[first_cluster] != 0) {
+	while (first_cluster < total_clusters && fat[first_cluster] != 0) {
 		++first_cluster;
 	}
 
@@ -203,12 +210,13 @@ cluster_t allocate_cluster_chain(size_t num_clusters)
 		return 0;
 	}
 
-	FAT_TABLE[first_cluster] = END_OF_CLUSTER_CHAIN;
+	fat[first_cluster] = END_OF_CLUSTER_CHAIN;
 
 	if (num_clusters > 1) {
-		if (extend_cluster_chain(first_cluster, num_clusters - 1) == 0) {
+		if (extend_cluster_chain(fat, total_clusters, first_cluster,
+								 num_clusters - 1) == 0) {
 			// Roll back the partially allocated chain
-			free_cluster_chain(first_cluster, 0);
+			free_cluster_chain(fat, first_cluster, 0);
 			return 0;
 		}
 	}
@@ -216,14 +224,17 @@ cluster_t allocate_cluster_chain(size_t num_clusters)
 	return first_cluster;
 }
 
-size_t count_free_clusters()
+cluster_t allocate_cluster_chain(size_t num_clusters)
 {
-	const size_t total_clusters = total_fat_clusters();
+	return allocate_cluster_chain(FAT_TABLE, total_fat_clusters(), num_clusters);
+}
 
+size_t count_free_clusters(const uint32_t* fat, size_t total_clusters)
+{
 	size_t free_count = 0;
 	// Start from cluster 2 (0 and 1 are reserved)
 	for (size_t i = 2; i < total_clusters; i++) {
-		if (FAT_TABLE[i] == 0) {
+		if (fat[i] == 0) {
 			free_count++;
 		}
 	}
@@ -231,7 +242,14 @@ size_t count_free_clusters()
 	return free_count;
 }
 
-void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster)
+size_t count_free_clusters()
+{
+	return count_free_clusters(FAT_TABLE, total_fat_clusters());
+}
+
+void free_cluster_chain(uint32_t* fat,
+						cluster_t start_cluster,
+						cluster_t keep_until_cluster)
 {
 	if (start_cluster == 0 || start_cluster >= 0x0FFFFFF8UL) {
 		return;
@@ -241,16 +259,16 @@ void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster)
 	bool found_keep_until = (keep_until_cluster == 0);
 
 	while (current != END_OF_CLUSTER_CHAIN && current < 0x0FFFFFF8UL) {
-		cluster_t next = FAT_TABLE[current];
+		cluster_t next = fat[current];
 
 		if (current == keep_until_cluster) {
-			FAT_TABLE[current] = END_OF_CLUSTER_CHAIN;
+			fat[current] = END_OF_CLUSTER_CHAIN;
 			found_keep_until = true;
 			break;
 		}
 
 		if (found_keep_until) {
-			FAT_TABLE[current] = 0;
+			fat[current] = 0;
 		}
 
 		current = next;
@@ -263,11 +281,16 @@ void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster)
 		// Free entire chain
 		current = start_cluster;
 		while (current != END_OF_CLUSTER_CHAIN && current < 0x0FFFFFF8UL) {
-			cluster_t next = FAT_TABLE[current];
-			FAT_TABLE[current] = 0;
+			cluster_t next = fat[current];
+			fat[current] = 0;
 			current = next;
 		}
 	}
+}
+
+void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster)
+{
+	free_cluster_chain(FAT_TABLE, start_cluster, keep_until_cluster);
 }
 
 void send_read_req_to_blk_device(unsigned int sector,

--- a/kernel/fs/file_info.cpp
+++ b/kernel/fs/file_info.cpp
@@ -9,7 +9,7 @@ namespace kernel::fs
 {
 
 const size_t MAX_FILE_CACHES = 50;
-std::unordered_map<fs_id_t, FileCache> file_caches;
+FileCacheMap file_caches;
 
 namespace
 {
@@ -17,9 +17,9 @@ fs_id_t next_fs_id = 0;
 uint64_t lru_tick = 0;
 } // namespace
 
-FileCache* find_file_cache_by_path(const char* path)
+FileCache* find_file_cache_by_path(FileCacheMap& caches, const char* path)
 {
-	for (auto& [id, cache] : file_caches) {
+	for (auto& [id, cache] : caches) {
 		if (strcmp(cache.path, path) == 0) {
 			cache.last_used = ++lru_tick;
 			return &cache;
@@ -29,20 +29,26 @@ FileCache* find_file_cache_by_path(const char* path)
 	return nullptr;
 }
 
-FileCache* create_file_cache(const char* path,
+FileCache* find_file_cache_by_path(const char* path)
+{
+	return find_file_cache_by_path(file_caches, path);
+}
+
+FileCache* create_file_cache(FileCacheMap& caches,
+							 const char* path,
 							 size_t total_size,
 							 ProcessId requester)
 {
-	if (file_caches.size() >= MAX_FILE_CACHES) {
+	if (caches.size() >= MAX_FILE_CACHES) {
 		// Evict the least recently used entry to make room.
-		auto oldest = file_caches.begin();
-		for (auto it = file_caches.begin(); it != file_caches.end(); ++it) {
+		auto oldest = caches.begin();
+		for (auto it = caches.begin(); it != caches.end(); ++it) {
 			if (it->second.last_used < oldest->second.last_used) {
 				oldest = it;
 			}
 		}
 
-		file_caches.erase(oldest);
+		caches.erase(oldest);
 	}
 
 	const fs_id_t id = generate_fs_id();
@@ -52,9 +58,16 @@ FileCache* create_file_cache(const char* path,
 	cache.path[sizeof(cache.path) - 1] = '\0';
 	cache.last_used = ++lru_tick;
 
-	auto result = file_caches.emplace(id, cache);
+	auto result = caches.emplace(id, cache);
 
 	return &result.first->second;
+}
+
+FileCache* create_file_cache(const char* path,
+							 size_t total_size,
+							 ProcessId requester)
+{
+	return create_file_cache(file_caches, path, total_size, requester);
 }
 
 bool remove_file_cache_by_path(const char* path)

--- a/kernel/fs/file_info.hpp
+++ b/kernel/fs/file_info.hpp
@@ -127,14 +127,29 @@ struct FileCache {
 };
 
 /**
+ * @brief Map type holding file caches keyed by cache id
+ */
+using FileCacheMap = std::unordered_map<fs_id_t, FileCache>;
+
+/**
  * @brief Global map of active file caches
  *
  * Maps cache IDs to their corresponding file cache objects.
  */
-extern std::unordered_map<fs_id_t, FileCache> file_caches;
+extern FileCacheMap file_caches;
 
 /**
- * @brief Find a file cache by file path
+ * @brief Find a file cache by file path in the given map
+ *
+ * @param caches Cache map to search (tests pass a private instance; the
+ * live FS task owns the global map and must never have it swapped out)
+ * @param path File path to search for
+ * @return file_cache* Pointer to cache if found, nullptr otherwise
+ */
+FileCache* find_file_cache_by_path(FileCacheMap& caches, const char* path);
+
+/**
+ * @brief Find a file cache by file path in the global map
  *
  * @param path File path to search for
  * @return file_cache* Pointer to cache if found, nullptr otherwise
@@ -142,7 +157,22 @@ extern std::unordered_map<fs_id_t, FileCache> file_caches;
 FileCache* find_file_cache_by_path(const char* path);
 
 /**
- * @brief Create a new file cache
+ * @brief Create a new file cache in the given map (evicts the LRU entry
+ * when the map is full)
+ *
+ * @param caches Cache map to insert into
+ * @param path File path to cache
+ * @param total_size Total size of the file
+ * @param requester Process requesting the cache
+ * @return file_cache* Pointer to the newly created cache
+ */
+FileCache* create_file_cache(FileCacheMap& caches,
+							 const char* path,
+							 size_t total_size,
+							 ProcessId requester);
+
+/**
+ * @brief Create a new file cache in the global map
  *
  * @param path File path to cache
  * @param total_size Total size of the file

--- a/kernel/tests/test_cases/fs_test.cpp
+++ b/kernel/tests/test_cases/fs_test.cpp
@@ -17,12 +17,6 @@
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
 
-namespace kernel::fs::fat
-{
-// Forward declarations for testing
-extern kernel::fs::DirectoryEntry* ROOT_DIR;
-extern uint32_t* FAT_TABLE;
-} // namespace kernel::fs::fat
 
 using namespace kernel::fs::fat;
 
@@ -186,32 +180,26 @@ void test_fs_id_monotonic_and_nonzero()
  */
 void test_file_cache_eviction_terminates()
 {
-	// Run against a private map so in-flight caches of the live FS task are
-	// not disturbed; restore the original map before asserting.
-	auto saved_caches = std::move(kernel::fs::file_caches);
-	kernel::fs::file_caches.clear();
+	// A private map keeps the test fully isolated from the live FS task,
+	// which uses the global file_caches concurrently (issue #313: swapping
+	// the global out mid-boot lost the shell's in-flight cache).
+	kernel::fs::FileCacheMap local_caches;
 
 	bool all_created = true;
 	char path[13];
 	for (int i = 0; i < 60; ++i) {
 		snprintf(path, sizeof(path), "F%d", i);
 		kernel::fs::FileCache* c = kernel::fs::create_file_cache(
-				path, 16, ProcessId::from_raw(1));
+				local_caches, path, 16, ProcessId::from_raw(1));
 		all_created = all_created && c != nullptr && c->id != 0;
 	}
 
-	const size_t cache_count = kernel::fs::file_caches.size();
-	const bool oldest_evicted =
-			kernel::fs::find_file_cache_by_path("F0") == nullptr;
-	const bool newest_present =
-			kernel::fs::find_file_cache_by_path("F59") != nullptr;
-
-	kernel::fs::file_caches = std::move(saved_caches);
-
 	ASSERT_TRUE(all_created);
-	ASSERT_TRUE(cache_count <= 50);
-	ASSERT_TRUE(oldest_evicted);
-	ASSERT_TRUE(newest_present);
+	ASSERT_TRUE(local_caches.size() <= 50);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "F0") ==
+				nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "F59") !=
+				nullptr);
 }
 
 /**
@@ -219,32 +207,29 @@ void test_file_cache_eviction_terminates()
  */
 void test_file_cache_lru_order()
 {
-	auto saved_caches = std::move(kernel::fs::file_caches);
-	kernel::fs::file_caches.clear();
+	kernel::fs::FileCacheMap local_caches;
 
 	char path[13];
 	for (int i = 0; i < 50; ++i) {
 		snprintf(path, sizeof(path), "L%d", i);
-		kernel::fs::create_file_cache(path, 16, ProcessId::from_raw(1));
+		kernel::fs::create_file_cache(local_caches, path, 16,
+									  ProcessId::from_raw(1));
 	}
 
 	// Touch the oldest entry so "L1" becomes the least recently used one
-	const bool touched = kernel::fs::find_file_cache_by_path("L0") != nullptr;
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L0") !=
+				nullptr);
 
 	// Cache is full: this create must evict exactly the LRU entry ("L1")
-	kernel::fs::create_file_cache("L50", 16, ProcessId::from_raw(1));
+	kernel::fs::create_file_cache(local_caches, "L50", 16,
+								  ProcessId::from_raw(1));
 
-	const bool touched_survived =
-			kernel::fs::find_file_cache_by_path("L0") != nullptr;
-	const bool lru_evicted = kernel::fs::find_file_cache_by_path("L1") == nullptr;
-	const bool new_present = kernel::fs::find_file_cache_by_path("L50") != nullptr;
-
-	kernel::fs::file_caches = std::move(saved_caches);
-
-	ASSERT_TRUE(touched);
-	ASSERT_TRUE(touched_survived);
-	ASSERT_TRUE(lru_evicted);
-	ASSERT_TRUE(new_present);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L0") !=
+				nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L1") ==
+				nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L50") !=
+				nullptr);
 }
 
 /**
@@ -291,10 +276,8 @@ void test_read_dir_entry_name_boundary()
  */
 void test_cluster_chain_disk_full()
 {
-	auto* saved_fat = FAT_TABLE;
-	auto* saved_bpb = VOLUME_BPB;
-
-	// Tiny fake volume: clusters 0-7 (2-7 usable), canaries after the table
+	// A private FAT keeps the test isolated from the live FS task; the
+	// globals must never be swapped while the FS task may run (issue #313)
 	constexpr size_t total_test_clusters = 8;
 	constexpr uint32_t canary_value = 0xDEADBEEF;
 	uint32_t fake_fat[total_test_clusters + 4];
@@ -305,34 +288,27 @@ void test_cluster_chain_disk_full()
 		fake_fat[i] = canary_value;
 	}
 
-	kernel::fs::BiosParameterBlock fake_bpb;
-	memset(&fake_bpb, 0, sizeof(fake_bpb));
-	fake_bpb.total_sectors_32 = total_test_clusters;
-	fake_bpb.sectors_per_cluster = 1;
-
-	FAT_TABLE = fake_fat;
-	VOLUME_BPB = &fake_bpb;
-
-	const size_t free_before = count_free_clusters();
-	const cluster_t first_chain = allocate_cluster_chain(4);
-	const size_t free_mid = count_free_clusters();
+	const size_t free_before = count_free_clusters(fake_fat, total_test_clusters);
+	const cluster_t first_chain =
+			allocate_cluster_chain(fake_fat, total_test_clusters, 4);
+	const size_t free_mid = count_free_clusters(fake_fat, total_test_clusters);
 
 	// Only 2 clusters left: this must fail and roll back, not scan past the
 	// end of the FAT
-	const cluster_t failed_chain = allocate_cluster_chain(4);
-	const size_t free_after = count_free_clusters();
+	const cluster_t failed_chain =
+			allocate_cluster_chain(fake_fat, total_test_clusters, 4);
+	const size_t free_after = count_free_clusters(fake_fat, total_test_clusters);
 
 	// Fully exhaust the remaining clusters, then fail again
-	const cluster_t second_chain = allocate_cluster_chain(2);
-	const cluster_t exhausted_chain = allocate_cluster_chain(1);
+	const cluster_t second_chain =
+			allocate_cluster_chain(fake_fat, total_test_clusters, 2);
+	const cluster_t exhausted_chain =
+			allocate_cluster_chain(fake_fat, total_test_clusters, 1);
 
 	bool canaries_intact = true;
 	for (size_t i = total_test_clusters; i < total_test_clusters + 4; ++i) {
 		canaries_intact = canaries_intact && fake_fat[i] == canary_value;
 	}
-
-	FAT_TABLE = saved_fat;
-	VOLUME_BPB = saved_bpb;
 
 	ASSERT_EQ(free_before, 6UL);
 	ASSERT_EQ(first_chain, 2UL);


### PR DESCRIPTION
## 概要

#328 マージ後に実機(virtio ディスクあり)で発生した「画面に何も映らない」問題の修正。

## 原因

#328 の fs テストが、テスト実行中だけ `file_caches` / `FAT_TABLE` / `VOLUME_BPB` を偽物に差し替えていた。CI(ディスク無し)では FAT32 タスクが初期化されず無害だが、実機では **shell バイナリのロードがテストと並行して走る**ため、差し替え窓の間のプリエンプトで FAT32 タスクがテスト用インスタンスを操作してしまう:

1. shell 用キャッシュが**テストのマップ側に**作られ、テスト終了時の復元で破棄 → 以後の blk 応答は `request id not found` で捨てられ、shell が `wait_for_message(IPC_READ_FILE_DATA)` で永久待ち → **画面に何も描かれない**
2. 同じ `unordered_map` を 2 タスクが並行変更すると内部構造が壊れ、テストランナー自身もハング(`TEST_SUMMARY` 未出力と整合)

QEMU は TCG(命令数決定的)のため毎回同じ結果になる。

## 修正

グローバル差し替えを全廃し、テスト対象関数をパラメータ化:

- `find_file_cache_by_path` / `create_file_cache` に `FileCacheMap&` を取るオーバーロードを追加(既存 API はグローバルを渡す薄いラッパーとして維持)
- `allocate_cluster_chain` / `extend_cluster_chain` / `free_cluster_chain` / `count_free_clusters` に `(fat, total_clusters)` オーバーロードを追加
- eviction / LRU / disk-full テストは**完全にプライベートなインスタンス**上で動作し、グローバルに一切触れない

`internal_common.hpp` に「テストはグローバルを差し替えてはならない(FS タスクが並行使用する)」旨の注記を追加。

## 検証

- CI(ビルド + QEMU テスト + clang-tidy)
- **実機の再現条件は CI では踏めない(ディスク無し構成)ため、マージ後に `./run_qemu.sh` で shell が表示されることの確認をお願いします**

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)