### PR TITLE
refactor: fold post-bootstrap memory init into initialize_allocators()

### DIFF
--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -3,11 +3,8 @@
 #include "hardware/serial.hpp"
 #include "interrupt/idt.hpp"
 #include "memory/bootstrap_allocator.hpp"
-#include "memory/buddy_system.hpp"
-#include "memory/page.hpp"
 #include "memory/paging.hpp"
 #include "memory/segment.hpp"
-#include "memory/slab.hpp"
 #include "syscall/syscall.hpp"
 #include "task/builtin.hpp"
 #include "task/task.hpp"
@@ -44,15 +41,7 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	kernel::tests::run_bootstrap_stage_tests();
 
-	kernel::memory::initialize_heap();
-
-	kernel::memory::initialize_pages();
-
-	kernel::memory::initialize_memory_manager();
-
-	kernel::memory::release_bootstrap();
-
-	kernel::memory::initialize_slab_allocator();
+	kernel::memory::initialize_allocators();
 
 	kernel::memory::initialize_tss();
 

--- a/kernel/memory/bootstrap_allocator.cpp
+++ b/kernel/memory/bootstrap_allocator.cpp
@@ -5,7 +5,9 @@
 #include <cstdint>
 #include "../../UchLoaderPkg/memory_map.hpp"
 #include "log/log.hpp"
+#include "memory/buddy_system.hpp"
 #include "memory/page.hpp"
+#include "memory/slab.hpp"
 
 #include <sys/types.h>
 
@@ -146,6 +148,19 @@ void release_bootstrap()
 	boot_allocator = nullptr;
 
 	LOG_INFO("Bootstrap allocator released.");
+}
+
+void initialize_allocators()
+{
+	// Order matters: the heap is carved out while the bootstrap allocator is
+	// still alive, page metadata must exist before the buddy system indexes
+	// it, and the bootstrap allocator is retired only once the buddy system
+	// can serve allocations. The slab allocator sits on top of buddy pages.
+	initialize_heap();
+	initialize_pages();
+	initialize_memory_manager();
+	release_bootstrap();
+	initialize_slab_allocator();
 }
 
 } // namespace kernel::memory

--- a/kernel/memory/bootstrap_allocator.hpp
+++ b/kernel/memory/bootstrap_allocator.hpp
@@ -54,6 +54,17 @@ void initialize(const MemoryMap& mem_map);
 void initialize_heap();
 
 /**
+ * @brief Bring up every post-bootstrap allocator in its required order
+ *
+ * Runs heap reservation, page metadata, the buddy system, bootstrap
+ * retirement and the slab allocator as one step, so the order dependency
+ * lives here instead of in the boot flow. Call once, after initialize()
+ * (and the bootstrap-stage tests, which exercise the bootstrap allocator
+ * before it is retired).
+ */
+void initialize_allocators();
+
+/**
  * @brief Retire the bootstrap allocator once the buddy system is up
  * @note Only drops the global pointer. The allocator's static BSS buffer
  * must never be freed into the buddy system.


### PR DESCRIPTION
Refs #312(Wave 1 の最終残項目「メモリ初期化 6 段の集約」)。**挙動変更なし**(呼び出し順は完全に同一)。

## 変更内容

- `kernel::memory::initialize_allocators()` を新設(bootstrap_allocator.cpp — 6 段中 3 段の持ち主)し、`initialize_heap` → `initialize_pages` → `initialize_memory_manager` → `release_bootstrap` → `initialize_slab_allocator` の順序依存を関数内に内在化(順序の理由をコメントで明記)
- `kernel/main.cpp` のブートフローは `memory::initialize(memory_map)`(bootstrap allocator)と `initialize_allocators()` の 2 呼び出しに簡約。bootstrap 段だけ分離しているのは **bootstrap ステージテストが 2 つの間で走る**ため(doc に明記)
- main.cpp の不要になった memory 系 include 3 本を削除

## 検証

- [x] 触ったファイルの構文チェック(ホスト clang -fsyntax-only)
- [x] CI(ビルド + QEMU ヘッドレステスト + clang-tidy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)