### PR TITLE
エラーハンドリング Tier A: 判定機構の一本化・握りつぶし解消・error_to_string 網羅(#356)

### DIFF
--- a/kernel/elf.cpp
+++ b/kernel/elf.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstring>
 #include "asm_utils.h"
+#include "error.hpp"
 #include "log/log.hpp"
 #include "memory/page.hpp"
 #include "memory/paging.hpp"
@@ -90,7 +91,7 @@ bool is_elf(elf64_ehdr_t* elf_header)
 				  4) == 0;
 }
 
-void copy_load_segment(elf64_ehdr_t* elf_header)
+error_t copy_load_segment(elf64_ehdr_t* elf_header)
 {
 	auto* program_header = get_program_header(elf_header);
 	for (int i = 0; i < elf_header->e_phnum; i++) {
@@ -105,7 +106,8 @@ void copy_load_segment(elf64_ehdr_t* elf_header)
 				(program_header[i].p_memsz + kernel::memory::PAGE_SIZE - 1) /
 				kernel::memory::PAGE_SIZE;
 
-		kernel::memory::setup_page_tables(dest_addr, num_pages, true);
+		RETURN_IF_ERROR(
+				kernel::memory::setup_page_tables(dest_addr, num_pages, true));
 
 		auto* const src =
 				reinterpret_cast<uint8_t*>(elf_header) + program_header[i].p_offset;
@@ -115,21 +117,24 @@ void copy_load_segment(elf64_ehdr_t* elf_header)
 		memset(dest + program_header[i].p_filesz, 0,
 			   program_header[i].p_memsz - program_header[i].p_filesz);
 	}
+
+	return OK;
 }
 
-void load_elf(elf64_ehdr_t* elf_header)
+error_t load_elf(elf64_ehdr_t* elf_header)
 {
 	if (elf_header->e_type != ET_EXEC) {
-		return;
+		LOG_ERROR("not an executable ELF file");
+		return ERR_INVALID_ARG;
 	}
 
 	const auto first_load_addr = get_first_load_addr(elf_header);
 	if (first_load_addr < 0xffff'8000'0000'0000) {
 		LOG_ERROR("invalid load address: %p", first_load_addr);
-		return;
+		return ERR_INVALID_ARG;
 	}
 
-	copy_load_segment(elf_header);
+	return copy_load_segment(elf_header);
 }
 
 void exec_elf(void* buffer, const char* name, const char* args)
@@ -140,10 +145,18 @@ void exec_elf(void* buffer, const char* name, const char* args)
 		return;
 	}
 
-	load_elf(elf_header);
+	error_t err = load_elf(elf_header);
+	if (IS_ERR(err)) {
+		LOG_ERROR("failed to load ELF file: %s", name);
+		return;
+	}
 
 	const kernel::memory::vaddr_t argv_addr{ 0xffff'ffff'ffff'f000 };
-	kernel::memory::setup_page_tables(argv_addr, 1, true);
+	err = kernel::memory::setup_page_tables(argv_addr, 1, true);
+	if (IS_ERR(err)) {
+		LOG_ERROR("failed to setup argv page table: %s", name);
+		return;
+	}
 
 	auto* argv = reinterpret_cast<char**>(argv_addr.data);
 	const int arg_v_len = 32;
@@ -155,8 +168,12 @@ void exec_elf(void* buffer, const char* name, const char* args)
 
 	const int stack_size = kernel::memory::PAGE_SIZE * 8;
 	const kernel::memory::vaddr_t stack_addr{ 0xffff'ffff'ffff'f000 - stack_size };
-	kernel::memory::setup_page_tables(stack_addr,
-									  stack_size / kernel::memory::PAGE_SIZE, true);
+	err = kernel::memory::setup_page_tables(
+			stack_addr, stack_size / kernel::memory::PAGE_SIZE, true);
+	if (IS_ERR(err)) {
+		LOG_ERROR("failed to setup stack page table: %s", name);
+		return;
+	}
 
 	enter_user_mode(argc, argv, kernel::memory::USER_SS, elf_header->e_entry,
 					stack_addr.data + stack_size - 8,

--- a/kernel/elf.hpp
+++ b/kernel/elf.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <cstdint>
+#include <libs/common/types.hpp>
 
 /**
  * @brief ELF64 data type definitions
@@ -148,10 +149,11 @@ typedef struct {
  * segments into their specified memory locations.
  *
  * @param elf_header Pointer to the ELF header in memory
+ * @return OK on success, or an error code if validation or page mapping failed
  *
  * @note This function assumes the ELF file is already loaded into memory
  */
-void load_elf(elf64_ehdr_t* elf_header);
+error_t load_elf(elf64_ehdr_t* elf_header);
 
 /**
  * @brief Execute an ELF file as a new process

--- a/kernel/error.hpp
+++ b/kernel/error.hpp
@@ -18,27 +18,16 @@ namespace kernel
 {
 
 /**
- * @brief Check if an error code indicates success
- * @param err Error code to check
- * @return true if success, false if error
- */
-inline bool is_ok(error_t err) { return !IS_ERR(err); }
-
-/**
- * @brief Check if an error code indicates an error
- * @param err Error code to check
- * @return true if error, false if success
- */
-inline bool is_error(error_t err) { return IS_ERR(err); }
-
-/**
  * @brief Convert error code to human-readable string
  * @param err Error code to convert
  * @return String representation of the error code
+ *
+ * The switch is exhaustive over ErrorCode (no default label) so -Wswitch
+ * flags a missing case here whenever a new ErrorCode value is added.
  */
 inline const char* error_to_string(error_t err)
 {
-	switch (err) {
+	switch (static_cast<ErrorCode>(err)) {
 		case OK:
 			return "OK";
 		case ERR_FORK_FAILED:
@@ -63,9 +52,15 @@ inline const char* error_to_string(error_t err)
 			return "Failed to initialize device";
 		case ERR_FAILED_WRITE_TO_DEVICE:
 			return "Failed to write to device";
-		default:
-			return "Unknown error";
+		case ERR_QUEUE_FULL:
+			return "Message queue full";
+		case ERR_FAILED_READ_FROM_DEVICE:
+			return "Failed to read from device";
+		case ERR_NO_SPACE:
+			return "No space";
 	}
+
+	return "Unknown error";
 }
 
 /**

--- a/kernel/hardware/virtio/blk.cpp
+++ b/kernel/hardware/virtio/blk.cpp
@@ -3,6 +3,7 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
+#include "error.hpp"
 #include "hardware/virtio/pci.hpp"
 #include "hardware/virtio/virtio.hpp"
 #include "log/log.hpp"
@@ -102,7 +103,7 @@ error_t validate_length(uint32_t len)
 
 error_t write_to_blk_device(const char* buffer, uint64_t sector, uint32_t len)
 {
-	ASSERT_OK(validate_length(len));
+	RETURN_IF_ERROR(validate_length(len));
 
 	void* req_ptr;
 	ALLOC_OR_RETURN_ERROR(req_ptr, sizeof(VirtioBlkReq),
@@ -145,7 +146,7 @@ error_t write_to_blk_device(const char* buffer, uint64_t sector, uint32_t len)
 
 error_t read_from_blk_device(const char* buffer, uint64_t sector, uint32_t len)
 {
-	ASSERT_OK(validate_length(len));
+	RETURN_IF_ERROR(validate_length(len));
 
 	void* req_ptr;
 	ALLOC_OR_RETURN_ERROR(req_ptr, sizeof(VirtioBlkReq),
@@ -196,7 +197,7 @@ error_t init_blk_device()
 
 	blk_dev = new (buffer) VirtioPciDevice();
 
-	ASSERT_OK(init_virtio_pci_device(blk_dev, VIRTIO_BLK));
+	RETURN_IF_ERROR(init_virtio_pci_device(blk_dev, VIRTIO_BLK));
 
 	kernel::task::CURRENT_TASK->is_initialized = true;
 

--- a/kernel/hardware/virtio/net.cpp
+++ b/kernel/hardware/virtio/net.cpp
@@ -1,6 +1,7 @@
 #include "hardware/virtio/net.hpp"
 #include <cstddef>
 #include <libs/common/types.hpp>
+#include "error.hpp"
 #include "hardware/virtio/pci.hpp"
 #include "hardware/virtio/virtio.hpp"
 #include "libs/common/message.hpp"
@@ -67,7 +68,7 @@ error_t init_virtio_net_device()
 	}
 
 	net_dev = new (buffer) VirtioPciDevice();
-	ASSERT_OK(init_virtio_pci_device(net_dev, VIRTIO_NET));
+	RETURN_IF_ERROR(init_virtio_pci_device(net_dev, VIRTIO_NET));
 
 	rx_queue = &net_dev->queues[0];
 	tx_queue = &net_dev->queues[1];

--- a/kernel/hardware/virtio/pci.cpp
+++ b/kernel/hardware/virtio/pci.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <libs/common/types.hpp>
 #include "bit_utils.hpp"
+#include "error.hpp"
 #include "hardware/pci.hpp"
 #include "hardware/virtio/net.hpp"
 #include "hardware/virtio/virtio.hpp"
@@ -173,7 +174,7 @@ error_t configure_pci_common_cfg(VirtioPciDevice& virtio_dev)
 	virtio_dev.common_cfg->device_status = VIRTIO_STATUS_ACKNOWLEDGE;
 	virtio_dev.common_cfg->device_status |= VIRTIO_STATUS_DRIVER;
 
-	ASSERT_OK(negotiate_features(virtio_dev));
+	RETURN_IF_ERROR(negotiate_features(virtio_dev));
 
 	virtio_dev.common_cfg->config_msix_vector = 0;
 	if (virtio_dev.common_cfg->config_msix_vector == NO_VECTOR) {
@@ -181,7 +182,7 @@ error_t configure_pci_common_cfg(VirtioPciDevice& virtio_dev)
 		return ERR_NO_MEMORY;
 	}
 
-	ASSERT_OK(setup_virtqueue(virtio_dev));
+	RETURN_IF_ERROR(setup_virtqueue(virtio_dev));
 
 	virtio_dev.common_cfg->device_status |= VIRTIO_STATUS_DRIVER_OK;
 
@@ -233,7 +234,7 @@ error_t set_virtio_pci_capability(VirtioPciDevice& virtio_dev)
 		virtio_dev.caps = virtio_dev.caps->next;
 	}
 
-	ASSERT_OK(configure_pci_notify_cfg(virtio_dev));
+	RETURN_IF_ERROR(configure_pci_notify_cfg(virtio_dev));
 
 	return OK;
 }

--- a/kernel/memory/paging.cpp
+++ b/kernel/memory/paging.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstring>
 #include <libs/common/types.hpp>
+#include "error.hpp"
 #include "log/log.hpp"
 #include "memory/page.hpp"
 #include "memory/slab.hpp"
@@ -167,18 +168,20 @@ int setup_page_table(page_table_entry* page_table,
 	return num_pages;
 }
 
-void setup_page_tables(vaddr_t addr, size_t num_pages, bool writable)
+error_t setup_page_tables(vaddr_t addr, size_t num_pages, bool writable)
 {
 	const int num_remaining_pages =
 			setup_page_table(get_active_page_table(), 4, addr, num_pages, writable);
 	if (num_remaining_pages == -1) {
 		LOG_ERROR("Failed to setup page tables.");
-		return;
+		return ERR_NO_MEMORY;
 	}
 
 	for (size_t i = 0; i < num_pages; i++) {
 		flush_tlb(addr.data + i * PAGE_SIZE);
 	}
+
+	return OK;
 }
 
 page_table_entry* config_new_page_table()
@@ -356,7 +359,7 @@ error_t handle_page_fault(uint64_t error_code, uint64_t fault_addr)
 	auto user = (error_code >> 2) & 1;
 
 	if ((user != 0) && (rw != 0) && (exist != 0)) {
-		ASSERT_OK(copy_target_page(fault_addr));
+		RETURN_IF_ERROR(copy_target_page(fault_addr));
 	} else {
 		LOG_ERROR("Page fault: user=%d, rw=%d, exist=%d", user, rw, exist);
 		return ERR_PAGE_NOT_PRESENT;

--- a/kernel/memory/paging.hpp
+++ b/kernel/memory/paging.hpp
@@ -142,7 +142,14 @@ int setup_page_table(page_table_entry* page_table,
 					 size_t num_pages,
 					 bool writable);
 
-void setup_page_tables(vaddr_t addr, size_t num_pages, bool writable);
+/**
+ * @brief Map num_pages of newly allocated user memory at addr and flush the TLB
+ * @param addr Start virtual address
+ * @param num_pages Number of pages to map
+ * @param writable Whether the leaf mappings are writable
+ * @return OK on success, or an error code if a page table allocation failed
+ */
+error_t setup_page_tables(vaddr_t addr, size_t num_pages, bool writable);
 
 page_table_entry* config_new_page_table();
 

--- a/kernel/tests/test_cases/user_test.cpp
+++ b/kernel/tests/test_cases/user_test.cpp
@@ -27,7 +27,7 @@ void test_copy_string_from_user_roundtrip()
 {
 	// Map one user page in the active address space and place a string
 	const kernel::memory::vaddr_t addr{ TEST_USER_STR_VADDR };
-	kernel::memory::setup_page_tables(addr, 1, true);
+	ASSERT_EQ(kernel::memory::setup_page_tables(addr, 1, true), OK);
 
 	char* user_buf = reinterpret_cast<char*>(addr.data);
 	strlcpy(user_buf, "hello", 6); // NOLINT(misc-include-cleaner)

--- a/libs/common/types.hpp
+++ b/libs/common/types.hpp
@@ -17,32 +17,35 @@ using message_handler_t = void (*)(const Message&);
 // error codes
 #define IS_OK(err) (!IS_ERR(err))
 #define IS_ERR(err) (((long)(err)) < 0)
-constexpr int OK = 0;
-constexpr int ERR_FORK_FAILED = -1;
-constexpr int ERR_NO_MEMORY = -2;
-constexpr int ERR_INVALID_ARG = -3;
-constexpr int ERR_INVALID_TASK = -4;
-constexpr int ERR_INVALID_FD = -5;
-constexpr int ERR_PAGE_NOT_PRESENT = -6;
-constexpr int ERR_NO_TASK = -7;
-constexpr int ERR_NO_FILE = -8;
-constexpr int ERR_NO_DEVICE = -9;
-constexpr int ERR_FAILED_INIT_DEVICE = -10;
-constexpr int ERR_FAILED_WRITE_TO_DEVICE = -11;
-constexpr int ERR_QUEUE_FULL = -12;
-constexpr int ERR_FAILED_READ_FROM_DEVICE = -13;
-constexpr int ERR_NO_SPACE = -14;
+
+/**
+ * @brief Kernel-wide error codes
+ *
+ * Unscoped enum with a fixed underlying type: values keep their implicit
+ * conversion to int (so existing callers need no changes), while giving
+ * error_to_string() an exhaustive switch (no default) so -Wswitch catches a
+ * missing case at compile time.
+ */
+enum ErrorCode : error_t {
+	OK = 0,
+	ERR_FORK_FAILED = -1,
+	ERR_NO_MEMORY = -2,
+	ERR_INVALID_ARG = -3,
+	ERR_INVALID_TASK = -4,
+	ERR_INVALID_FD = -5,
+	ERR_PAGE_NOT_PRESENT = -6,
+	ERR_NO_TASK = -7,
+	ERR_NO_FILE = -8,
+	ERR_NO_DEVICE = -9,
+	ERR_FAILED_INIT_DEVICE = -10,
+	ERR_FAILED_WRITE_TO_DEVICE = -11,
+	ERR_QUEUE_FULL = -12,
+	ERR_FAILED_READ_FROM_DEVICE = -13,
+	ERR_NO_SPACE = -14,
+};
 
 // file descriptor
 constexpr int NO_FD = -1;
 constexpr int STDIN_FILENO = 0;
 constexpr int STDOUT_FILENO = 1;
 constexpr int STDERR_FILENO = 2;
-
-#define ASSERT_OK(expression)                                                       \
-	do {                                                                            \
-		const error_t __err = (expression);                                         \
-		if (IS_ERR(__err)) {                                                        \
-			return __err;                                                           \
-		}                                                                           \
-	} while (0)

--- a/libs/user/file.cpp
+++ b/libs/user/file.cpp
@@ -85,7 +85,7 @@ void fs_change_dir(char* buf, const char* path)
 	m.data.fs.name[strlen(path)] = '\0';
 
 	Message res = call(process_ids::FS_FAT32, &m);
-	if (res.data.fs.result == -1) {
+	if (IS_ERR(res.data.fs.result)) {
 		buf[0] = '\0';
 		return;
 	}

--- a/userland/commands/cat/main.cpp
+++ b/userland/commands/cat/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char** argv)
 	}
 
 	fd_t fd = fs_open(input, 0);
-	if (fd == -1) {
+	if (fd < 0) {
 		printu("cat: No such file or directory");
 		return 0;
 	}


### PR DESCRIPTION
Part of #356(**Tier A のみ**。Tier B は #314 の IPC v2 設計と同時に実施するため issue は閉じない)

## 変更内容

### 1. エラーコードの enum 化 + `error_to_string` の網羅強制
- `constexpr int OK / ERR_*` 15 定数を `enum ErrorCode : error_t` に変換(unscoped enum なので int への暗黙変換は全て従来どおり = 既存呼び出しコードは無変更)
- `error_to_string` を `switch (static_cast<ErrorCode>(err))` + **default 無し**に変更。カーネルは `-Wall` ビルドなので、以後 ERR_* を追加して case を書き忘れると `-Wswitch` 警告で発見できる(issue の「漏れたら気付ける仕組み」)
- 欠落していた 3 件の文字列を追加: `ERR_QUEUE_FULL` / `ERR_FAILED_READ_FROM_DEVICE` / `ERR_NO_SPACE`。ipc.cpp:88 で実際に出ていた `(error: Unknown error)` が正しい文言になる

### 2. 判定・伝搬機構の一本化
- **伝搬**: `RETURN_IF_ERROR`(error.hpp)に統一。誤称の重複マクロ `ASSERT_OK`(assert ではなく return する)を削除し、8 箇所を置換
- **判定**: 使用 0 だった `kernel::is_ok()` / `is_error()` inline を削除し、`IS_OK` / `IS_ERR` マクロに一本化(#351 で使用箇所は既に消えていたため定義の削除のみ)

### 3. `setup_page_tables` の握りつぶし解消
- `void` → `error_t` 化(内部失敗を LOG のみで飲み込んでいた)
- elf.cpp で `copy_load_segment` → `load_elf` → `exec_elf` と伝搬し、**半分だけマップされたアドレス空間のままユーザーモードへ突入する経路を遮断**(失敗時は enter_user_mode 前に LOG + return)
- user_test.cpp の呼び出しも `ASSERT_EQ(..., OK)` 化

### 4. userland の `== -1` 判定是正
- `libs/user/file.cpp`: `res.data.fs.result == -1` → `IS_ERR(...)`(`ERR_NO_MEMORY`(-2)等が成功扱いになるバグ)
- `cat/main.cpp`: `fd == -1` → `fd < 0`
- `grep '== -1' libs/user userland` のエラー判定用途は 0 に

## 完了条件との対応(Tier A 分)

- ✅ 伝搬マクロが 1 つ(`ASSERT_OK` は grep 0 件)
- ✅ `error_to_string` が全 ERR_* を網羅 + 網羅を強制する構造(-Wswitch)
- ✅ `== -1` エラー判定 0 件
- ⏭ 「戻り値が読めない error_t 関数 0」(`send_message`)は Tier B / #314 へ

## 検証

- ホスト clang で変更ファイル + 影響の大きい主要 TU(ipc / syscall / fs / task)を `-Wall` 構文チェック、警告なし。変更行は clang-format 済み
- フルビルド・QEMU テスト・clang-tidy は CI で検証(この環境に cross sysroot 無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)