### PR TITLE
refactor: bind INITIAL_TASKS to SystemProcessId, move SECTOR_SIZE to libs/common, rename GetCode

### DIFF
--- a/kernel/fs/fat/fat.cpp
+++ b/kernel/fs/fat/fat.cpp
@@ -8,7 +8,6 @@
 #include <libs/common/types.hpp>
 #include <queue>
 #include "fs/file_info.hpp"
-#include "hardware/virtio/blk.hpp"
 #include "internal_common.hpp"
 #include "task/task.hpp"
 
@@ -23,7 +22,7 @@ void fat32_service()
 
 	init_read_contexts();
 
-	send_read_req_to_blk_device(BOOT_SECTOR, kernel::hw::virtio::SECTOR_SIZE,
+	send_read_req_to_blk_device(BOOT_SECTOR, SECTOR_SIZE,
 								MsgType::INITIALIZE_TASK);
 
 	// Register message handlers

--- a/kernel/fs/fat/init.cpp
+++ b/kernel/fs/fat/init.cpp
@@ -11,7 +11,6 @@
 #include <queue>
 #include "fat.hpp"
 #include "fs/path.hpp"
-#include "hardware/virtio/blk.hpp"
 #include "internal_common.hpp"
 #include "log/log.hpp"
 #include "memory/slab.hpp"
@@ -48,7 +47,7 @@ void handle_initialize(const Message& m)
 
 		const size_t table_size =
 				static_cast<size_t>(VOLUME_BPB->fat_size_32) *
-				static_cast<size_t>(kernel::hw::virtio::SECTOR_SIZE);
+				static_cast<size_t>(SECTOR_SIZE);
 
 		send_read_req_to_blk_device(FAT_TABLE_SECTOR, table_size,
 									MsgType::INITIALIZE_TASK);

--- a/kernel/graphics/color.cpp
+++ b/kernel/graphics/color.cpp
@@ -4,7 +4,7 @@
 namespace kernel::graphics
 {
 
-uint32_t Color::GetCode() const
+uint32_t Color::code() const
 {
 	uint32_t code = 0;
 	code += r_;

--- a/kernel/graphics/color.hpp
+++ b/kernel/graphics/color.hpp
@@ -46,7 +46,7 @@ public:
 	 *
 	 * @return uint32_t The 32-bit color code
 	 */
-	uint32_t GetCode() const;
+	uint32_t code() const;
 
 private:
 	uint8_t r_; ///< Red component (0-255)

--- a/kernel/graphics/log_sink.cpp
+++ b/kernel/graphics/log_sink.cpp
@@ -35,7 +35,7 @@ void advance_line()
 	// Erase whatever was on the line we are about to write
 	screen->fill_rectangle({ 0, kernel_cursor_y * GLYPH_HEIGHT },
 						   { screen->width(), GLYPH_HEIGHT },
-						   screen->bg_color().GetCode());
+						   screen->bg_color().code());
 }
 } // namespace
 

--- a/kernel/graphics/screen.cpp
+++ b/kernel/graphics/screen.cpp
@@ -53,7 +53,7 @@ void initialize(const FrameBufferConf& frame_buffer_conf, Color bg_color)
 	kscreen = new (screen_buffer) Screen{ frame_buffer_conf, bg_color };
 
 	kscreen->fill_rectangle(Point2D{ 0, 0 }, kscreen->size(),
-							kscreen->bg_color().GetCode());
+							kscreen->bg_color().code());
 
 	// From here on log lines can be drawn; everything logged before this
 	// point exists on the serial console only.

--- a/kernel/hardware/virtio/blk.cpp
+++ b/kernel/hardware/virtio/blk.cpp
@@ -65,8 +65,8 @@ void handle_write_request(const Message& m)
 	Message reply = make_blk_reply(m);
 
 	const int sector = m.data.blk_io.sector;
-	const int len = m.data.blk_io.len < kernel::hw::virtio::SECTOR_SIZE
-							? kernel::hw::virtio::SECTOR_SIZE
+	const int len = m.data.blk_io.len < SECTOR_SIZE
+							? SECTOR_SIZE
 							: m.data.blk_io.len;
 
 	const error_t err = kernel::hw::virtio::write_to_blk_device(

--- a/kernel/hardware/virtio/blk.hpp
+++ b/kernel/hardware/virtio/blk.hpp
@@ -78,11 +78,6 @@ constexpr int VIRTIO_BLK_S_UNSUPP = 2; ///< Request not supported
 /** @} */
 
 /**
- * @brief Standard sector size in bytes
- */
-constexpr size_t SECTOR_SIZE = 512;
-
-/**
  * @struct VirtioBlkReq
  * @brief VirtIO Block Request Structure
  *

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -34,24 +34,37 @@ std::array<Task*, MAX_TASKS> tasks;
 Task* CURRENT_TASK = nullptr;
 Task* IDLE_TASK = nullptr;
 
-const InitialTaskInfo INITIAL_TASKS[] = {
-	{ "main", 0, false, true },
-	{ "idle", reinterpret_cast<uint64_t>(&kernel::task::idle_service), true, true },
-	{ "usb_handler", reinterpret_cast<uint64_t>(&kernel::task::usb_handler_service),
+constexpr InitialTaskInfo INITIAL_TASKS[] = {
+	{ SystemProcessId::KERNEL, "main", nullptr, false, true },
+	{ SystemProcessId::IDLE, "idle", &kernel::task::idle_service, true, true },
+	{ SystemProcessId::XHCI, "usb_handler", &kernel::task::usb_handler_service,
 	  true, true },
-	{ "virtio_blk",
-	  reinterpret_cast<uint64_t>(&kernel::hw::virtio::virtio_blk_service), true,
+	{ SystemProcessId::VIRTIO_BLK, "virtio_blk",
+	  &kernel::hw::virtio::virtio_blk_service, true, false },
+	{ SystemProcessId::FS_FAT32, "fat32", &kernel::fs::fat32_service, true, true },
+	{ SystemProcessId::SHELL, "shell", &kernel::task::shell_service, true, false },
+	{ SystemProcessId::VIRTIO_NET, "virtio_net",
+	  &kernel::hw::virtio::virtio_net_service, true, false },
+	{ SystemProcessId::NET, "net", &kernel::net::packet_handler_service, true,
 	  false },
-	{ "fat32", reinterpret_cast<uint64_t>(&kernel::fs::fat32_service), true, true },
-	{ "shell", reinterpret_cast<uint64_t>(&kernel::task::shell_service), true,
-	  false },
-	{ "virtio_net",
-	  reinterpret_cast<uint64_t>(&kernel::hw::virtio::virtio_net_service), true,
-	  false },
-	{ "net", reinterpret_cast<uint64_t>(&kernel::net::packet_handler_service), true,
-	  false },
-
 };
+
+namespace
+{
+// create_task() hands out slots in ascending order, so each entry's declared
+// SystemProcessId only holds if the array is ordered by those ids with no gap.
+constexpr bool initial_tasks_match_their_slots()
+{
+	for (size_t i = 0; i < sizeof(INITIAL_TASKS) / sizeof(INITIAL_TASKS[0]); ++i) {
+		if (static_cast<pid_t>(INITIAL_TASKS[i].id) != static_cast<pid_t>(i)) {
+			return false;
+		}
+	}
+	return true;
+}
+static_assert(initial_tasks_match_their_slots(),
+			  "INITIAL_TASKS must be ordered by SystemProcessId, gap-free");
+} // namespace
 
 ProcessId get_available_task_id()
 {
@@ -346,15 +359,16 @@ void initialize()
 	list_init(&run_queue);
 
 	for (const auto& t_info : INITIAL_TASKS) {
-		Task* new_task = create_task(t_info.name, t_info.addr, t_info.setup_context,
-									 t_info.is_initialized);
+		Task* new_task =
+				create_task(t_info.name, reinterpret_cast<uint64_t>(t_info.entry),
+							t_info.setup_context, t_info.is_initialized);
 		if (new_task != nullptr) {
 			schedule_task(new_task->id);
 		}
 	}
 
-	CURRENT_TASK = tasks[0];
-	IDLE_TASK = tasks[1];
+	CURRENT_TASK = tasks[process_ids::KERNEL.raw()];
+	IDLE_TASK = tasks[process_ids::IDLE.raw()];
 
 	CURRENT_TASK->state = TASK_RUNNING;
 }

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -90,8 +90,9 @@ struct Task {
 };
 
 struct InitialTaskInfo {
+	SystemProcessId id; ///< tasks[] slot this entry must land in (asserted)
 	const char* name;
-	uint64_t addr;
+	void (*entry)(); ///< Service entry point, nullptr for the boot task
 	bool setup_context;
 	bool is_initialized;
 };

--- a/libs/common/message.hpp
+++ b/libs/common/message.hpp
@@ -11,6 +11,10 @@
 constexpr int IPC_RECV = 0;
 constexpr int IPC_SEND = 1;
 
+// Sector size of the block-device IPC contract: blk_io.sector is expressed in
+// this unit and blk_io.len is expected to be a multiple of it.
+constexpr size_t SECTOR_SIZE = 512;
+
 enum class MsgType : int32_t {
 	NO_TASK = -1,
 	NOTIFY_KEY_INPUT,


### PR DESCRIPTION
Refs #338(Tier 2 の残り 2 点 + #352 から持ち越した改名 1 点)。これで #338 の Wave 1 対象は完了。**挙動変更なし**。

## 変更内容

1. **INITIAL_TASKS ↔ SystemProcessId の束縛**(task.hpp/task.cpp)
   - 各エントリに `SystemProcessId` を明示フィールドで持たせ、`static_assert` で「配列順 = enum 値・欠番なし」の不変条件を固定(create_task はスロットを昇順に払い出すため、これまで並び順が暗黙の意味を持っていた)
   - `static_assert` を効かせるためエントリポイントを事前 `reinterpret_cast` 済み `uint64_t` から型付き関数ポインタに変更し、テーブルを `constexpr` 化(キャストは使用点の 1 箇所へ)
   - `CURRENT_TASK = tasks[0]` / `IDLE_TASK = tasks[1]` の添字直書きを `process_ids::KERNEL` / `IDLE` 参照に
2. **SECTOR_SIZE を libs/common/message.hpp へ移動**
   - fs → hardware の include 2 本(fat.cpp / init.cpp)の実体はこの 1 定数のみだった。blk_io IPC ペイロードの契約値なので、その定義の隣へ移動
   - **これで `kernel/fs/` から `hardware/` への include は 0 本**(2026-07-19 構造分析の目標達成)
3. **`Color::GetCode()` → `code()`**(#352 で log.cpp が #342 と衝突するためスキップした持ち越し分)

## 検証

- [x] 触った全ファイルの構文チェック(ホスト clang -fsyntax-only)
- [x] `rg '#include "hardware/' kernel/fs/` が 0 件、`rg GetCode` が 0 件
- [ ] CI(ビルド + QEMU ヘッドレステスト + clang-tidy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)