### PR TITLE
heap-debug: CI 常時出力の invalid/double free 報告の切り分けと抑制(#350)

### DIFF
--- a/kernel/memory/heap_debug.cpp
+++ b/kernel/memory/heap_debug.cpp
@@ -57,6 +57,10 @@ std::unordered_map<void*, size_t> poisoned_objs;
 
 Stats g_stats = { 0, 0, 0 };
 
+// Depth of nested ExpectedViolation scopes currently alive. While non-zero,
+// violation LOG_ERROR calls are suppressed (stats() still updates).
+int g_expected_violations = 0;
+
 void poison_fill(void* addr, size_t n)
 {
 	auto* p = static_cast<uint8_t*>(addr);
@@ -101,6 +105,7 @@ void initialize()
 	live_allocs = std::unordered_map<void*, AllocInfo>();
 	poisoned_objs = std::unordered_map<void*, size_t>();
 	g_stats = { 0, 0, 0 };
+	g_expected_violations = 0;
 }
 
 size_t redzone_reserve() { return REDZONE_SIZE; }
@@ -113,10 +118,12 @@ void* on_alloc(void* raw, size_t user_size, size_t object_size, void* caller)
 	if (pit != poisoned_objs.end()) {
 		if (!poison_intact(raw, pit->second)) {
 			++g_stats.use_after_free;
-			LOG_ERROR(
-					"heap-debug: use-after-free in object %p (size %lu), "
-					"reallocated from %p",
-					raw, static_cast<unsigned long>(pit->second), caller);
+			if (g_expected_violations == 0) {
+				LOG_ERROR(
+						"heap-debug: use-after-free in object %p (size %lu), "
+						"reallocated from %p",
+						raw, static_cast<unsigned long>(pit->second), caller);
+			}
 		}
 		poisoned_objs.erase(pit);
 	}
@@ -146,8 +153,10 @@ void* on_free(void* user, void* caller)
 	auto it = live_allocs.find(user);
 	if (it == live_allocs.end()) {
 		++g_stats.double_free;
-		LOG_ERROR("heap-debug: invalid or double free of %p (freed from %p)", user,
-				  caller);
+		if (g_expected_violations == 0) {
+			LOG_ERROR("heap-debug: invalid or double free of %p (freed from %p)",
+					  user, caller);
+		}
 		return nullptr;
 	}
 
@@ -159,11 +168,13 @@ void* on_free(void* user, void* caller)
 	if (!redzone_intact(reinterpret_cast<void*>(tail),
 						base + info.object_size - tail)) {
 		++g_stats.redzone;
-		LOG_ERROR(
-				"heap-debug: buffer overflow on %p (size %lu, allocated from "
-				"%p, freed from %p)",
-				user, static_cast<unsigned long>(info.user_size), info.caller,
-				caller);
+		if (g_expected_violations == 0) {
+			LOG_ERROR(
+					"heap-debug: buffer overflow on %p (size %lu, allocated from "
+					"%p, freed from %p)",
+					user, static_cast<unsigned long>(info.user_size), info.caller,
+					caller);
+		}
 	}
 
 	poison_fill(info.raw, info.object_size);
@@ -223,6 +234,10 @@ void report_leaks(int top_n)
 }
 
 Stats stats() { return g_stats; }
+
+ExpectedViolation::ExpectedViolation() { ++g_expected_violations; }
+
+ExpectedViolation::~ExpectedViolation() { --g_expected_violations; }
 
 } // namespace kernel::memory::heap_debug
 

--- a/kernel/memory/heap_debug.hpp
+++ b/kernel/memory/heap_debug.hpp
@@ -114,6 +114,34 @@ void report_leaks(int top_n);
 /// @brief Snapshot of the violation counters
 Stats stats();
 
+/**
+ * @brief Suppress violation LOG_ERROR output for deliberate test faults
+ *
+ * While at least one instance is alive, detected violations still update
+ * stats() but are not logged, so a green CI run's serial log stays free of
+ * heap-debug errors and any that do appear are real regressions (issue #350).
+ */
+class ExpectedViolation
+{
+public:
+	ExpectedViolation();
+	~ExpectedViolation();
+};
+
+} // namespace kernel::memory::heap_debug
+
+#else
+
+namespace kernel::memory::heap_debug
+{
+/// No-op stand-in so tests need no #ifdef around deliberate-fault scopes.
+/// User-provided ctor/dtor keep -Wunused-variable quiet at use sites.
+class ExpectedViolation
+{
+public:
+	ExpectedViolation() {}
+	~ExpectedViolation() {}
+};
 } // namespace kernel::memory::heap_debug
 
 #endif // KERNEL_HEAP_DEBUG_ENABLED

--- a/kernel/tests/test_cases/heap_debug_test.cpp
+++ b/kernel/tests/test_cases/heap_debug_test.cpp
@@ -44,7 +44,10 @@ void test_heap_debug_detects_double_free()
 	ASSERT_NOT_NULL(p);
 
 	kernel::memory::free(p);
-	kernel::memory::free(p); // double free
+	{
+		const hd::ExpectedViolation expected;
+		kernel::memory::free(p); // double free
+	}
 
 	ASSERT_EQ(hd::stats().double_free, before + 1);
 }
@@ -65,8 +68,12 @@ void test_heap_debug_detects_use_after_free()
 	static_cast<volatile uint8_t*>(p)[0] = 0x12;
 
 	// The same object comes back and its broken poison is detected.
-	void* q = kernel::memory::alloc(SINGLE_OBJECT_SIZE,
-									kernel::memory::ALLOC_UNINITIALIZED);
+	void* q;
+	{
+		const hd::ExpectedViolation expected;
+		q = kernel::memory::alloc(SINGLE_OBJECT_SIZE,
+								  kernel::memory::ALLOC_UNINITIALIZED);
+	}
 	ASSERT_EQ(q, p);
 	ASSERT_EQ(hd::stats().use_after_free, before + 1);
 
@@ -86,7 +93,10 @@ void test_heap_debug_detects_overflow()
 
 	p[size] = 0xAA; // one byte past the payload -> tail redzone
 
-	kernel::memory::free(const_cast<uint8_t*>(p));
+	{
+		const hd::ExpectedViolation expected;
+		kernel::memory::free(const_cast<uint8_t*>(p));
+	}
 	ASSERT_EQ(hd::stats().redzone, before + 1);
 }
 

--- a/kernel/tests/test_cases/memory_test.cpp
+++ b/kernel/tests/test_cases/memory_test.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include "memory/bootstrap_allocator.hpp"
 #include "memory/buddy_system.hpp"
+#include "memory/heap_debug.hpp"
 #include "memory/page.hpp"
 #include "memory/slab.hpp"
 #include "tests/framework.hpp"
@@ -256,7 +257,10 @@ void test_slab_double_free_detected()
 	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(ptr));
 
 	// A second free must be detected and ignored (issue #313)
-	kernel::memory::free(ptr);
+	{
+		const kernel::memory::heap_debug::ExpectedViolation expected;
+		kernel::memory::free(ptr);
+	}
 	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(ptr));
 
 	// The object is handed out exactly once afterwards
@@ -273,7 +277,10 @@ void test_slab_free_rejects_foreign_pointer()
 	void* raw = kernel::memory::memory_manager->allocate(kernel::memory::PAGE_SIZE);
 	ASSERT_NOT_NULL(raw);
 
-	kernel::memory::free(raw);
+	{
+		const kernel::memory::heap_debug::ExpectedViolation expected;
+		kernel::memory::free(raw);
+	}
 	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(raw));
 
 	// The page still belongs to the buddy system


### PR DESCRIPTION
Closes #350

## 調査結果(切り分け)

**偽陽性(ただし heap_debug の盲点ではなく、意図的なネガティブテストのログ)** と確定した。

1. **仮説 1(buddy 直行パスの未追跡)は反証**: `alloc()`(`kernel/memory/slab.cpp:240-315`)にバイパス経路は存在しない。どんな大サイズでも 2 冪丸めで専用キャッシュが作られ(上限 1 GiB)、全確保が `heap_debug::on_alloc` で追跡され、全 `free()` がフックを通る
2. **仮説 2(実バグ)も否定**: 発生源は次の 2 テスト。呼び出し元アドレスが約 0x160 差で隣接し、run ごとに 1 回ずつという観測形状と完全に一致
   - `test_slab_double_free_detected`(memory_test.cpp)— 100000 バイト確保(redzone 込みで 128 KiB クラス)の**意図的な二重 free**
   - `test_slab_free_rejects_foreign_pointer`(同)— buddy から直接取ったページの**意図的な異物 free**
3. #347(スケジューリング遅延)マージ後の CI でも残存していたことから、サービスタスク並走説は事前に棄却済み(issue 記載の切り分け手順どおり)

つまり検出器は正しく仕事をしており、問題は「**期待どおりの違反ログがグリーン run の serial.log に毎回出て、本物の回帰と見分けが付かない**」という診断ノイズのみ。

## 修正

`heap_debug` に RAII スコープ `ExpectedViolation` を追加:

- スコープ内で検出された違反は **`stats()` カウンタは従来どおり加算**(テストのアサートはそのまま機能)し、`LOG_ERROR` のみ抑制
- 意図的に違反を起こす 5 箇所(memory_test の 2 箇所、heap_debug_test の double free / use-after-free / redzone)をスコープで包んだ
- `KERNEL_HEAP_DEBUG=OFF` ビルド用に no-op 版を用意し、テスト側に `#ifdef` を散らさない(未使用変数警告はユーザー定義 ctor/dtor で抑止することを確認済み)

**効果**: グリーン CI の serial.log から heap-debug エラーが完全に消える。以後 `heap-debug:` 行が出たらそれは本物の回帰。

## 検証

- ホスト clang で ON/OFF 両相当の構文チェック、変更行の clang-format 済み。ビルドと QEMU テスト(カウンタのアサートが抑制下でも通ること)は CI で確認
- 期待される CI ログの変化: `TEST_SUMMARY` は従来どおり PASS、`heap-debug:` の LOG_ERROR 行が 0 になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)