### PR TITLE
RAII によるカーネル内所有権規約(unique_kbuf ヘルパ)

### DIFF
--- a/.claude/rules/kernel.md
+++ b/.claude/rules/kernel.md
@@ -12,6 +12,13 @@ paths:
 - **カーネルヒープ**: slab allocator の `alloc(size, flags)` / `free(addr)`(`kernel/memory/slab.hpp`)
 - 確保結果は必ず nullptr チェックすること
 
+## ヒープ所有権(RAII 必須)
+- **新規・変更コードでは、所有権を持つ生ポインタ + 手動 `free()` を禁止**。所有権は `kernel::memory::unique_kbuf<T>` / `make_kbuf()`(または `std::unique_ptr`)で表現する(`kernel/memory/slab.hpp`)
+- IPC などで所有権を手放す境界では `.release()` を明示的に呼ぶ。借用(見るだけ)は `.get()` を渡す
+- `unique_kbuf` はデストラクタを呼ばず `free()` するだけ。生バッファか trivially destructible な型にのみ使う
+- `enter_user_mode` / `exec_elf` など**戻らない呼び出しの前**ではスコープ終端に到達しないため、事前に `.reset()` か `.release()` で決着させる
+- 既存コードの一括書き換えはしない。ファイルを触るタイミングで段階的に移行する(issue #322)
+
 ## エラーハンドリング
 - panic は最終手段。リソース枯渇などは `LOG_ERROR` でログを出しエラーを返す
 - ログは `kernel/log/log.hpp` の `LOG_DEBUG` / `LOG_INFO` / `LOG_ERROR`(printf 形式)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,9 @@ cd userland/commands/[コマンド名] && make clean && make
 | クラス・構造体・列挙型 | PascalCase | `PageTable`, `VirtioBlkReq` |
 | マクロ・定数 | ALL_CAPS | `KERNEL_VIRTUAL_BASE` |
 
+### ヒープ所有権(カーネル)
+新規・変更コードでは所有権を持つ生ポインタ + 手動 `free()` を禁止。`kernel::memory::unique_kbuf` / `make_kbuf()`(`kernel/memory/slab.hpp`)で RAII 管理し、IPC 等の所有権移転境界のみ `.release()` を明示する(詳細は `.claude/rules/kernel.md`)。
+
 ### エラーハンドリング
 カーネル内では panic よりログを優先する(`kernel/log/log.hpp`、printf 形式):
 

--- a/kernel/fs/fat/file.cpp
+++ b/kernel/fs/fat/file.cpp
@@ -84,26 +84,24 @@ void process_write_completion(const Message& m)
 
 error_t process_read_data_response(const Message& m, bool for_user)
 {
+	// Take ownership of the block device buffer once; it is freed
+	// automatically on every return path below.
+	kernel::memory::unique_kbuf<> buf{ m.data.blk_io.buf };
+
 	auto it = file_caches.find(m.data.blk_io.request_id);
 	if (it == file_caches.end()) {
 		LOG_ERROR("request id not found: %lu", m.data.blk_io.request_id);
-		if (m.data.blk_io.buf != nullptr) {
-			kernel::memory::free(m.data.blk_io.buf);
-		}
 		return ERR_INVALID_ARG;
 	}
 
 	auto& ctx = it->second;
 
-	if (IS_ERR(m.data.blk_io.result) || m.data.blk_io.buf == nullptr) {
+	if (IS_ERR(m.data.blk_io.result) || buf == nullptr) {
 		// Device read failed: release the requester with an error reply and
 		// drop the partially filled cache so it never serves stale data.
 		LOG_ERROR("block read failed: result=%d sector=%u", m.data.blk_io.result,
 				  m.data.blk_io.sector);
 		send_empty_reply(m.type, ctx.requester);
-		if (m.data.blk_io.buf != nullptr) {
-			kernel::memory::free(m.data.blk_io.buf);
-		}
 		file_caches.erase(it);
 		return ERR_FAILED_READ_FROM_DEVICE;
 	}
@@ -112,21 +110,18 @@ error_t process_read_data_response(const Message& m, bool for_user)
 
 	// オフセットがファイルサイズを超えている場合は無視
 	if (offset >= ctx.total_size) {
-		kernel::memory::free(m.data.blk_io.buf);
 		return OK;
 	}
 
 	const size_t copy_len = std::min(BYTES_PER_CLUSTER, ctx.total_size - offset);
 
-	memcpy(ctx.buffer.data() + offset, m.data.blk_io.buf, copy_len);
+	memcpy(ctx.buffer.data() + offset, buf.get(), copy_len);
 	ctx.read_size += copy_len;
 
 	if (ctx.is_read_complete()) {
 		send_file_data(m.data.blk_io.request_id, ctx.buffer.data(), ctx.total_size,
 					   ctx.requester, m.type, for_user);
 	}
-
-	kernel::memory::free(m.data.blk_io.buf);
 
 	return OK;
 }
@@ -428,9 +423,9 @@ void handle_fs_write(const Message& m)
 		return;
 	}
 
-	void* cluster_buffer =
-			kernel::memory::alloc(BYTES_PER_CLUSTER, kernel::memory::ALLOC_ZEROED);
-	if (cluster_buffer == nullptr) {
+	auto cluster_buffer = kernel::memory::make_kbuf(BYTES_PER_CLUSTER,
+													kernel::memory::ALLOC_ZEROED);
+	if (!cluster_buffer) {
 		LOG_ERROR("failed to allocate cluster buffer");
 		reply.data.fs.len = 0;
 		kernel::task::send_message(m.sender, reply);
@@ -446,13 +441,12 @@ void handle_fs_write(const Message& m)
 			void* write_data = m.tool_desc.present
 									   ? m.tool_desc.addr
 									   : const_cast<char*>(m.data.fs.temp_buf);
-			memcpy(static_cast<char*>(cluster_buffer) + offset_in_cluster,
+			memcpy(static_cast<char*>(cluster_buffer.get()) + offset_in_cluster,
 				   write_data, write_len);
 		} else {
 			// TODO: For existing data, need to read first
 			LOG_ERROR(
 					"partial cluster writes with existing data not yet implemented");
-			kernel::memory::free(cluster_buffer);
 			reply.data.fs.len = 0;
 			kernel::task::send_message(m.sender, reply);
 			return;
@@ -462,7 +456,7 @@ void handle_fs_write(const Message& m)
 		void* write_data = m.tool_desc.present
 								   ? m.tool_desc.addr
 								   : const_cast<char*>(m.data.fs.temp_buf);
-		memcpy(cluster_buffer, write_data, write_len);
+		memcpy(cluster_buffer.get(), write_data, write_len);
 	}
 
 	// Invalidate the cached file contents so a read after this write does not
@@ -476,9 +470,11 @@ void handle_fs_write(const Message& m)
 	const fs_id_t write_request_id = generate_fs_id();
 	pending_writes[write_request_id] = PendingWrite{ m.sender, write_len };
 
-	send_write_req_to_blk_device(cluster_buffer, calc_start_sector(target_cluster),
-								 BYTES_PER_CLUSTER, MsgType::FS_WRITE,
-								 write_request_id);
+	// Ownership moves to the blk device task, which frees the buffer once
+	// the write completes (see kernel/hardware/virtio/blk.cpp:79).
+	send_write_req_to_blk_device(
+			cluster_buffer.release(), calc_start_sector(target_cluster),
+			BYTES_PER_CLUSTER, MsgType::FS_WRITE, write_request_id);
 
 	fd->offset += write_len;
 

--- a/kernel/memory/slab.hpp
+++ b/kernel/memory/slab.hpp
@@ -161,8 +161,33 @@ void free(void* addr);
 bool is_slab_object_in_use(void* addr);
 
 struct FreeDeleter {
-	void operator()(void* p) { free(p); }
+	void operator()(void* p) const { free(p); }
 };
+
+/**
+ * @brief Owning smart pointer for kernel heap memory allocated with alloc()
+ *
+ * Frees the buffer with kernel::memory::free() on scope exit, so early
+ * returns on error paths cannot leak. Use .release() at ownership-transfer
+ * boundaries (e.g. handing a buffer over via IPC).
+ *
+ * @note The deleter only calls free(); no destructor runs. Use only for
+ * raw buffers and trivially destructible types.
+ */
+template<typename T = void>
+using unique_kbuf = std::unique_ptr<T, FreeDeleter>;
+
+/**
+ * @brief Allocate kernel memory owned by a unique_kbuf
+ * @param size Size to allocate
+ * @param flags Allocation flags (e.g., ALLOC_ZEROED)
+ * @param align Alignment requirement (default: 1)
+ * @return Owning pointer to the allocation; empty on failure
+ */
+inline unique_kbuf<> make_kbuf(size_t size, unsigned flags, int align = 1)
+{
+	return unique_kbuf<>(alloc(size, flags, align));
+}
 
 /**
  * @brief Initialize the slab allocator

--- a/kernel/tests/test_cases/memory_test.cpp
+++ b/kernel/tests/test_cases/memory_test.cpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <utility>
 #include "memory/bootstrap_allocator.hpp"
 #include "memory/buddy_system.hpp"
 #include "memory/page.hpp"
@@ -297,6 +298,85 @@ void test_slab_cache_name_truncation()
 	ASSERT_EQ(strlen(cache->name()), 19UL);
 }
 
+void test_unique_kbuf_frees_on_scope_exit()
+{
+	void* raw = nullptr;
+	{
+		kernel::memory::unique_kbuf<> buf =
+				kernel::memory::make_kbuf(64, kernel::memory::ALLOC_UNINITIALIZED);
+		ASSERT_NOT_NULL(buf.get());
+		ASSERT_TRUE(kernel::memory::is_slab_object_in_use(buf.get()));
+		raw = buf.get();
+	}
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(raw));
+}
+
+void test_unique_kbuf_release_transfers_ownership()
+{
+	kernel::memory::unique_kbuf<> buf =
+			kernel::memory::make_kbuf(64, kernel::memory::ALLOC_UNINITIALIZED);
+	ASSERT_NOT_NULL(buf.get());
+	void* raw = buf.release();
+
+	// RAII must not have freed the object; ownership now belongs to the caller
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(raw));
+
+	kernel::memory::free(raw);
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(raw));
+}
+
+void test_unique_kbuf_reset_frees()
+{
+	kernel::memory::unique_kbuf<> buf =
+			kernel::memory::make_kbuf(64, kernel::memory::ALLOC_UNINITIALIZED);
+	ASSERT_NOT_NULL(buf.get());
+	void* raw = buf.get();
+
+	buf.reset();
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(raw));
+	ASSERT_FALSE(static_cast<bool>(buf));
+}
+
+void test_unique_kbuf_move_transfers_ownership()
+{
+	kernel::memory::unique_kbuf<> a =
+			kernel::memory::make_kbuf(64, kernel::memory::ALLOC_UNINITIALIZED);
+	ASSERT_NOT_NULL(a.get());
+	void* raw = a.get();
+
+	kernel::memory::unique_kbuf<> b = std::move(a);
+	ASSERT_FALSE(static_cast<bool>(a));
+	ASSERT_EQ(b.get(), raw);
+	ASSERT_TRUE(kernel::memory::is_slab_object_in_use(raw));
+
+	// Guards against double-free by construction: only b owns the object
+	b.reset();
+	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(raw));
+}
+
+void test_make_kbuf_zeroed()
+{
+	constexpr size_t size = 128;
+	kernel::memory::unique_kbuf<> buf =
+			kernel::memory::make_kbuf(size, kernel::memory::ALLOC_ZEROED);
+	ASSERT_NOT_NULL(buf.get());
+
+	uint8_t* bytes = static_cast<uint8_t*>(buf.get());
+	for (size_t i = 0; i < size; ++i) {
+		ASSERT_EQ(bytes[i], 0);
+	}
+}
+
+void test_unique_kbuf_null_is_safe()
+{
+	kernel::memory::unique_kbuf<> empty{};
+	ASSERT_FALSE(static_cast<bool>(empty));
+
+	// free(nullptr) inside the deleter must be a no-op
+	empty.reset();
+	ASSERT_FALSE(static_cast<bool>(empty));
+}
+
 void register_slab_tests()
 {
 	test_register("slab_basic", test_slab_basic);
@@ -308,6 +388,15 @@ void register_slab_tests()
 	test_register("slab_free_rejects_foreign_pointer",
 				  test_slab_free_rejects_foreign_pointer);
 	test_register("slab_cache_name_truncation", test_slab_cache_name_truncation);
+	test_register("unique_kbuf_frees_on_scope_exit",
+				  test_unique_kbuf_frees_on_scope_exit);
+	test_register("unique_kbuf_release_transfers_ownership",
+				  test_unique_kbuf_release_transfers_ownership);
+	test_register("unique_kbuf_reset_frees", test_unique_kbuf_reset_frees);
+	test_register("unique_kbuf_move_transfers_ownership",
+				  test_unique_kbuf_move_transfers_ownership);
+	test_register("make_kbuf_zeroed", test_make_kbuf_zeroed);
+	test_register("unique_kbuf_null_is_safe", test_unique_kbuf_null_is_safe);
 }
 
 static void helper_alloc_or_return_void()


### PR DESCRIPTION
Closes #322

## 概要

カーネルヒープの所有権を型で表現する `kernel::memory::unique_kbuf<T>` / `make_kbuf()` を追加し、所有権規約をルールファイルに明文化した。使用例として `kernel/fs/fat/file.cpp` の 2 箇所を実際に変換し、テストを 6 本追加。

## 変更内容

### ヘルパ(`kernel/memory/slab.hpp`)
- 既存の未使用 `FreeDeleter` を `const` 化して流用
- `unique_kbuf<T = void>` エイリアスと `make_kbuf(size, flags, align = 1)`(実際の `alloc()` シグネチャに合わせた)
- deleter は `free()` を呼ぶだけでデストラクタは走らないため、生バッファ / trivially destructible 型限定である旨を Doxygen に明記

### 規約(`.claude/rules/kernel.md` / `CLAUDE.md`)
- 新規・変更コードでの「所有権を持つ生ポインタ + 手動 free」禁止
- IPC 等の所有権移転境界では `.release()` を明示、借用は `.get()`
- `enter_user_mode` / `exec_elf` など戻らない呼び出しの前は事前に決着させる
- 既存コードの一括書き換えはしない(段階移行)

### 使用例の変換(`kernel/fs/fat/file.cpp`)
- **`process_read_data_response`**: 受け取った blk バッファの free 4 箇所(うち 2 箇所は nullptr ガード付き)を関数先頭の owning guard 1 つに集約。全 return 経路で解放が保証される
- **`handle_fs_write`**: `cluster_buffer` を `make_kbuf` で確保し、エラー経路の手動 free を削除。デバイスへの引き渡し点で `cluster_buffer.release()` を明示(virtio-blk 側 `kernel/hardware/virtio/blk.cpp:79` が書き込み後に free することを確認済み)

### テスト(`kernel/tests/test_cases/memory_test.cpp`、slab スイートに追加)
スコープ離脱で解放 / `release()` で所有権移転(RAII は解放しない)/ `reset()` で解放 / ムーブで移転(二重 free なし)/ `ALLOC_ZEROED` のゼロ埋め / 空ハンドルの安全性 — いずれも `is_slab_object_in_use()` で実際の slab 状態を検証

## issue 例示の sys_exec を変換しなかった理由

分析の結果、#313 修正後の `sys_exec` には `entry` 受領〜解放の間に early return が存在せずリーク窓がない。さらに成功経路が `enter_user_mode`(noreturn)で終わるため関数スコープの RAII が発火せず、教材としてかえって誤解を招く。代わりに free の重複集約(`process_read_data_response`)と `.release()` 移転(`handle_fs_write`)という規約の 2 大イディオムを示す箇所を選定した。

## 検証

- ローカルはホスト clang の `-fsyntax-only` と clang-format(変更行)まで(この環境に cross sysroot 無し)。ビルド・QEMU テスト・clang-tidy は CI で検証
- テストランナーのスイート前後リークチェックにより、新テスト自身の解放漏れも検出対象

🤖 Generated with [Claude Code](https://claude.com/claude-code)