### PR TITLE
refactor: collapse IPC request/reply boilerplate into make_request/call

### DIFF
--- a/libs/user/file.cpp
+++ b/libs/user/file.cpp
@@ -4,44 +4,36 @@
 #include <libs/common/types.hpp>
 #include <libs/user/file.hpp>
 #include <libs/user/ipc.hpp>
-#include <libs/user/syscall.hpp>
 
 fd_t fs_open(const char* path, int flags)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_OPEN, .sender = pid };
+	Message m = make_request(MsgType::FS_OPEN);
 	memcpy(m.data.fs.name, path, strlen(path));
 	m.data.fs.operation = flags;
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message res = wait_for_message(MsgType::FS_OPEN);
+	Message res = call(process_ids::FS_FAT32, &m);
 
 	return res.data.fs.fd;
 }
 
 size_t fs_read(fd_t fd, void* buf, size_t count)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_READ, .sender = pid };
+	Message m = make_request(MsgType::FS_READ);
 	m.data.fs.fd = fd;
 	m.data.fs.len = count;
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message res = wait_for_message(MsgType::FS_READ);
+	Message res = call(process_ids::FS_FAT32, &m);
 
 	memcpy(buf, res.tool_desc.addr, res.tool_desc.size);
 
-	deallocate_ool_memory(pid, res.tool_desc.addr, res.tool_desc.size);
+	deallocate_ool_memory(m.sender, res.tool_desc.addr, res.tool_desc.size);
 
 	return res.tool_desc.size;
 }
 
 void fs_close(fd_t fd)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_CLOSE, .sender = pid };
+	Message m = make_request(MsgType::FS_CLOSE);
 	m.data.fs.fd = fd;
 
 	send_message(process_ids::FS_FAT32, &m);
@@ -49,33 +41,26 @@ void fs_close(fd_t fd)
 
 fd_t fs_create(const char* path)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_MKFILE, .sender = pid };
+	Message m = make_request(MsgType::FS_MKFILE);
 	memcpy(m.data.fs.name, path, strlen(path));
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message res = wait_for_message(MsgType::FS_MKFILE);
+	Message res = call(process_ids::FS_FAT32, &m);
 
 	return res.data.fs.fd;
 }
 
 void fs_pwd(char* buf, size_t size)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_PWD, .sender = pid };
+	Message m = make_request(MsgType::FS_PWD);
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message res = wait_for_message(MsgType::FS_PWD);
+	Message res = call(process_ids::FS_FAT32, &m);
 
 	memcpy(buf, res.data.fs.name, size);
 }
 
 size_t fs_write(fd_t fd, const void* buf, size_t count)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_WRITE, .sender = pid };
+	Message m = make_request(MsgType::FS_WRITE);
 	m.data.fs.fd = fd;
 	m.data.fs.len = count;
 
@@ -88,23 +73,18 @@ size_t fs_write(fd_t fd, const void* buf, size_t count)
 		return 0;
 	}
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message res = wait_for_message(MsgType::FS_WRITE);
+	Message res = call(process_ids::FS_FAT32, &m);
 
 	return res.data.fs.len;
 }
 
 void fs_change_dir(char* buf, const char* path)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_CHANGE_DIR, .sender = pid };
+	Message m = make_request(MsgType::FS_CHANGE_DIR);
 	memcpy(m.data.fs.name, path, strlen(path));
 	m.data.fs.name[strlen(path)] = '\0';
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message res = wait_for_message(MsgType::FS_CHANGE_DIR);
+	Message res = call(process_ids::FS_FAT32, &m);
 	if (res.data.fs.result == -1) {
 		buf[0] = '\0';
 		return;
@@ -118,14 +98,11 @@ void fs_change_dir(char* buf, const char* path)
 
 int fs_dup2(fd_t oldfd, fd_t newfd)
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .type = MsgType::FS_DUP2, .sender = pid };
+	Message m = make_request(MsgType::FS_DUP2);
 	m.data.fs.fd = oldfd;
 	m.data.fs.operation = newfd;
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message res = wait_for_message(MsgType::FS_DUP2);
+	Message res = call(process_ids::FS_FAT32, &m);
 
 	return res.data.fs.result;
 }

--- a/libs/user/ipc.cpp
+++ b/libs/user/ipc.cpp
@@ -24,15 +24,21 @@ Message wait_for_message(MsgType type)
 	return m;
 }
 
+Message make_request(MsgType type)
+{
+	return Message{ .type = type, .sender = ProcessId::from_raw(sys_getpid()) };
+}
+
+Message call(ProcessId dst, Message* msg)
+{
+	send_message(dst, msg);
+	return wait_for_message(msg->type);
+}
+
 void initialize_task()
 {
-	ProcessId pid = ProcessId::from_raw(sys_getpid());
-	Message m = { .sender = pid };
-
-	m.type = MsgType::FS_REGISTER_PATH;
-	send_message(process_ids::FS_FAT32, &m);
-
-	wait_for_message(MsgType::FS_REGISTER_PATH);
+	Message m = make_request(MsgType::FS_REGISTER_PATH);
+	call(process_ids::FS_FAT32, &m);
 
 	m.type = MsgType::INITIALIZE_TASK;
 	send_message(process_ids::KERNEL, &m);

--- a/libs/user/ipc.hpp
+++ b/libs/user/ipc.hpp
@@ -10,6 +10,27 @@ void send_message(ProcessId dst, const Message* msg);
 
 Message wait_for_message(MsgType type);
 
+/**
+ * @brief Build a request message stamped with this process as the sender
+ * @param type Message type of the request
+ * @return Message with type and sender filled in
+ */
+Message make_request(MsgType type);
+
+/**
+ * @brief Send a request and block until the reply of the same type arrives
+ *
+ * Wraps the send_message / wait_for_message pair used by every synchronous
+ * service call. Replies are matched by message type (the current IPC has no
+ * correlation id — see issue #314); when IPC v2 lands, only this function
+ * has to change.
+ *
+ * @param dst Destination process
+ * @param msg Request to send (sender must already be set)
+ * @return The reply message
+ */
+Message call(ProcessId dst, Message* msg);
+
 void initialize_task();
 
 void deallocate_ool_memory(ProcessId sender, void* addr, size_t size);

--- a/userland/commands/free/main.cpp
+++ b/userland/commands/free/main.cpp
@@ -7,13 +7,9 @@
 
 extern "C" int main(int argc, char** argv)
 {
-	pid_t pid = sys_getpid();
+	Message m = make_request(MsgType::IPC_MEMORY_USAGE);
 
-	Message m = { .type = MsgType::IPC_MEMORY_USAGE,
-				  .sender = ProcessId::from_raw(pid) };
-	send_message(process_ids::KERNEL, &m);
-
-	Message msg = wait_for_message(MsgType::IPC_MEMORY_USAGE);
+	Message msg = call(process_ids::KERNEL, &m);
 
 	printu("Used memory: %u MiB\nTotal memory: %u MiB",
 		   msg.data.memory_usage.used / 1024 / 1024,

--- a/userland/commands/ls/main.cpp
+++ b/userland/commands/ls/main.cpp
@@ -9,20 +9,16 @@
 
 int main(int argc, char** argv)
 {
-	pid_t pid = sys_getpid();
 	char* input = argv[1];
 
-	Message m = { .type = MsgType::GET_DIRECTORY_CONTENTS,
-				  .sender = ProcessId::from_raw(pid) };
+	Message m = make_request(MsgType::GET_DIRECTORY_CONTENTS);
 	if (input != nullptr) {
 		memcpy(m.data.fs.name, input, strlen(input));
 	} else {
 		memcpy(m.data.fs.name, "/", 1);
 	}
 
-	send_message(process_ids::FS_FAT32, &m);
-
-	Message msg = wait_for_message(MsgType::GET_DIRECTORY_CONTENTS);
+	Message msg = call(process_ids::FS_FAT32, &m);
 
 	char buf[256];
 	size_t buf_pos = 0;
@@ -57,8 +53,7 @@ int main(int argc, char** argv)
 	buf[buf_pos] = '\0'; // Ensure null termination
 	printu(buf);
 
-	deallocate_ool_memory(ProcessId::from_raw(pid), msg.tool_desc.addr,
-						  msg.tool_desc.size);
+	deallocate_ool_memory(m.sender, msg.tool_desc.addr, msg.tool_desc.size);
 
 	return 0;
 }

--- a/userland/commands/lspci/main.cpp
+++ b/userland/commands/lspci/main.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char** argv)
 {
 	pid_t pid = sys_getpid();
-	Message m = { .type = MsgType::IPC_PCI, .sender = ProcessId::from_raw(pid) };
+	Message m = make_request(MsgType::IPC_PCI);
 	send_message(process_ids::KERNEL, &m);
 
 	Message msg;


### PR DESCRIPTION
Refs #338(Tier 2 の IPC call() ヘルパ集約)。#314 IPC v2 の前準備。

## 変更内容

「getpid → Message 構築 → send_message → wait_for_message」の同期呼び出し定型(10 箇所超)を libs/user/ipc の 2 ヘルパに集約:

- `make_request(type)`: sender に自プロセスをスタンプした要求メッセージを構築
- `call(dst, msg)`: 送信して同型の応答をブロッキング待ち。**「reply は同型でマッチ(correlation id なし)」という現行規約がこの 1 関数に閉じた**ため、#314 で API が変わるときの移行箇所が 1 点になる

適用先: libs/user/file.cpp の全 8 ラッパー、initialize_task、ls / free の main、lspci の送信部(受信ループは複数応答を処理するため現状維持)。

## 検証

- [x] userland 全コマンド+shell のビルド成功(make clean && make)
- [x] コミット済み .o の変更は含めていない(#338 で .o 自体を削除予定)
- [ ] QEMU 実機での ls / cat / free 等の動作確認(ユーザー確認をお願いします)

🤖 Generated with [Claude Code](https://claude.com/claude-code)