### PR TITLE
refactor(fs): FAT定数の名前付け・死んだコードの削除・命名整理

### DIFF
--- a/kernel/fs/fat/directory.cpp
+++ b/kernel/fs/fat/directory.cpp
@@ -34,8 +34,9 @@ fs_id_t next_change_dir_id = 1000000;
 namespace
 {
 
-void update_directory_path_from_parent(kernel::task::Task* t,
-									   const std::string& parent_path)
+/// Set fs_path (full_path / current_dir_name) from an already-known parent
+/// path string; used for ".." when the parent's path was precomputed.
+void set_fs_path_to_parent(kernel::task::Task* t, const std::string& parent_path)
 {
 	strncpy(t->fs_path.full_path, parent_path.c_str(),
 			sizeof(t->fs_path.full_path) - 1);
@@ -55,7 +56,9 @@ void update_directory_path_from_parent(kernel::task::Task* t,
 	}
 }
 
-void update_directory_path_append(kernel::task::Task* t, const std::string& dir_name)
+/// Set fs_path (full_path / current_dir_name) by appending a child directory
+/// name; used when the current directory changes to a named subdirectory.
+void set_fs_path_to_child(kernel::task::Task* t, const std::string& dir_name)
 {
 	strncpy(t->fs_path.current_dir_name, dir_name.c_str(), 12);
 	t->fs_path.current_dir_name[12] = '\0';
@@ -70,7 +73,10 @@ void update_directory_path_append(kernel::task::Task* t, const std::string& dir_
 	}
 }
 
-void change_to_root_directory(kernel::task::Task* t)
+/// Reset fs_path (current_dir / current_dir_name / full_path) to the root
+/// directory. State only: unlike handle_change_to_root(), this does not send
+/// a reply message.
+void set_fs_path_to_root(kernel::task::Task* t)
 {
 	if (t->fs_path.current_dir != nullptr && t->fs_path.current_dir != ROOT_DIR) {
 		kernel::memory::free(t->fs_path.current_dir);
@@ -101,7 +107,9 @@ bool validate_change_dir_request(const Message& m, kernel::task::Task*& task)
 	return true;
 }
 
-void update_directory_entry(kernel::task::Task* t, DirectoryEntry* new_dir)
+/// Replace fs_path.current_dir with a newly loaded directory-cluster buffer,
+/// freeing the previous buffer (unless it is the shared ROOT_DIR).
+void set_fs_path_current_dir(kernel::task::Task* t, DirectoryEntry* new_dir)
 {
 	if (t->fs_path.current_dir != nullptr && t->fs_path.current_dir != ROOT_DIR) {
 		kernel::memory::free(t->fs_path.current_dir);
@@ -116,13 +124,13 @@ void finalize_directory_change(const Message& m, kernel::task::Task* t)
 		if (name_it->second == "..") {
 			auto parent_name_it = parent_dir_names.find(m.data.blk_io.request_id);
 			if (parent_name_it != parent_dir_names.end()) {
-				update_directory_path_from_parent(t, parent_name_it->second);
+				set_fs_path_to_parent(t, parent_name_it->second);
 				parent_dir_names.erase(parent_name_it);
 			} else if (t->fs_path.current_dir == ROOT_DIR) {
-				change_to_root_directory(t);
+				set_fs_path_to_root(t);
 			}
 		} else {
-			update_directory_path_append(t, name_it->second);
+			set_fs_path_to_child(t, name_it->second);
 		}
 		change_dir_names.erase(name_it);
 	}
@@ -147,14 +155,15 @@ void handle_virtio_response(const Message& m)
 		return;
 	}
 
-	update_directory_entry(task,
-						   reinterpret_cast<DirectoryEntry*>(m.data.blk_io.buf));
+	set_fs_path_current_dir(task,
+							reinterpret_cast<DirectoryEntry*>(m.data.blk_io.buf));
 	finalize_directory_change(m, task);
 }
 
-void change_to_root(const Message& m, kernel::task::Task* t)
+/// Reset to the root directory and reply to the FS_CHANGE_DIR request.
+void handle_change_to_root(const Message& m, kernel::task::Task* t)
 {
-	change_to_root_directory(t);
+	set_fs_path_to_root(t);
 
 	Message reply = { .type = MsgType::FS_CHANGE_DIR,
 					  .sender = process_ids::FS_FAT32 };
@@ -207,7 +216,7 @@ void request_parent_directory_load(const Message& m,
 void handle_parent_directory_change(const Message& m, kernel::task::Task* t)
 {
 	if (t->fs_path.current_dir == ROOT_DIR) {
-		change_to_root(m, t);
+		handle_change_to_root(m, t);
 		return;
 	}
 
@@ -218,7 +227,7 @@ void handle_parent_directory_change(const Message& m, kernel::task::Task* t)
 	}
 
 	if (parent_entry->first_cluster() == 0) {
-		change_to_root(m, t);
+		handle_change_to_root(m, t);
 		return;
 	}
 
@@ -283,7 +292,7 @@ void handle_fs_change_dir(const Message& m)
 	const char* path_name = reinterpret_cast<const char*>(m.data.fs.name);
 
 	if (strcmp(path_name, "/") == 0) {
-		change_to_root(m, task);
+		handle_change_to_root(m, task);
 		return;
 	}
 
@@ -326,11 +335,11 @@ void handle_get_directory_contents(const Message& m)
 	std::vector<char> entries(ENTRIES_PER_CLUSTER * sizeof(DirectoryEntry));
 	int entries_count = 0;
 	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (current_dir[i].name[0] == 0x00) {
+		if (current_dir[i].name[0] == DIR_ENTRY_END) {
 			break;
 		}
 
-		if (current_dir[i].name[0] == 0xE5) {
+		if (current_dir[i].name[0] == DIR_ENTRY_DELETED) {
 			continue;
 		}
 
@@ -405,7 +414,7 @@ void handle_fs_pwd(const Message& m)
 	kernel::task::send_message(m.sender, reply);
 }
 
-void update_directory_entry_on_disk(DirectoryEntry* entry, const char* name)
+void persist_directory_entry(DirectoryEntry* entry, const char* name)
 {
 	if (entry == nullptr || ROOT_DIR == nullptr) {
 		LOG_ERROR("Invalid directory entry or ROOT_DIR not initialized");
@@ -414,7 +423,7 @@ void update_directory_entry_on_disk(DirectoryEntry* entry, const char* name)
 
 	DirectoryEntry* disk_entry = nullptr;
 	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (ROOT_DIR[i].name[0] == 0x00) {
+		if (ROOT_DIR[i].name[0] == DIR_ENTRY_END) {
 			break;
 		}
 
@@ -442,8 +451,10 @@ void update_directory_entry_on_disk(DirectoryEntry* entry, const char* name)
 	send_write_req_to_blk_device(write_buffer, root_dir_sector, BYTES_PER_CLUSTER,
 								 MsgType::FS_WRITE, 0, 0);
 
-	// Note: The buffer will be freed when the write operation completes
-	// TODO: This should be handled in the write completion handler
+	// write_buffer is freed by the block device driver (kernel::hw::virtio::blk's
+	// IPC_WRITE_TO_BLK_DEVICE handler) once it has copied the data to disk;
+	// this request is not tracked in file.cpp's pending_writes map because no
+	// caller here is waiting on an FS_WRITE reply.
 }
 
 } // namespace kernel::fs::fat

--- a/kernel/fs/fat/fat.hpp
+++ b/kernel/fs/fat/fat.hpp
@@ -58,6 +58,20 @@ enum class entry_attribute : uint8_t {
 	LONG_NAME = 0x0F,
 };
 
+/// First byte of DirectoryEntry::name marking the end of a directory's used
+/// entries: this slot and all that follow it in the cluster are unused.
+constexpr unsigned char DIR_ENTRY_END = 0x00;
+
+/// First byte of DirectoryEntry::name marking a deleted entry: the slot is
+/// free for reuse, but later entries in the same cluster may still be valid.
+constexpr unsigned char DIR_ENTRY_DELETED = 0xE5;
+
+/// Mask for one 16-bit half (low or high) of a 32-bit cluster number.
+constexpr uint32_t CLUSTER_LOW_MASK = 0xFFFF;
+
+/// Bit shift to reach the high half of a 32-bit cluster number.
+constexpr unsigned int CLUSTER_HIGH_SHIFT = 16;
+
 struct DirectoryEntry {
 	unsigned char name[11];
 	entry_attribute attribute;
@@ -76,9 +90,28 @@ struct DirectoryEntry {
 	{
 		return first_cluster_low | (static_cast<uint32_t>(first_cluster_high) << 16);
 	}
+
+	/**
+	 * @brief Set the first cluster number, splitting it across the low/high fields
+	 * @param cluster Cluster number to store
+	 */
+	void set_first_cluster(uint32_t cluster)
+	{
+		first_cluster_low = cluster & CLUSTER_LOW_MASK;
+		first_cluster_high = (cluster >> CLUSTER_HIGH_SHIFT) & CLUSTER_LOW_MASK;
+	}
 } __attribute__((packed));
 
+/// This implementation always writes this exact value when it marks the end
+/// of a cluster chain in the FAT table.
 static const cluster_t END_OF_CLUSTER_CHAIN = 0x0FFFFFFFLU;
+
+/// FAT32 reserves every value from here through END_OF_CLUSTER_CHAIN
+/// (0x0FFFFFFF) as an end-of-chain/reserved marker; readers must treat any
+/// FAT entry in this range as "no next cluster", even though this
+/// implementation only ever writes END_OF_CLUSTER_CHAIN itself when
+/// terminating a chain.
+static const cluster_t FAT32_EOC_MIN = 0x0FFFFFF8UL;
 
 constexpr unsigned int BOOT_SECTOR = 0;
 

--- a/kernel/fs/fat/file.cpp
+++ b/kernel/fs/fat/file.cpp
@@ -148,8 +148,7 @@ error_t process_file_read_request(const Message& m,
 	// An empty file has no cluster chain to read; reply immediately so the
 	// requester does not block forever waiting for data that never arrives.
 	if (entry->file_size == 0 || entry->first_cluster() == 0) {
-		send_file_data(m.data.fs.request_id, nullptr, 0, m.sender, m.type,
-					   for_user);
+		send_file_data(m.data.fs.request_id, nullptr, 0, m.sender, m.type, for_user);
 		return OK;
 	}
 
@@ -193,11 +192,11 @@ void handle_get_file_info(const Message& m)
 	sm.data.fs.buf = nullptr;
 
 	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (ROOT_DIR[i].name[0] == 0x00) {
+		if (ROOT_DIR[i].name[0] == DIR_ENTRY_END) {
 			break;
 		}
 
-		if (ROOT_DIR[i].name[0] == 0xE5) {
+		if (ROOT_DIR[i].name[0] == DIR_ENTRY_DELETED) {
 			continue;
 		}
 
@@ -377,8 +376,7 @@ void handle_fs_write(const Message& m)
 			return;
 		}
 
-		entry->first_cluster_low = new_cluster & 0xFFFF;
-		entry->first_cluster_high = (new_cluster >> 16) & 0xFFFF;
+		entry->set_first_cluster(new_cluster);
 		write_fat_table_to_disk();
 	}
 
@@ -493,9 +491,8 @@ void handle_fs_write(const Message& m)
 			if (new_clusters < current_clusters) {
 				if (new_clusters == 0) {
 					// File is now empty, free all clusters
-					free_cluster_chain(entry->first_cluster(), 0);
-					entry->first_cluster_low = 0;
-					entry->first_cluster_high = 0;
+					free_cluster_chain(entry->first_cluster());
+					entry->set_first_cluster(0);
 				} else {
 					// Find the cluster that should be the last one
 					cluster_t current = entry->first_cluster();
@@ -508,7 +505,7 @@ void handle_fs_write(const Message& m)
 						// Free clusters after this one
 						cluster_t next = next_cluster(current);
 						if (next != END_OF_CLUSTER_CHAIN) {
-							free_cluster_chain(next, 0);
+							free_cluster_chain(next);
 							FAT_TABLE[current] = END_OF_CLUSTER_CHAIN;
 						}
 					}
@@ -518,7 +515,7 @@ void handle_fs_write(const Message& m)
 		}
 
 		entry->file_size = new_size;
-		update_directory_entry_on_disk(entry, fd->name);
+		persist_directory_entry(entry, fd->name);
 	}
 
 	// The FS_WRITE reply is sent from process_write_completion() once the

--- a/kernel/fs/fat/internal_common.hpp
+++ b/kernel/fs/fat/internal_common.hpp
@@ -29,6 +29,9 @@ extern std::queue<Message> pending_messages;
 // FAT table write optimization constants
 constexpr size_t FAT_WRITE_CHUNK_SIZE = 65536; // 64KB chunks for batch writes
 
+/// Space character used to right-pad the 8.3 short file name fields.
+constexpr char SFN_PAD = 0x20;
+
 // Change directory request tracking
 extern std::map<fs_id_t, ProcessId> change_dir_requests;
 extern std::map<fs_id_t, std::string> change_dir_names;
@@ -36,7 +39,6 @@ extern std::map<fs_id_t, std::string> parent_dir_names;
 extern fs_id_t next_change_dir_id;
 
 // Common utility functions
-std::vector<char*> parse_path(const char* path);
 void read_dir_entry_name_raw(const kernel::fs::DirectoryEntry& entry, char* dest);
 void read_dir_entry_name(const kernel::fs::DirectoryEntry& entry, char* dest);
 bool entry_name_is_equal(const kernel::fs::DirectoryEntry& entry, const char* name);
@@ -58,10 +60,8 @@ cluster_t allocate_cluster_chain(uint32_t* fat,
 								 size_t total_clusters,
 								 size_t num_clusters);
 cluster_t allocate_cluster_chain(size_t num_clusters);
-void free_cluster_chain(uint32_t* fat,
-						cluster_t start_cluster,
-						cluster_t keep_until_cluster = 0);
-void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster = 0);
+void free_cluster_chain(uint32_t* fat, cluster_t start_cluster);
+void free_cluster_chain(cluster_t start_cluster);
 size_t count_free_clusters(const uint32_t* fat, size_t total_clusters);
 size_t count_free_clusters();
 size_t total_fat_clusters();
@@ -92,8 +92,7 @@ void send_file_data(fs_id_t id,
 					bool for_user);
 
 // Directory entry persistence
-void update_directory_entry_on_disk(kernel::fs::DirectoryEntry* entry,
-									const char* name);
+void persist_directory_entry(kernel::fs::DirectoryEntry* entry, const char* name);
 
 // Message handlers declarations
 void handle_initialize(const Message& m);

--- a/kernel/fs/fat/utils.cpp
+++ b/kernel/fs/fat/utils.cpp
@@ -9,7 +9,6 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <vector>
 #include "fat.hpp"
 #include "graphics/log.hpp"
 #include "internal_common.hpp"
@@ -20,39 +19,6 @@
 namespace kernel::fs::fat
 {
 
-std::vector<char*> parse_path(const char* path)
-{
-	std::vector<char*> result;
-	if (path == nullptr) {
-		return result;
-	}
-
-	while (*path != '\0') {
-		while (*path == '/') {
-			++path;
-		}
-
-		if (*path == 0) {
-			break;
-		}
-
-		result.push_back(const_cast<char*>(path));
-
-		while (*path != '/' && *path != 0) {
-			++path;
-		}
-
-		if (*path == 0) {
-			break;
-		}
-
-		*const_cast<char*>(path) = 0;
-		++path;
-	}
-
-	return result;
-}
-
 void read_dir_entry_name_raw(const DirectoryEntry& entry, char* dest)
 {
 	char extension[5] = ".";
@@ -60,13 +26,13 @@ void read_dir_entry_name_raw(const DirectoryEntry& entry, char* dest)
 	memcpy(dest, &entry.name[0], 8);
 	dest[8] = 0;
 
-	for (int i = 7; i >= 0 && dest[i] == 0x20; i--) {
+	for (int i = 7; i >= 0 && dest[i] == SFN_PAD; i--) {
 		dest[i] = 0;
 	}
 
 	memcpy(extension + 1, &entry.name[8], 3);
 	extension[4] = 0;
-	for (int i = 2; i >= 0 && extension[i + 1] == 0x20; i--) {
+	for (int i = 2; i >= 0 && extension[i + 1] == SFN_PAD; i--) {
 		extension[i + 1] = 0;
 	}
 
@@ -111,7 +77,7 @@ unsigned int calc_start_sector(cluster_t cluster_id)
 cluster_t next_cluster(cluster_t cluster_id)
 {
 	const uint32_t next = FAT_TABLE[cluster_id];
-	if (next >= 0x0FFFFFF8UL) {
+	if (next >= FAT32_EOC_MIN) {
 		return END_OF_CLUSTER_CHAIN;
 	}
 
@@ -121,7 +87,7 @@ cluster_t next_cluster(cluster_t cluster_id)
 DirectoryEntry* find_dir_entry(DirectoryEntry* parent_dir, const char* name)
 {
 	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (parent_dir[i].name[0] == 0) {
+		if (parent_dir[i].name[0] == DIR_ENTRY_END) {
 			break;
 		}
 
@@ -140,7 +106,7 @@ DirectoryEntry* find_empty_dir_entry()
 	}
 
 	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (ROOT_DIR[i].name[0] == 0) {
+		if (ROOT_DIR[i].name[0] == DIR_ENTRY_END) {
 			return &ROOT_DIR[i];
 		}
 	}
@@ -159,7 +125,7 @@ size_t total_fat_clusters()
 			VOLUME_BPB->total_sectors_32 / VOLUME_BPB->sectors_per_cluster;
 
 	// Cluster numbers above 0x0FFFFFF7 are reserved in FAT32
-	return total_clusters < 0x0FFFFFF8UL ? total_clusters : 0x0FFFFFF8UL;
+	return total_clusters < FAT32_EOC_MIN ? total_clusters : FAT32_EOC_MIN;
 }
 
 cluster_t extend_cluster_chain(uint32_t* fat,
@@ -216,7 +182,7 @@ cluster_t allocate_cluster_chain(uint32_t* fat,
 		if (extend_cluster_chain(fat, total_clusters, first_cluster,
 								 num_clusters - 1) == 0) {
 			// Roll back the partially allocated chain
-			free_cluster_chain(fat, first_cluster, 0);
+			free_cluster_chain(fat, first_cluster);
 			return 0;
 		}
 	}
@@ -247,50 +213,23 @@ size_t count_free_clusters()
 	return count_free_clusters(FAT_TABLE, total_fat_clusters());
 }
 
-void free_cluster_chain(uint32_t* fat,
-						cluster_t start_cluster,
-						cluster_t keep_until_cluster)
+void free_cluster_chain(uint32_t* fat, cluster_t start_cluster)
 {
-	if (start_cluster == 0 || start_cluster >= 0x0FFFFFF8UL) {
+	if (start_cluster == 0 || start_cluster >= FAT32_EOC_MIN) {
 		return;
 	}
 
 	cluster_t current = start_cluster;
-	bool found_keep_until = (keep_until_cluster == 0);
-
-	while (current != END_OF_CLUSTER_CHAIN && current < 0x0FFFFFF8UL) {
+	while (current != END_OF_CLUSTER_CHAIN && current < FAT32_EOC_MIN) {
 		cluster_t next = fat[current];
-
-		if (current == keep_until_cluster) {
-			fat[current] = END_OF_CLUSTER_CHAIN;
-			found_keep_until = true;
-			break;
-		}
-
-		if (found_keep_until) {
-			fat[current] = 0;
-		}
-
+		fat[current] = 0;
 		current = next;
-	}
-
-	// If keep_until_cluster was not found, free entire chain
-	if (!found_keep_until && keep_until_cluster != 0) {
-		LOG_INFO("keep_until_cluster {} not found in chain starting at {}",
-				 keep_until_cluster, start_cluster);
-		// Free entire chain
-		current = start_cluster;
-		while (current != END_OF_CLUSTER_CHAIN && current < 0x0FFFFFF8UL) {
-			cluster_t next = fat[current];
-			fat[current] = 0;
-			current = next;
-		}
 	}
 }
 
-void free_cluster_chain(cluster_t start_cluster, cluster_t keep_until_cluster)
+void free_cluster_chain(cluster_t start_cluster)
 {
-	free_cluster_chain(FAT_TABLE, start_cluster, keep_until_cluster);
+	free_cluster_chain(FAT_TABLE, start_cluster);
 }
 
 void send_read_req_to_blk_device(unsigned int sector,

--- a/kernel/fs/file_descriptor.cpp
+++ b/kernel/fs/file_descriptor.cpp
@@ -78,7 +78,7 @@ FileDescriptor* get_process_fd(FileDescriptor* fd_table, size_t table_size, fd_t
 	}
 
 	if (fd_table[fd].is_unused()) {
-		LOG_ERROR("fd: %d", fd);
+		LOG_ERROR("fd %d is not in use", fd);
 		return nullptr;
 	}
 


### PR DESCRIPTION
## 概要
issue #338 (Tier 1) のうち `kernel/fs/` 領域のリファクタリングを実施。挙動変更なし(ログ文言・コメントの是正を除く)。

## 変更内容

### 1. FAT 仕様値の定数化 (`fat.hpp` / `internal_common.hpp`)
- EOC 判定閾値 `0x0FFFFFF8UL`(utils.cpp 5箇所)→ `FAT32_EOC_MIN`(`fat.hpp` に `END_OF_CLUSTER_CHAIN` との関係をコメントで明記)
- ディレクトリエントリ先頭バイト `0x00`(終端)/`0xE5`(削除済み)→ `DIR_ENTRY_END` / `DIR_ENTRY_DELETED`(`==0x00` と `==0` の表記揺れも統一、utils.cpp/directory.cpp/file.cpp 計7箇所)
- `first_cluster_low`/`first_cluster_high` への分割代入(file.cpp:380-381 ほか)→ `CLUSTER_LOW_MASK`/`CLUSTER_HIGH_SHIFT` 定数 + `DirectoryEntry::set_first_cluster()`(既存の `first_cluster()` getter に対応する setter)
- SFN パディングの空白 `0x20`(utils.cpp 2箇所)→ `SFN_PAD` 定数

### 2. `parse_path` の削除 (`utils.cpp` / `internal_common.hpp`)
呼び出し元ゼロ(grep で確認済み)の `const_cast` 破壊関数を削除。使われなくなった `#include <vector>` も除去。

### 3. `free_cluster_chain` の死分岐撤去 (`utils.cpp` / `internal_common.hpp`)
`keep_until_cluster` 引数は全呼び出し(file.cpp 2箇所、utils.cpp 1箇所)で `0` 固定だったため、引数ごと削除し「起点から全解放」の一本道に単純化。この引数が非ゼロの場合のみ到達する「見つからなかった場合のフォールバック」分岐(展開されない `{}` 書式の `LOG_INFO` を含む)は到達不能コードだったため、丸ごと削除。

### 4. `directory.cpp` の命名整理
2〜4通りの意味が同じ「update_/change_to_root」系プレフィックスに重なっていた関数を、役割が伝わる名前にリネーム(ロジックは無変更、名前と呼び出し箇所のみ変更):
- `change_to_root_directory`(状態のみ)→ `set_fs_path_to_root`
- `change_to_root`(状態+返信)→ `handle_change_to_root`(兄弟の `handle_parent_directory_change` 等と統一)
- `update_directory_entry`(current_dir ポインタ差替)→ `set_fs_path_current_dir`
- `update_directory_entry_on_disk`(ディスク書込)→ `persist_directory_entry`
- `update_directory_path_from_parent` → `set_fs_path_to_parent`
- `update_directory_path_append` → `set_fs_path_to_child`

`set_fs_path_to_{root,parent,child}` の3つは同じ命名パターンに揃え、`t->fs_path` のどのケースを更新するかが名前から分かるようにした。判断に迷う項目ではなかったため実装済みだが、命名方針に異論があればご指摘ください。

### 5. コメント・ログの陳腐化修正
- `persist_directory_entry`(旧 `update_directory_entry_on_disk`)末尾のコメントが「書き込み完了時に解放される」と「TODO: 未実装」を併記しており矛盾していた。実際には `write_buffer` は virtio_blk 側の `IPC_WRITE_TO_BLK_DEVICE` ハンドラが書き込み完了時に解放している(`kernel/hardware/virtio/blk.cpp` の `handle_write_request` で確認)ため、実態に合わせて記述を修正。
- `file_descriptor.cpp` の `get_process_fd()` にあった `LOG_ERROR("fd: %d", fd)` は何が問題かを示していなかったため、`"fd %d is not in use"` に変更。

## スキップした項目
なし。実装項目5件すべて対応済み。

## 検証結果
- ビルド: `cmake -B build kernel && cmake --build build` → 成功(clang, 100%)
- Lint: `./lint.sh`(clang-tidy-18, リポジトリ全体)→ 警告0件
- 影響範囲は `kernel/fs/fat/{directory,file,utils}.cpp`, `kernel/fs/fat/{fat,internal_common}.hpp`, `kernel/fs/file_descriptor.cpp` の6ファイルのみ。`kernel/tests/test_cases/fs_test.cpp` は無変更(既存テストが参照する `END_OF_CLUSTER_CHAIN` 等は非破壊)。

Refs #338(Tier 1 の fs 領域)

🤖 Generated with [Claude Code](https://claude.com/claude-code)