### PR TITLE
fix: defer scheduling start until after main-stage test suites

### DIFF
--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -70,5 +70,10 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	kernel::tests::run_main_stage_tests();
 
+	// Scheduling starts only after the test suites have finished: a timer
+	// interrupt switching to a service task mid-suite would pollute the
+	// leak accounting and race against half-initialized boot state.
+	kernel::task::start_scheduling();
+
 	kernel::task::kernel_service();
 }

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -357,9 +357,9 @@ void initialize()
 	IDLE_TASK = tasks[1];
 
 	CURRENT_TASK->state = TASK_RUNNING;
-
-	kernel::timers::ktimer->add_switch_task_event(200);
 }
+
+void start_scheduling() { kernel::timers::ktimer->add_switch_task_event(200); }
 
 Task::Task(int raw_id,
 		   const char* task_name,

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -19,6 +19,17 @@ namespace kernel::task
 
 void initialize();
 
+/**
+ * @brief Start preemptive scheduling by arming the switch-task timer
+ *
+ * Kept separate from initialize() so the boot flow controls exactly when
+ * task switching begins. The main-stage test suites run between the two:
+ * they must not be preempted, because a service task running mid-suite
+ * corrupts the per-suite leak accounting and can hit half-initialized
+ * state (this was a real CI flake, three failure modes from one race).
+ */
+void start_scheduling();
+
 enum TaskState : uint8_t { TASK_RUNNING, TASK_READY, TASK_WAITING, TASK_EXITED };
 
 static constexpr int MAX_FDS_PER_PROCESS = 32;
@@ -51,8 +62,7 @@ struct Task {
 	{
 		if (ctx.cr3 != 0) {
 			kernel::memory::clean_page_tables(
-					reinterpret_cast<kernel::memory::page_table_entry*>(
-							ctx.cr3));
+					reinterpret_cast<kernel::memory::page_table_entry*>(ctx.cr3));
 		}
 
 		kernel::memory::free(stack);

--- a/kernel/tests/test_cases/timer_test.cpp
+++ b/kernel/tests/test_cases/timer_test.cpp
@@ -23,6 +23,11 @@ void test_add_timer_event()
 	const uint64_t invalid_event_id = kernel::timers::ktimer->add_timer_event(
 			1000, TimeoutAction::SWITCH_TASK, ProcessId::from_raw(-1));
 	ASSERT_NE(invalid_event_id, 0);
+
+	// Leaving these queued would start task switching ~1s after the local
+	// APIC comes up, racing the boot flow and the main-stage suites.
+	kernel::timers::ktimer->remove_timer_event(event_id);
+	kernel::timers::ktimer->remove_timer_event(invalid_event_id);
 }
 
 void test_remove_timer_event()
@@ -54,6 +59,19 @@ void test_increment_tick()
 	kernel::timers::ktimer->remove_timer_event(id);
 }
 
+void test_removed_event_does_not_fire()
+{
+	auto id = kernel::timers::ktimer->add_switch_task_event(20); // 20ms
+	kernel::timers::ktimer->remove_timer_event(id);
+
+	bool need_switch = false;
+	for (int i = 0; i < 5; ++i) {
+		need_switch |= kernel::timers::ktimer->increment_tick();
+	}
+
+	ASSERT_FALSE(need_switch);
+}
+
 void test_tick_to_time()
 {
 	float time = kernel::timers::ktimer->tick_to_time(100);
@@ -69,5 +87,7 @@ void register_timer_tests()
 	test_register("timer_add_event", test_add_timer_event);
 	test_register("timer_remove_event", test_remove_timer_event);
 	test_register("timer_increment_tick", test_increment_tick);
+	test_register("timer_removed_event_does_not_fire",
+				  test_removed_event_does_not_fire);
 	test_register("timer_tick_to_time", test_tick_to_time);
 }

--- a/kernel/timers/timer.cpp
+++ b/kernel/timers/timer.cpp
@@ -99,6 +99,14 @@ bool KernelTimer::increment_tick()
 		auto e = events_.top();
 		events_.pop();
 
+		// Removal is lazy: remove_timer_event() only records the id, and the
+		// queued entry is discarded here when it expires. Checked before the
+		// SWITCH_TASK branch so a removed switch event neither switches nor
+		// re-arms itself.
+		if (ignore_events_.erase(e.id) > 0) {
+			continue;
+		}
+
 		if (e.action == TimeoutAction::SWITCH_TASK) {
 			need_switch_task = true;
 


### PR DESCRIPTION
## 問題

master を含む全ブランチの CI が非決定的に落ちる(#342/#343/#344 で顕在化、3 PR とも 3 様の落ち方)。原因を serial.log の比較調査で特定:

**`task::initialize()` 内でタスク切替タイマーを起動していたため、main-stage テスト実行中にタイマー割り込みでサービスタスク(xhci/virtio/fat32 等)が並走していた。**

master の「成功」ログにも証拠が毎回出ている:
- テストスイートの出力の間に `Initializing xHCI...` / `No virtio device found` が混入
- サービスタスクのデバイス不在パスが `heap-debug: invalid or double free` を 2 回発火(別 issue として起票)
- `message queue full: dest = 15` ×8

これがリークチェック(#321)と組み合わさり:
1. サービスタスクの確保がスイートの live_bytes 差分に乗る → 偶発的な `LEAK: suite leaked 48976 bytes`(#342/#343 の failed=1 の正体)
2. ブート途中の半初期化状態への割り込み → **カーネル無変更の #344 が LAPIC 初期化直後にトリプルフォールト**(qemu status 0)
3. 成否は TCG の実行速度(タイミング)の運任せ

## 修正

タイマー起動を `task::initialize()` から分離し、明示的な `task::start_scheduling()` として `run_main_stage_tests()` **完了後**に呼ぶ。

- ブート初期化とテストは無プリエンプションで決定的に走る
- KERNEL_TEST_EXIT(CI)ではスケジューリング開始前に exit するため、サービスタスクは一切走らない — ランナーのヘッダに書かれた契約(userland・デバイス不要)と完全に一致
- 対話ブートへの影響は「サービス起動がテスト完了後になる」だけ(従来も実質そうだったものが確実になる)

## 検証

- [x] ビルド成功・lint 警告ゼロ
- [ ] **本 PR の CI が green になること自体が修正の証明**(落ち方が 3 様だったため、決定化されれば再現しない)
- [ ] QEMU 実機での通常ブート確認(ユーザー確認をお願いします)

マージ後、#342/#343/#344 は rebase 不要で re-run すれば green になります(PR CI は merge ref で走るため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)