### PR TITLE
refactor(memory): constant-ize magic numbers, drop dead code in kernel/memory

### DIFF
--- a/kernel/memory/bootstrap_allocator.cpp
+++ b/kernel/memory/bootstrap_allocator.cpp
@@ -12,20 +12,19 @@
 namespace kernel::memory
 {
 
-BootstrapAllocator::BootstrapAllocator()
-	: bitmap_{}, memory_start_{ 0x0 }, memory_end_{ 0x0 }
+BootstrapAllocator::BootstrapAllocator() : bitmap_{}, memory_end_{ 0x0 }
 {
 	bitmap_.fill(ULONG_MAX);
 }
 
 void* BootstrapAllocator::allocate(size_t size)
 {
-	const size_t num_pages = (size + PAGE_SIZE - 1) / PAGE_SIZE;
+	const size_t num_pages = pages_for_bytes(size);
 
 	size_t consecutive_start_index = 0;
 	size_t num_consecutive_pages = 0;
 
-	for (size_t i = start_index(); i < end_index(); i++) {
+	for (size_t i = 0; i < end_index(); i++) {
 		if (is_bit_set(i)) {
 			num_consecutive_pages = 0;
 			continue;
@@ -43,8 +42,7 @@ void* BootstrapAllocator::allocate(size_t size)
 				bitmap_[j / BITMAP_ENTRY_SIZE] |= 1UL << (j % BITMAP_ENTRY_SIZE);
 			}
 
-			return reinterpret_cast<void*>(consecutive_start_index *
-										   kernel::memory::PAGE_SIZE);
+			return reinterpret_cast<void*>(consecutive_start_index * PAGE_SIZE);
 		}
 	}
 
@@ -55,9 +53,8 @@ void* BootstrapAllocator::allocate(size_t size)
 
 void BootstrapAllocator::free(void* addr, size_t size)
 {
-	auto start = reinterpret_cast<uintptr_t>(addr) / kernel::memory::PAGE_SIZE;
-	auto end =
-			(reinterpret_cast<uintptr_t>(addr) + size) / kernel::memory::PAGE_SIZE;
+	auto start = reinterpret_cast<uintptr_t>(addr) / PAGE_SIZE;
+	auto end = (reinterpret_cast<uintptr_t>(addr) + size) / PAGE_SIZE;
 
 	for (auto i = start; i < end; i++) {
 		bitmap_[i / BITMAP_ENTRY_SIZE] &= ~(1UL << (i % BITMAP_ENTRY_SIZE));
@@ -66,32 +63,29 @@ void BootstrapAllocator::free(void* addr, size_t size)
 
 void BootstrapAllocator::mark_available(void* addr, size_t size)
 {
-	auto start = reinterpret_cast<uintptr_t>(addr) / kernel::memory::PAGE_SIZE;
-	auto end =
-			(reinterpret_cast<uintptr_t>(addr) + size) / kernel::memory::PAGE_SIZE;
+	auto start = reinterpret_cast<uintptr_t>(addr) / PAGE_SIZE;
+	auto end = (reinterpret_cast<uintptr_t>(addr) + size) / PAGE_SIZE;
 
 	for (auto i = start; i < end; i++) {
 		bitmap_[i / BITMAP_ENTRY_SIZE] &= ~(1UL << (i % BITMAP_ENTRY_SIZE));
 	}
 
-	memory_end_ = std::max(memory_end_,
-						   reinterpret_cast<void*>(end * kernel::memory::PAGE_SIZE));
+	memory_end_ = std::max(memory_end_, reinterpret_cast<void*>(end * PAGE_SIZE));
 }
 
 void BootstrapAllocator::show_available_memory() const
 {
 	size_t available_pages = 0;
 
-	for (size_t i = start_index(); i < end_index(); i++) {
+	for (size_t i = 0; i < end_index(); i++) {
 		if (!is_bit_set(i)) {
 			available_pages++;
 		}
 	}
 
-	LOG_INFO(
-			"available memory: %u MiB / %u MiB",
-			available_pages * kernel::memory::PAGE_SIZE / 1024 / 1024,
-			(end_index() - start_index()) * kernel::memory::PAGE_SIZE / 1024 / 1024);
+	LOG_INFO("available memory: %u MiB / %u MiB",
+			 available_pages * PAGE_SIZE / 1024 / 1024,
+			 end_index() * PAGE_SIZE / 1024 / 1024);
 }
 
 alignas(BootstrapAllocator) char bootstrap_allocator_buffer[sizeof(
@@ -101,8 +95,7 @@ BootstrapAllocator* boot_allocator;
 void initialize(const MemoryMap& mem_map)
 {
 	LOG_INFO("Initializing bootstrap allocator...");
-	kernel::memory::boot_allocator = new (kernel::memory::bootstrap_allocator_buffer)
-			kernel::memory::BootstrapAllocator();
+	boot_allocator = new (bootstrap_allocator_buffer) BootstrapAllocator();
 
 	const auto mem_map_base = reinterpret_cast<uintptr_t>(mem_map.buffer);
 	const auto mem_map_end = mem_map_base + mem_map.map_size;
@@ -119,12 +112,11 @@ void initialize(const MemoryMap& mem_map)
 			continue;
 		}
 
-		kernel::memory::boot_allocator->mark_available(
-				reinterpret_cast<void*>(desc->physical_start),
-				desc->number_of_pages * kernel::memory::PAGE_SIZE);
+		boot_allocator->mark_available(reinterpret_cast<void*>(desc->physical_start),
+									   desc->number_of_pages * PAGE_SIZE);
 	}
 
-	kernel::memory::boot_allocator->show_available_memory();
+	boot_allocator->show_available_memory();
 
 	LOG_INFO("Bootstrap allocator initialized successfully.");
 }
@@ -135,9 +127,9 @@ void initialize_heap()
 {
 	// 128 MiB
 	const size_t heap_pages = 64UL * 512;
-	const size_t heap_size = heap_pages * kernel::memory::PAGE_SIZE;
+	const size_t heap_size = heap_pages * PAGE_SIZE;
 
-	auto* heap = kernel::memory::boot_allocator->allocate(heap_size);
+	auto* heap = boot_allocator->allocate(heap_size);
 	if (heap == nullptr) {
 		LOG_ERROR("failed to allocate heap");
 		return;
@@ -151,7 +143,7 @@ void release_bootstrap()
 {
 	// The allocator lives in a static buffer inside the kernel BSS, so its
 	// pages must never be handed to the buddy system; just drop the pointer.
-	kernel::memory::boot_allocator = nullptr;
+	boot_allocator = nullptr;
 
 	LOG_INFO("Bootstrap allocator released.");
 }

--- a/kernel/memory/bootstrap_allocator.hpp
+++ b/kernel/memory/bootstrap_allocator.hpp
@@ -32,11 +32,6 @@ public:
 			   0U;
 	}
 
-	size_t start_index() const
-	{
-		return reinterpret_cast<uintptr_t>(memory_start_) / PAGE_SIZE;
-	}
-
 	size_t end_index() const
 	{
 		return reinterpret_cast<uintptr_t>(memory_end_) / PAGE_SIZE;
@@ -44,7 +39,7 @@ public:
 
 private:
 	std::array<unsigned long, TOTAL_PAGES / BITMAP_ENTRY_SIZE> bitmap_;
-	void *memory_start_, *memory_end_;
+	void* memory_end_;
 };
 
 extern BootstrapAllocator* boot_allocator;

--- a/kernel/memory/buddy_system.cpp
+++ b/kernel/memory/buddy_system.cpp
@@ -31,7 +31,7 @@ void BuddySystem::split_memory_block(int order)
 	free_lists_[order].pop_front();
 
 	const int lower_order = order - 1;
-	const auto block_size = (1 << lower_order) * kernel::memory::PAGE_SIZE;
+	const auto block_size = (1 << lower_order) * PAGE_SIZE;
 
 	auto buddy_addr = reinterpret_cast<uintptr_t>(block->ptr()) ^ block_size;
 	auto* buddy_block = get_page(reinterpret_cast<void*>(buddy_addr));
@@ -42,8 +42,7 @@ void BuddySystem::split_memory_block(int order)
 
 void* BuddySystem::allocate(size_t size)
 {
-	const int order = calculate_order((size + kernel::memory::PAGE_SIZE - 1) /
-									  kernel::memory::PAGE_SIZE);
+	const int order = calculate_order(pages_for_bytes(size));
 	if (order == -1) {
 		LOG_ERROR("invalid size: %d", size);
 		return nullptr;
@@ -87,15 +86,13 @@ void* BuddySystem::allocate(size_t size)
 
 void BuddySystem::free(void* addr, size_t size)
 {
-	auto* start_page =
-			&pages[reinterpret_cast<uintptr_t>(addr) / kernel::memory::PAGE_SIZE];
+	auto* start_page = &pages[reinterpret_cast<uintptr_t>(addr) / PAGE_SIZE];
 	if (start_page->is_free()) {
 		LOG_ERROR("double free detected at address: %p", addr);
 		return;
 	}
 
-	int order = calculate_order((size + kernel::memory::PAGE_SIZE - 1) /
-								kernel::memory::PAGE_SIZE);
+	int order = calculate_order(pages_for_bytes(size));
 	if (order == -1) {
 		LOG_ERROR("invalid size: %d", size);
 		return;
@@ -113,7 +110,7 @@ void BuddySystem::free(void* addr, size_t size)
 		}
 
 		auto buddy_addr = reinterpret_cast<uintptr_t>(start_page->ptr()) ^
-						  (num_order_pages * kernel::memory::PAGE_SIZE);
+						  (num_order_pages * PAGE_SIZE);
 
 		Page* buddy_block = get_page(reinterpret_cast<void*>(buddy_addr));
 
@@ -157,14 +154,13 @@ void BuddySystem::register_memory_blocks(size_t num_total_pages, Page* start_pag
 
 	size_t order = calc_max_order_in_total_pages(num_total_pages);
 
-	const uintptr_t alignment_size = (1 << order) * kernel::memory::PAGE_SIZE;
+	const uintptr_t alignment_size = (1 << order) * PAGE_SIZE;
 	const uintptr_t page_addr = reinterpret_cast<uintptr_t>(start_page->ptr());
 	if ((page_addr % alignment_size) != 0) {
 		const auto aligned_addr =
 				static_cast<uintptr_t>(align_up(page_addr, alignment_size));
 
-		const size_t num_rounded_up_pages =
-				(aligned_addr - page_addr) / kernel::memory::PAGE_SIZE;
+		const size_t num_rounded_up_pages = (aligned_addr - page_addr) / PAGE_SIZE;
 		if ((num_total_pages - num_rounded_up_pages) < (1 << order)) {
 			--order;
 		}

--- a/kernel/memory/buddy_system.hpp
+++ b/kernel/memory/buddy_system.hpp
@@ -29,36 +29,38 @@ public:
 	BuddySystem() = default;
 
 	/**
-	 * \brief Allocates memory of the specified size using the buddy system.
+	 * @brief Allocates memory of the specified size using the buddy system.
 	 *
 	 * This function attempts to find a block of memory of the requested size.
 	 * If no block of the exact size is available, it tries to split a larger block
 	 * until a block of the desired size is available.
 	 *
-	 * \param size The amount of memory to allocate in bytes.
-	 * \return A pointer to the allocated memory, or nullptr if the allocation
+	 * @param size The amount of memory to allocate in bytes.
+	 * @return A pointer to the allocated memory, or nullptr if the allocation
 	 * failed.
 	 */
 	void* allocate(size_t size);
 
 	/**
-	 * \brief Frees a block of memory allocated by the buddy system.
+	 * @brief Frees a block of memory allocated by the buddy system.
 	 *
 	 * This function frees a block of memory allocated by the buddy system. The
 	 * block is added to the appropriate free list for future allocations.
 	 *
-	 * \param addr A pointer to the memory to be freed.
+	 * @param addr A pointer to the memory to be freed.
+	 * @param size Size in bytes of the block being freed (must match the size
+	 * originally passed to allocate()).
 	 */
 	void free(void* addr, size_t size);
 
 	/**
-	 * \brief Registers a block of memory pages with the buddy system.
+	 * @brief Registers a block of memory pages with the buddy system.
 	 *
 	 * This function divides the given memory into appropriate order blocks
 	 * and adds them to the system's free lists for future allocations.
 	 *
-	 * \param num_consecutive_pages The number of memory pages in the block.
-	 * \param start_page The starting address of the memory block.
+	 * @param num_total_pages The number of memory pages in the block.
+	 * @param start_page The starting address of the memory block.
 	 */
 	void register_memory_blocks(size_t num_total_pages, Page* start_page);
 
@@ -66,26 +68,26 @@ public:
 
 private:
 	/**
-	 * \brief Splits a memory block of the given order into two smaller blocks.
+	 * @brief Splits a memory block of the given order into two smaller blocks.
 	 *
 	 * This function is used in the buddy memory allocation system to split
 	 * larger blocks of memory into two smaller, equally-sized blocks when no
 	 * blocks of the desired size are available.
 	 *
-	 * \param order The order of the memory block to be split.
+	 * @param order The order of the memory block to be split.
 	 */
 	void split_memory_block(int order);
 
 	/**
-	 * \brief Calculates the order of a memory block of the given size.
+	 * @brief Calculates the order of a memory block of the given size.
 	 *
 	 * This function calculates the order of a memory block of the given size.
 	 * The order is the power of two that is equal to or greater than the size.
 	 * -1 is returned if the size is too large to be allocated by the buddy
 	 * system.
 	 *
-	 * \param num_pages The number of pages of the memory block.
-	 * \return The order of the memory block, or -1 if num_pages is 0 or
+	 * @param num_pages The number of pages of the memory block.
+	 * @return The order of the memory block, or -1 if num_pages is 0 or
 	 * exceeds the largest block the buddy system can manage.
 	 */
 

--- a/kernel/memory/page.cpp
+++ b/kernel/memory/page.cpp
@@ -11,19 +11,16 @@ std::vector<Page> pages;
 
 void initialize_pages()
 {
-	const size_t memory_start_index = boot_allocator->start_index();
 	const size_t memory_end_index = boot_allocator->end_index();
 
-	pages.resize(memory_end_index - memory_start_index);
+	pages.resize(memory_end_index);
 
-	for (size_t i = memory_start_index; i < memory_end_index; ++i) {
-		const size_t page_index = i - memory_start_index;
-
-		pages[page_index].set_ptr(reinterpret_cast<void*>(i * PAGE_SIZE));
+	for (size_t i = 0; i < memory_end_index; ++i) {
+		pages[i].set_ptr(reinterpret_cast<void*>(i * PAGE_SIZE));
 		if (boot_allocator->is_bit_set(i)) {
-			pages[page_index].set_used();
+			pages[i].set_used();
 		} else {
-			pages[page_index].set_free();
+			pages[i].set_free();
 		}
 	}
 }

--- a/kernel/memory/page.hpp
+++ b/kernel/memory/page.hpp
@@ -23,6 +23,23 @@ class MSlab;
 constexpr size_t PAGE_SIZE = 4096;
 
 /**
+ * @brief Bit shift equivalent to dividing/multiplying by PAGE_SIZE
+ */
+constexpr size_t PAGE_SHIFT = 12;
+
+static_assert(PAGE_SIZE == (1UL << PAGE_SHIFT), "PAGE_SHIFT must match PAGE_SIZE");
+
+/**
+ * @brief Round a byte size up to the number of PAGE_SIZE pages it needs
+ * @param size Size in bytes
+ * @return Number of pages (ceiling division by PAGE_SIZE)
+ */
+constexpr size_t pages_for_bytes(size_t size)
+{
+	return (size + PAGE_SIZE - 1) / PAGE_SIZE;
+}
+
+/**
  * @brief Represents a single memory page in the system
  *
  * This class manages individual pages of memory, tracking their allocation

--- a/kernel/memory/paging.cpp
+++ b/kernel/memory/paging.cpp
@@ -25,13 +25,13 @@ alignas(PAGE_SIZE)
 
 void setup_identity_mapping()
 {
-	pml4_table[0] = reinterpret_cast<uint64_t>(&pdp_table) | 0x003;
+	pml4_table[0] = reinterpret_cast<uint64_t>(&pdp_table) | PTE_KERNEL_FLAGS;
 	for (size_t i_pdpt = 0; i_pdpt < PAGE_DIRECTORY_COUNT; i_pdpt++) {
-		pdp_table[i_pdpt] =
-				reinterpret_cast<uint64_t>(&page_directory[i_pdpt]) | 0x003;
+		pdp_table[i_pdpt] = reinterpret_cast<uint64_t>(&page_directory[i_pdpt]) |
+							PTE_KERNEL_FLAGS;
 		for (size_t i_pd = 0; i_pd < 512; i_pd++) {
 			page_directory[i_pdpt][i_pd] =
-					i_pdpt * PAGE_1GIB + i_pd * PAGE_2MIB | 0x083;
+					i_pdpt * PAGE_1GIB + i_pd * PAGE_2MIB | PTE_KERNEL_HUGE_FLAGS;
 		}
 	}
 }
@@ -65,7 +65,7 @@ paddr_t get_paddr(page_table_entry* table, vaddr_t addr)
 		return paddr_t{ 0 };
 	}
 
-	return paddr_t{ pte->bits.address << 12 };
+	return paddr_t{ pte->bits.address << PAGE_SHIFT };
 }
 
 void dump_page_table(page_table_entry* table, int page_table_level, vaddr_t addr)
@@ -177,7 +177,7 @@ void setup_page_tables(vaddr_t addr, size_t num_pages, bool writable)
 	}
 
 	for (size_t i = 0; i < num_pages; i++) {
-		flush_tlb(addr.data + i * kernel::memory::PAGE_SIZE);
+		flush_tlb(addr.data + i * PAGE_SIZE);
 	}
 }
 
@@ -206,7 +206,7 @@ void clean_page_table(page_table_entry* table, int page_table_level)
 			// Intermediate tables are exclusively owned by this address
 			// space (clones deep-copy them), so always free them.
 			clean_page_table(entry.get_next_level_table(), page_table_level - 1);
-			kernel::memory::free(entry.get_next_level_table());
+			free(entry.get_next_level_table());
 			table[i].data = 0;
 			continue;
 		}
@@ -222,7 +222,7 @@ void clean_page_table(page_table_entry* table, int page_table_level)
 		Page* page = get_page(data_page);
 		if (page == nullptr || page->dec_ref() == 0) {
 			// Last reference (or untracked page): release it
-			kernel::memory::free(data_page);
+			free(data_page);
 		}
 		table[i].data = 0;
 	}
@@ -237,11 +237,11 @@ void clean_page_tables(page_table_entry* table)
 		}
 
 		clean_page_table(entry.get_next_level_table(), 3);
-		kernel::memory::free(entry.get_next_level_table());
+		free(entry.get_next_level_table());
 		table[i].data = 0;
 	}
 
-	kernel::memory::free(table);
+	free(table);
 }
 
 void copy_page_tables(page_table_entry* dst,
@@ -302,8 +302,8 @@ error_t copy_target_page(uint64_t addr)
 		return ERR_NO_MEMORY;
 	}
 
-	const auto aligned_addr = addr & ~0xfff;
-	memcpy(page, reinterpret_cast<void*>(aligned_addr), kernel::memory::PAGE_SIZE);
+	const auto aligned_addr = addr & ~(PAGE_SIZE - 1);
+	memcpy(page, reinterpret_cast<void*>(aligned_addr), PAGE_SIZE);
 
 	// This address space stops referencing the shared CoW page
 	void* shared_page = nullptr;
@@ -322,7 +322,7 @@ error_t copy_target_page(uint64_t addr)
 	if (shared_page != nullptr) {
 		Page* old_page = get_page(shared_page);
 		if (old_page == nullptr || old_page->dec_ref() == 0) {
-			kernel::memory::free(shared_page);
+			free(shared_page);
 		}
 	}
 
@@ -331,7 +331,8 @@ error_t copy_target_page(uint64_t addr)
 
 void copy_kernel_space(page_table_entry* dst)
 {
-	memcpy(dst, get_active_page_table(), 256 * sizeof(page_table_entry));
+	memcpy(dst, get_active_page_table(),
+		   USER_SPACE_START_INDEX * sizeof(page_table_entry));
 }
 
 page_table_entry* clone_page_table(page_table_entry* src, bool writable)
@@ -369,10 +370,10 @@ vaddr_t create_vaddr_from_index(int pml4_i, int pdpt_i, int pd_i, int pt_i)
 	vaddr_t addr;
 	addr.data = 0;
 
-	addr.set_part(4, pml4_i & 0x1FF);
-	addr.set_part(3, pdpt_i & 0x1FF);
-	addr.set_part(2, pd_i & 0x1FF);
-	addr.set_part(1, pt_i & 0x1FF);
+	addr.set_part(4, pml4_i & PT_INDEX_MASK);
+	addr.set_part(3, pdpt_i & PT_INDEX_MASK);
+	addr.set_part(2, pd_i & PT_INDEX_MASK);
+	addr.set_part(1, pt_i & PT_INDEX_MASK);
 
 	if ((addr.bits.page_map_level_4_index & 0x100) != 0) {
 		addr.bits.canonical = 0xFFFF;
@@ -413,7 +414,7 @@ error_t map_frame_to_vaddr(page_table_entry* table,
 					table[i + j].bits.writable = 0;
 					table[i + j].bits.user_accessible = 1;
 					table[i + j].bits.address =
-							(frame + j * kernel::memory::PAGE_SIZE) >> 12;
+							(frame + j * PAGE_SIZE) >> PAGE_SHIFT;
 
 					indices[4 - level] = i;
 
@@ -446,7 +447,7 @@ error_t map_frame_to_vaddr(page_table_entry* table,
 error_t unmap_frame(page_table_entry* table, vaddr_t addr, size_t num_pages)
 {
 	for (size_t i = 0; i < num_pages; i++) {
-		const vaddr_t target_addr{ addr.data + i * kernel::memory::PAGE_SIZE };
+		const vaddr_t target_addr{ addr.data + i * PAGE_SIZE };
 		auto* pte = get_pte(table, target_addr, 1);
 		if (pte == nullptr) {
 			return ERR_INVALID_ARG;
@@ -463,8 +464,8 @@ size_t calc_required_pages(vaddr_t start, size_t size)
 {
 	const vaddr_t end{ start.data + size };
 	const vaddr_t start_page{ start.data - start.part(0) };
-	const vaddr_t end_page{ end.data - end.part(0) + kernel::memory::PAGE_SIZE };
-	return (end_page.data - start_page.data) / kernel::memory::PAGE_SIZE;
+	const vaddr_t end_page{ end.data - end.part(0) + PAGE_SIZE };
+	return (end_page.data - start_page.data) / PAGE_SIZE;
 }
 
 void initialize_paging()

--- a/kernel/memory/paging.hpp
+++ b/kernel/memory/paging.hpp
@@ -16,6 +16,9 @@ namespace kernel::memory
 constexpr size_t USER_SPACE_START_INDEX = 256;
 constexpr size_t PT_ENTRIES = 512;
 
+/// Mask for a single 9-bit page-table level index (PT_ENTRIES - 1)
+constexpr int PT_INDEX_MASK = static_cast<int>(PT_ENTRIES) - 1;
+
 union vaddr_t {
 	uint64_t data;
 
@@ -69,6 +72,18 @@ union vaddr_t {
 		}
 	}
 };
+
+/// Present bit (bit 0): entry maps to a valid frame/table
+constexpr uint64_t PTE_PRESENT = 1ULL << 0;
+/// Writable bit (bit 1): entry permits writes
+constexpr uint64_t PTE_WRITABLE = 1ULL << 1;
+/// Huge-page bit (bit 7): leaf maps a large page instead of a sub-table
+constexpr uint64_t PTE_HUGE = 1ULL << 7;
+
+/// Flags for a kernel identity-mapped entry (present + writable)
+constexpr uint64_t PTE_KERNEL_FLAGS = PTE_PRESENT | PTE_WRITABLE;
+/// Flags for a kernel identity-mapped huge-page entry
+constexpr uint64_t PTE_KERNEL_HUGE_FLAGS = PTE_KERNEL_FLAGS | PTE_HUGE;
 
 union page_table_entry {
 	uint64_t data;

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -32,20 +32,15 @@ MCache* get_cache_in_chain(const char* name)
 }
 
 MCache::MCache(const char* name, size_t object_size)
-	: object_size_(object_size),
-	  num_active_objects_(0),
-	  num_total_objects_(0),
-	  num_active_slabs_(0),
-	  num_total_slabs_(0),
-	  num_pages_per_slab_(0)
+	: object_size_(object_size), num_pages_per_slab_(0)
 {
 	strncpy(name_, name, sizeof(name_) - 1);
 	name_[sizeof(name_) - 1] = '\0';
 
-	if (object_size <= kernel::memory::PAGE_SIZE) {
+	if (object_size <= PAGE_SIZE) {
 		num_pages_per_slab_ = 1;
 	} else {
-		num_pages_per_slab_ = object_size / kernel::memory::PAGE_SIZE;
+		num_pages_per_slab_ = object_size / PAGE_SIZE;
 	}
 }
 
@@ -69,15 +64,15 @@ MCache& m_cache_create(const char* name, size_t obj_size)
 		name = temp_name;
 	}
 
-	cache_chain.push_back(std::make_unique<kernel::memory::MCache>(name, obj_size));
+	cache_chain.push_back(std::make_unique<MCache>(name, obj_size));
 
 	return *cache_chain.back();
 }
 
 bool MCache::grow()
 {
-	size_t const bytes_per_slab = num_pages_per_slab_ * kernel::memory::PAGE_SIZE;
-	void* addr = kernel::memory::memory_manager->allocate(bytes_per_slab);
+	size_t const bytes_per_slab = num_pages_per_slab_ * PAGE_SIZE;
+	void* addr = memory_manager->allocate(bytes_per_slab);
 	if (addr == nullptr) {
 		LOG_ERROR("failed to allocate memory");
 		return false;
@@ -89,20 +84,16 @@ bool MCache::grow()
 	// Mark every page of the slab so that free() can resolve the owning
 	// cache/slab from any object address.
 	for (size_t i = 0; i < num_pages_per_slab_; ++i) {
-		Page* page = get_page(reinterpret_cast<char*>(addr) +
-							  i * kernel::memory::PAGE_SIZE);
+		Page* page = get_page(reinterpret_cast<char*>(addr) + i * PAGE_SIZE);
 		if (page == nullptr) {
 			LOG_ERROR("failed to look up page for slab at %p", addr);
-			kernel::memory::memory_manager->free(addr, bytes_per_slab);
+			memory_manager->free(addr, bytes_per_slab);
 			return false;
 		}
 
 		page->set_cache(this);
 		page->set_slab(slab.get());
 	}
-
-	++num_total_slabs_;
-	num_total_objects_ += num_objs;
 
 	slab->set_status(SlabStatus::FREE);
 	slabs_free_.push_back(std::move(slab));
@@ -122,8 +113,6 @@ void* MCache::alloc()
 
 		auto* free_slab = slabs_free_.front().get();
 		free_slab->move_list(*this, SlabStatus::PARTIAL);
-
-		++num_active_slabs_;
 	}
 
 	auto* current_slab = slabs_partial_.front().get();
@@ -134,7 +123,6 @@ void* MCache::alloc()
 		return nullptr;
 	}
 
-	++num_active_objects_;
 	if (current_slab->is_full()) {
 		auto* full_slab = slabs_partial_.front().get();
 		full_slab->move_list(*this, SlabStatus::FULL);
@@ -143,6 +131,24 @@ void* MCache::alloc()
 	return addr;
 }
 
+namespace
+{
+// Single lookup shared by both ends of the move in move_list(), instead of
+// two parallel switches over the same enum.
+std::list<std::unique_ptr<MSlab>>& slab_list_for(MCache& cache, SlabStatus status)
+{
+	switch (status) {
+		case SlabStatus::FREE:
+			return cache.slabs_free_;
+		case SlabStatus::PARTIAL:
+			return cache.slabs_partial_;
+		case SlabStatus::FULL:
+		default:
+			return cache.slabs_full_;
+	}
+}
+} // namespace
+
 void MSlab::move_list(MCache& cache, SlabStatus to)
 {
 	if (status_ == to) {
@@ -150,32 +156,11 @@ void MSlab::move_list(MCache& cache, SlabStatus to)
 	}
 
 	auto current_slab = std::move(*position_in_list_);
-	switch (status_) {
-		case SlabStatus::FREE:
-			cache.slabs_free_.erase(position_in_list_);
-			break;
-		case SlabStatus::PARTIAL:
-			cache.slabs_partial_.erase(position_in_list_);
-			break;
-		case SlabStatus::FULL:
-			cache.slabs_full_.erase(position_in_list_);
-			break;
-	}
+	slab_list_for(cache, status_).erase(position_in_list_);
 
-	switch (to) {
-		case SlabStatus::FREE:
-			cache.slabs_free_.push_back(std::move(current_slab));
-			position_in_list_ = std::prev(cache.slabs_free_.end());
-			break;
-		case SlabStatus::PARTIAL:
-			cache.slabs_partial_.push_back(std::move(current_slab));
-			position_in_list_ = std::prev(cache.slabs_partial_.end());
-			break;
-		case SlabStatus::FULL:
-			cache.slabs_full_.push_back(std::move(current_slab));
-			position_in_list_ = std::prev(cache.slabs_full_.end());
-			break;
-	}
+	auto& to_list = slab_list_for(cache, to);
+	to_list.push_back(std::move(current_slab));
+	position_in_list_ = std::prev(to_list.end());
 
 	status_ = to;
 }
@@ -243,12 +228,10 @@ bool MSlab::is_object_in_use(void* addr, size_t obj_size) const
 	return objects_[objs_index].is_in_use();
 }
 
-} // namespace kernel::memory
-
+// Table mapping an aligned allocation back to the raw slab object it was
+// carved from; only used on the non-heap-debug path (see alloc()/free()
+// below), where alignment padding must be undone before resolving the page.
 std::unordered_map<void*, void*> aligned_to_raw_addr_map;
-
-namespace kernel::memory
-{
 
 // Largest single allocation: the biggest block the buddy system can back
 // a slab with.
@@ -370,15 +353,12 @@ void free(void* addr)
 		return;
 	}
 
-	cache->decrease_num_active_objects();
-
 	if (slab->status() == SlabStatus::FULL) {
 		slab->move_list(*cache, SlabStatus::PARTIAL);
 	}
 
 	if (slab->is_empty()) {
 		slab->move_list(*cache, SlabStatus::FREE);
-		cache->decrease_num_active_slabs();
 	}
 }
 

--- a/kernel/memory/slab.hpp
+++ b/kernel/memory/slab.hpp
@@ -105,9 +105,6 @@ public:
 	char* name() { return name_; }
 	size_t object_size() const { return object_size_; }
 
-	void decrease_num_active_objects() { num_active_objects_--; }
-	void decrease_num_active_slabs() { num_active_slabs_--; }
-
 	bool grow();
 	void* alloc();
 
@@ -118,10 +115,6 @@ public:
 private:
 	char name_[20];
 	size_t object_size_;
-	size_t num_active_objects_;
-	size_t num_total_objects_;
-	size_t num_active_slabs_;
-	size_t num_total_slabs_;
 	size_t num_pages_per_slab_;
 };
 


### PR DESCRIPTION
## 変更内容

kernel/memory/ の可読性リファクタ(Tier 1)。挙動変更なし。

- **paging.cpp/hpp**: PTE フラグ・シフト・マスクの生値を定数化
  - `| 0x003` → `PTE_KERNEL_FLAGS`(`PTE_PRESENT | PTE_WRITABLE`)
  - `| 0x083` → `PTE_KERNEL_HUGE_FLAGS`(+ `PTE_HUGE`)
  - `<<12` / `>>12` → `PAGE_SHIFT`
  - `& ~0xfff` → `& ~(PAGE_SIZE - 1)`
  - `& 0x1FF` → `& PT_INDEX_MASK`
  - `256 * sizeof(page_table_entry)` → `USER_SPACE_START_INDEX * sizeof(...)`
- **slab.hpp/cpp**: 読み出し口が一つも無い死んだ集計フィールド(`num_active_objects_` 等 4 つ)と、それらを更新するだけだったメソッド・呼び出し箇所を削除
- **buddy_system.hpp**: `register_memory_blocks` の doc 引数名を実引数に合わせて修正、`free` の第 2 引数(`size`)の doc を追加、`\brief`/`\param`/`\return` を `@brief`/`@param`/`@return` に統一
- **page.hpp**: `pages_for_bytes(size)` ヘルパを追加し、`(size + PAGE_SIZE - 1) / PAGE_SIZE` の重複式を buddy_system.cpp・bootstrap_allocator.cpp で置換
- **bootstrap_allocator.hpp/cpp・paging.cpp・buddy_system.cpp・slab.cpp**: `namespace kernel::memory` ブロック内での冗長な `kernel::memory::` 自己修飾を削除
- **slab.cpp**: `move_list()` の SlabStatus→リスト対応の並行 switch 2 本を、1 本の switch を共有する `slab_list_for()` ヘルパに統合。ルート名前空間に浮いていた `aligned_to_raw_addr_map` を `kernel::memory` 名前空間内へ移動し、それによって 2 分割されていた namespace ブロックを 1 つに統合
- **bootstrap_allocator.hpp/cpp・page.cpp**: 常に 0 であることを grep で確認した `memory_start_` / `start_index()` を廃止し、絶対インデックス(0 始まり)に統一

## スキップした項目(理由)

- **`part`/`set_part` の level→ビットフィールド switch の表引き化**: ビットフィールドメンバへのポインタは C++ で禁止されており、`&Class::bitfield` は使えない。シフト/幅のテーブルを別途手で持たせる案はビット配置の定義をユニオンの宣言と二重管理することになり、シンプルさより複雑さが増すため現状維持
- **メモリ初期化 6 段の 1 関数への集約**: `kernel::tests::run_bootstrap_stage_tests()` が `initialize()` と `release_bootstrap()` の間で `boot_allocator` を直接使う制約が `kernel/tests/runner.hpp` に明記されている。`release_bootstrap()` は `boot_allocator` を nullptr にするため、テスト呼び出しをこの制約より後ろに動かすとヌルポインタ参照になる。呼び出し順を保ったまま 1 関数に畳むには memory→tests のコールバック依存を新設するしかなく、レイヤリング上望ましくないためスキップ

## 検証結果

- `cmake -B build kernel && cmake --build build`: 成功(警告 0)
- `./lint.sh`: 警告 0(変更した 5 つの .cpp ファイルを含め全体でクリーン)
- `userland/commands/ping/main.cpp` は変更していません

Refs #338(Tier 1 の memory 領域)

🤖 Generated with [Claude Code](https://claude.com/claude-code)