### PR TITLE
IPC v2 Stage B: call/reply + correlation id・FS 同期化・wait_for_message 全廃 (#314)

### DIFF
--- a/kernel/fs/fat/directory.cpp
+++ b/kernel/fs/fat/directory.cpp
@@ -10,7 +10,6 @@
 #include <libs/common/process_id.hpp>
 #include <libs/common/stat.hpp>
 #include <libs/common/types.hpp>
-#include <map>
 #include <string>
 #include <vector>
 #include "fat.hpp"
@@ -18,18 +17,12 @@
 #include "graphics/font.hpp"
 #include "internal_common.hpp"
 #include "log/log.hpp"
-#include "memory/page.hpp"
 #include "memory/slab.hpp"
 #include "task/ipc.hpp"
 #include "task/task.hpp"
 
 namespace kernel::fs::fat
 {
-
-std::map<fs_id_t, ProcessId> change_dir_requests;
-std::map<fs_id_t, std::string> change_dir_names;
-std::map<fs_id_t, std::string> parent_dir_names;
-fs_id_t next_change_dir_id = 1000000;
 
 namespace
 {
@@ -74,8 +67,7 @@ void set_fs_path_to_child(kernel::task::Task* t, const std::string& dir_name)
 }
 
 /// Reset fs_path (current_dir / current_dir_name / full_path) to the root
-/// directory. State only: unlike handle_change_to_root(), this does not send
-/// a reply message.
+/// directory. State only: this does not send a reply.
 void set_fs_path_to_root(kernel::task::Task* t)
 {
 	if (t->fs_path.current_dir != nullptr && t->fs_path.current_dir != ROOT_DIR) {
@@ -89,24 +81,6 @@ void set_fs_path_to_root(kernel::task::Task* t)
 	t->fs_path.full_path[sizeof(t->fs_path.full_path) - 1] = '\0';
 }
 
-bool validate_change_dir_request(const Message& m, kernel::task::Task*& task)
-{
-	auto it = change_dir_requests.find(m.data.blk_io.request_id);
-	if (it == change_dir_requests.end()) {
-		LOG_ERROR("request_id not found in change_dir_requests");
-		return false;
-	}
-
-	task = kernel::task::get_task(it->second);
-	if (task == nullptr) {
-		LOG_ERROR("task not found");
-		change_dir_requests.erase(it);
-		return false;
-	}
-
-	return true;
-}
-
 /// Replace fs_path.current_dir with a newly loaded directory-cluster buffer,
 /// freeing the previous buffer (unless it is the shared ROOT_DIR).
 void set_fs_path_current_dir(kernel::task::Task* t, DirectoryEntry* new_dir)
@@ -117,100 +91,37 @@ void set_fs_path_current_dir(kernel::task::Task* t, DirectoryEntry* new_dir)
 	t->fs_path.current_dir = new_dir;
 }
 
-void finalize_directory_change(const Message& m, kernel::task::Task* t)
+/// Reply to an FS_CHANGE_DIR request with the (possibly truncated) new
+/// directory name and OK.
+void reply_change_dir(const Message& m, const char* name)
 {
-	auto name_it = change_dir_names.find(m.data.blk_io.request_id);
-	if (name_it != change_dir_names.end()) {
-		if (name_it->second == "..") {
-			auto parent_name_it = parent_dir_names.find(m.data.blk_io.request_id);
-			if (parent_name_it != parent_dir_names.end()) {
-				set_fs_path_to_parent(t, parent_name_it->second);
-				parent_dir_names.erase(parent_name_it);
-			} else if (t->fs_path.current_dir == ROOT_DIR) {
-				set_fs_path_to_root(t);
-			}
-		} else {
-			set_fs_path_to_child(t, name_it->second);
-		}
-		change_dir_names.erase(name_it);
-	}
-	change_dir_requests.erase(m.data.blk_io.request_id);
-}
-
-void handle_virtio_response(const Message& m)
-{
-	kernel::task::Task* task = nullptr;
-	if (!validate_change_dir_request(m, task)) {
-		return;
-	}
-
-	if (IS_ERR(m.data.blk_io.result) || m.data.blk_io.buf == nullptr) {
-		// Device read failed: keep the current directory instead of
-		// pointing it at a null buffer.
-		LOG_ERROR("failed to read directory cluster: result=%d",
-				  m.data.blk_io.result);
-		change_dir_names.erase(m.data.blk_io.request_id);
-		parent_dir_names.erase(m.data.blk_io.request_id);
-		change_dir_requests.erase(m.data.blk_io.request_id);
-		return;
-	}
-
-	set_fs_path_current_dir(task,
-							reinterpret_cast<DirectoryEntry*>(m.data.blk_io.buf));
-	finalize_directory_change(m, task);
+	Message reply = { .type = MsgType::FS_CHANGE_DIR,
+					  .sender = process_ids::FS_FAT32 };
+	// Truncate to the reply buffer: full_path can be far longer than
+	// data.fs.name and an unchecked memcpy corrupts the Message (issue #313).
+	strncpy(reply.data.fs.name, name, sizeof(reply.data.fs.name) - 1);
+	reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
+	reply.result = OK;
+	kernel::task::reply(m, &reply);
 }
 
 /// Reset to the root directory and reply to the FS_CHANGE_DIR request.
 void handle_change_to_root(const Message& m, kernel::task::Task* t)
 {
 	set_fs_path_to_root(t);
-
-	Message reply = { .type = MsgType::FS_CHANGE_DIR,
-					  .sender = process_ids::FS_FAT32 };
-	reply.data.fs.name[0] = '/';
-	reply.data.fs.name[1] = '\0';
-	reply.data.fs.result = 0;
-	kernel::task::send_message(m.sender, reply);
+	reply_change_dir(m, "/");
 }
 
 void send_error_response(const Message& m, const char* error_msg = nullptr)
 {
 	Message reply = { .type = MsgType::FS_CHANGE_DIR,
 					  .sender = process_ids::FS_FAT32 };
-	reply.data.fs.result = -1;
+	reply.result = ERR_NO_FILE;
 	if (error_msg != nullptr) {
 		strncpy(reply.data.fs.name, error_msg, sizeof(reply.data.fs.name) - 1);
 		reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
 	}
-	kernel::task::send_message(m.sender, reply);
-}
-
-void request_parent_directory_load(const Message& m,
-								   kernel::task::Task* t,
-								   DirectoryEntry* parent_entry)
-{
-	const fs_id_t request_id = next_change_dir_id++;
-	change_dir_requests[request_id] = t->id;
-	change_dir_names[request_id] = "..";
-
-	const std::string current_full_path = t->fs_path.full_path;
-	const size_t last_slash = current_full_path.rfind('/');
-	parent_dir_names[request_id] =
-			(last_slash == 0) ? "/" : current_full_path.substr(0, last_slash);
-
-	send_read_req_to_blk_device(calc_start_sector(parent_entry->first_cluster()),
-								BYTES_PER_CLUSTER, MsgType::FS_CHANGE_DIR,
-								request_id);
-
-	Message reply = { .type = MsgType::FS_CHANGE_DIR,
-					  .sender = process_ids::FS_FAT32 };
-	// Truncate to the reply buffer: full_path can be far longer than
-	// data.fs.name and an unchecked memcpy corrupts the Message (issue #313).
-	strncpy(reply.data.fs.name, parent_dir_names[request_id].c_str(),
-			sizeof(reply.data.fs.name) - 1);
-	reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
-	reply.data.fs.result = 0;
-	kernel::task::send_message(m.sender, reply);
+	kernel::task::reply(m, &reply);
 }
 
 void handle_parent_directory_change(const Message& m, kernel::task::Task* t)
@@ -231,7 +142,26 @@ void handle_parent_directory_change(const Message& m, kernel::task::Task* t)
 		return;
 	}
 
-	request_parent_directory_load(m, t, parent_entry);
+	const std::string current_full_path = t->fs_path.full_path;
+	const size_t last_slash = current_full_path.rfind('/');
+	const std::string parent_path =
+			(last_slash == 0) ? "/" : current_full_path.substr(0, last_slash);
+
+	// Synchronous cluster load (issue #314 Stage B): the reply below
+	// reports the real outcome, and the change_dir_requests/names maps
+	// that tracked the in-flight load are gone.
+	auto buf = read_from_blk(calc_start_sector(parent_entry->first_cluster()),
+							 BYTES_PER_CLUSTER);
+	if (!buf) {
+		// Device read failed: keep the current directory instead of
+		// pointing it at a null buffer.
+		send_error_response(m);
+		return;
+	}
+
+	set_fs_path_current_dir(t, reinterpret_cast<DirectoryEntry*>(buf.release()));
+	set_fs_path_to_parent(t, parent_path);
+	reply_change_dir(m, parent_path.c_str());
 }
 
 void handle_normal_directory_change(const Message& m,
@@ -249,20 +179,16 @@ void handle_normal_directory_change(const Message& m,
 		return;
 	}
 
-	const fs_id_t request_id = next_change_dir_id++;
-	change_dir_requests[request_id] = t->id;
-	change_dir_names[request_id] = upper_name;
+	auto buf = read_from_blk(calc_start_sector(entry->first_cluster()),
+							 BYTES_PER_CLUSTER);
+	if (!buf) {
+		send_error_response(m);
+		return;
+	}
 
-	send_read_req_to_blk_device(calc_start_sector(entry->first_cluster()),
-								BYTES_PER_CLUSTER, MsgType::FS_CHANGE_DIR,
-								request_id);
-
-	Message reply = { .type = MsgType::FS_CHANGE_DIR,
-					  .sender = process_ids::FS_FAT32 };
-	strncpy(reply.data.fs.name, upper_name, sizeof(reply.data.fs.name) - 1);
-	reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
-	reply.data.fs.result = 0;
-	kernel::task::send_message(m.sender, reply);
+	set_fs_path_current_dir(t, reinterpret_cast<DirectoryEntry*>(buf.release()));
+	set_fs_path_to_child(t, upper_name);
+	reply_change_dir(m, upper_name);
 }
 
 kernel::task::Task* get_effective_task(ProcessId sender)
@@ -278,11 +204,6 @@ kernel::task::Task* get_effective_task(ProcessId sender)
 
 void handle_fs_change_dir(const Message& m)
 {
-	if (m.sender == process_ids::VIRTIO_BLK) {
-		handle_virtio_response(m);
-		return;
-	}
-
 	auto* task = get_effective_task(m.sender);
 	if (task == nullptr) {
 		send_error_response(m, "Task not found");
@@ -306,10 +227,6 @@ void handle_fs_change_dir(const Message& m)
 
 void handle_get_directory_contents(const Message& m)
 {
-	if (m.type == MsgType::IPC_READ_FROM_BLK_DEVICE) {
-		return;
-	}
-
 	auto* t = kernel::task::get_task(m.sender);
 	if (t == nullptr) {
 		// Requester is gone; there is no one to reply to.
@@ -327,9 +244,7 @@ void handle_get_directory_contents(const Message& m)
 	DirectoryEntry* current_dir = t->fs_path.current_dir;
 	if (current_dir == nullptr) {
 		LOG_ERROR("current directory not set");
-		Message sm = { .type = MsgType::GET_DIRECTORY_CONTENTS,
-					   .sender = process_ids::FS_FAT32 };
-		kernel::task::send_message(m.sender, sm);
+		reply_error(m, ERR_NO_FILE);
 		return;
 	}
 	std::vector<char> entries(ENTRIES_PER_CLUSTER * sizeof(DirectoryEntry));
@@ -377,11 +292,12 @@ void handle_get_directory_contents(const Message& m)
 
 	Message sm = { .type = MsgType::GET_DIRECTORY_CONTENTS,
 				   .sender = process_ids::FS_FAT32 };
+	sm.result = OK;
 	sm.tool_desc.addr = buf;
 	sm.tool_desc.size = entries_count * sizeof(Stat);
 	sm.tool_desc.present = buf != nullptr;
 
-	kernel::task::send_message(m.sender, sm);
+	kernel::task::reply(m, &sm);
 }
 
 void handle_fs_pwd(const Message& m)
@@ -403,15 +319,16 @@ void handle_fs_pwd(const Message& m)
 	}
 
 	if (t->fs_path.current_dir == nullptr) {
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_NO_FILE);
 		return;
 	}
 
 	strncpy(reply.data.fs.name, t->fs_path.current_dir_name,
 			sizeof(reply.data.fs.name) - 1);
 	reply.data.fs.name[sizeof(reply.data.fs.name) - 1] = '\0';
+	reply.result = OK;
 
-	kernel::task::send_message(m.sender, reply);
+	kernel::task::reply(m, &reply);
 }
 
 void persist_directory_entry(DirectoryEntry* entry, const char* name)
@@ -447,14 +364,13 @@ void persist_directory_entry(DirectoryEntry* entry, const char* name)
 
 	const unsigned int root_dir_sector = calc_start_sector(VOLUME_BPB->root_cluster);
 
-	// Write the entire ROOT_DIR cluster back to disk
-	send_write_req_to_blk_device(write_buffer, root_dir_sector, BYTES_PER_CLUSTER,
-								 MsgType::FS_WRITE, 0, 0);
-
-	// write_buffer is freed by the block device driver (kernel::hw::virtio::blk's
-	// IPC_WRITE_TO_BLK_DEVICE handler) once it has copied the data to disk;
-	// this request is not tracked in file.cpp's pending_writes map because no
-	// caller here is waiting on an FS_WRITE reply.
+	// Write the entire ROOT_DIR cluster back to disk; write_to_blk hands
+	// buffer ownership to the blk task and reports the real outcome
+	const error_t err =
+			write_to_blk(write_buffer, root_dir_sector, BYTES_PER_CLUSTER);
+	if (IS_ERR(err)) {
+		LOG_ERROR("failed to persist directory entry: %d", err);
+	}
 }
 
 } // namespace kernel::fs::fat

--- a/kernel/fs/fat/fat.cpp
+++ b/kernel/fs/fat/fat.cpp
@@ -6,9 +6,9 @@
 #include "fat.hpp"
 #include <libs/common/message.hpp>
 #include <libs/common/types.hpp>
-#include <queue>
 #include "fs/file_info.hpp"
 #include "internal_common.hpp"
+#include "log/log.hpp"
 #include "task/task.hpp"
 
 namespace kernel::fs::fat
@@ -18,15 +18,21 @@ void fat32_service()
 {
 	kernel::task::Task* t = kernel::task::CURRENT_TASK;
 	t->is_initialized = false;
-	pending_messages = std::queue<Message>();
 
 	init_read_contexts();
 
-	send_read_req_to_blk_device(BOOT_SECTOR, SECTOR_SIZE,
-								MsgType::INITIALIZE_TASK);
+	if (IS_ERR(initialize_fat32())) {
+		// Without the volume metadata every request would corrupt state;
+		// park the service instead of serving garbage.
+		LOG_ERROR("FAT32 initialization failed; file system unavailable");
+		while (true) {
+			__asm__("hlt");
+		}
+	}
+
+	t->is_initialized = true;
 
 	// Register message handlers
-	t->add_msg_handler(MsgType::INITIALIZE_TASK, handle_initialize);
 	t->add_msg_handler(MsgType::IPC_GET_FILE_INFO, handle_get_file_info);
 	t->add_msg_handler(MsgType::IPC_READ_FILE_DATA, handle_read_file_data);
 	t->add_msg_handler(MsgType::GET_DIRECTORY_CONTENTS,

--- a/kernel/fs/fat/file.cpp
+++ b/kernel/fs/fat/file.cpp
@@ -9,8 +9,6 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <map>
-#include <vector>
 #include "elf.hpp"
 #include "fat.hpp"
 #include "fs/file_descriptor.hpp"
@@ -28,25 +26,6 @@ namespace kernel::fs::fat
 namespace
 {
 
-/// In-flight file data writes waiting for a block device completion,
-/// keyed by request id.
-struct PendingWrite {
-	ProcessId requester; ///< Process waiting for the FS_WRITE reply
-	size_t write_len;	 ///< Bytes to report on success
-};
-
-std::map<fs_id_t, PendingWrite> pending_writes;
-
-/// Reply with an empty payload so the requester blocked in
-/// wait_for_message() is always released, even on failure.
-void send_empty_reply(MsgType type, ProcessId requester)
-{
-	Message reply = { .type = type, .sender = process_ids::FS_FAT32 };
-	reply.data.fs.buf = nullptr;
-	reply.data.fs.len = 0;
-	kernel::task::send_message(requester, reply);
-}
-
 /// Build the cache key used by the file cache: the raw 11-byte 8.3 name.
 void entry_cache_key(const DirectoryEntry* entry, char (&key)[12])
 {
@@ -54,118 +33,78 @@ void entry_cache_key(const DirectoryEntry* entry, char (&key)[12])
 	key[11] = '\0';
 }
 
-void process_write_completion(const Message& m)
-{
-	auto it = pending_writes.find(m.data.blk_io.request_id);
-	if (it == pending_writes.end()) {
-		// Metadata writes (FAT table, directory entries) are not tracked;
-		// still surface device errors instead of dropping them silently.
-		if (IS_ERR(m.data.blk_io.result)) {
-			LOG_ERROR("block write failed: result=%d sector=%u",
-					  m.data.blk_io.result, m.data.blk_io.sector);
-		}
-		return;
-	}
-
-	Message reply = { .type = MsgType::FS_WRITE, .sender = process_ids::FS_FAT32 };
-	if (IS_ERR(m.data.blk_io.result)) {
-		LOG_ERROR("block write failed: result=%d sector=%u", m.data.blk_io.result,
-				  m.data.blk_io.sector);
-		reply.data.fs.len = 0;
-	} else {
-		reply.data.fs.len = it->second.write_len;
-	}
-
-	kernel::task::send_message(it->second.requester, reply);
-	pending_writes.erase(it);
-}
-
-} // namespace
-
-error_t process_read_data_response(const Message& m, bool for_user)
-{
-	// Take ownership of the block device buffer once; it is freed
-	// automatically on every return path below.
-	kernel::memory::unique_kbuf<> buf{ m.data.blk_io.buf };
-
-	auto it = file_caches.find(m.data.blk_io.request_id);
-	if (it == file_caches.end()) {
-		LOG_ERROR("request id not found: %lu", m.data.blk_io.request_id);
-		return ERR_INVALID_ARG;
-	}
-
-	auto& ctx = it->second;
-
-	if (IS_ERR(m.data.blk_io.result) || buf == nullptr) {
-		// Device read failed: release the requester with an error reply and
-		// drop the partially filled cache so it never serves stale data.
-		LOG_ERROR("block read failed: result=%d sector=%u", m.data.blk_io.result,
-				  m.data.blk_io.sector);
-		send_empty_reply(m.type, ctx.requester);
-		file_caches.erase(it);
-		return ERR_FAILED_READ_FROM_DEVICE;
-	}
-
-	const size_t offset = m.data.blk_io.sequence * BYTES_PER_CLUSTER;
-
-	// オフセットがファイルサイズを超えている場合は無視
-	if (offset >= ctx.total_size) {
-		return OK;
-	}
-
-	const size_t copy_len = std::min(BYTES_PER_CLUSTER, ctx.total_size - offset);
-
-	memcpy(ctx.buffer.data() + offset, buf.get(), copy_len);
-	ctx.read_size += copy_len;
-
-	if (ctx.is_read_complete()) {
-		send_file_data(m.data.blk_io.request_id, ctx.buffer.data(), ctx.total_size,
-					   ctx.requester, m.type, for_user);
-	}
-
-	return OK;
-}
-
-error_t process_file_read_request(const Message& m,
-								  DirectoryEntry* entry,
-								  bool for_user)
+/**
+ * @brief Load a file's contents into the file cache, cluster by cluster
+ *
+ * Each cluster is a synchronous call to the blk service (issue #314
+ * Stage B); the old per-request async state machine
+ * (request_id/sequence tracking, partial-read progress) is gone.
+ *
+ * @return The populated cache entry, or nullptr on failure (a partially
+ * filled cache is dropped so it can never serve stale data)
+ */
+FileCache* load_file(const DirectoryEntry* entry, ProcessId requester)
 {
 	char file_name[12];
 	entry_cache_key(entry, file_name);
 
-	FileCache* c = find_file_cache_by_path(file_name);
-	if (c != nullptr) {
-		send_file_data(m.data.fs.request_id, c->buffer.data(), c->total_size,
-					   m.sender, m.type, for_user);
-		return OK;
+	FileCache* cached = find_file_cache_by_path(file_name);
+	if (cached != nullptr) {
+		return cached;
 	}
 
-	// An empty file has no cluster chain to read; reply immediately so the
-	// requester does not block forever waiting for data that never arrives.
-	if (entry->file_size == 0 || entry->first_cluster() == 0) {
-		send_file_data(m.data.fs.request_id, nullptr, 0, m.sender, m.type, for_user);
-		return OK;
-	}
-
-	cluster_t target_cluster = entry->first_cluster();
-	size_t sequence = 0;
-	FileCache* cache = create_file_cache(file_name, entry->file_size, m.sender);
+	FileCache* cache = create_file_cache(file_name, entry->file_size, requester);
 	if (cache == nullptr) {
 		LOG_ERROR("failed to create file cache");
-		send_empty_reply(m.type, m.sender);
-		return ERR_NO_MEMORY;
+		return nullptr;
 	}
 
-	while (target_cluster != END_OF_CLUSTER_CHAIN) {
-		send_read_req_to_blk_device(calc_start_sector(target_cluster),
-									BYTES_PER_CLUSTER, m.type, cache->id,
-									sequence++);
+	size_t offset = 0;
+	cluster_t cluster = entry->first_cluster();
+	while (cluster != END_OF_CLUSTER_CHAIN && offset < entry->file_size) {
+		auto buf = read_from_blk(calc_start_sector(cluster), BYTES_PER_CLUSTER);
+		if (!buf) {
+			remove_file_cache_by_path(file_name);
+			return nullptr;
+		}
 
-		target_cluster = next_cluster(target_cluster);
+		const size_t copy_len =
+				std::min(BYTES_PER_CLUSTER, entry->file_size - offset);
+		memcpy(cache->buffer.data() + offset, buf.get(), copy_len);
+		offset += copy_len;
+
+		cluster = next_cluster(cluster);
 	}
 
-	return OK;
+	cache->read_size = entry->file_size;
+
+	return cache;
 }
+
+/**
+ * @brief Read a file and reply to the requester with its contents
+ */
+void reply_read_result(const Message& req,
+					   const DirectoryEntry* entry,
+					   bool for_user)
+{
+	// An empty file has no cluster chain to read; reply immediately so
+	// the requester is not left blocking forever.
+	if (entry->file_size == 0 || entry->first_cluster() == 0) {
+		reply_file_data(req, nullptr, 0, for_user);
+		return;
+	}
+
+	FileCache* cache = load_file(entry, req.sender);
+	if (cache == nullptr) {
+		reply_error(req, ERR_FAILED_READ_FROM_DEVICE);
+		return;
+	}
+
+	reply_file_data(req, cache->buffer.data(), cache->total_size, for_user);
+}
+
+} // namespace
 
 void execute_file(void* data, const char* name, const char* args)
 {
@@ -174,16 +113,12 @@ void execute_file(void* data, const char* name, const char* args)
 
 void handle_get_file_info(const Message& m)
 {
-	if (!kernel::task::CURRENT_TASK->is_initialized) {
-		pending_messages.push(m);
-		return;
-	}
-
 	const auto* name = m.data.fs.name;
 	kernel::graphics::to_upper(const_cast<char*>(name));
 
 	Message sm = { .type = MsgType::IPC_GET_FILE_INFO,
 				   .sender = process_ids::FS_FAT32 };
+	sm.result = ERR_NO_FILE;
 	sm.data.fs.buf = nullptr;
 
 	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
@@ -203,60 +138,53 @@ void handle_get_file_info(const Message& m)
 			void* buf = kernel::memory::alloc(sizeof(DirectoryEntry),
 											  kernel::memory::ALLOC_ZEROED);
 			if (buf == nullptr) {
-				// Fall through and reply with buf == nullptr so the
-				// requester is not left blocking forever.
 				LOG_ERROR("failed to allocate directory entry buffer");
+				sm.result = ERR_NO_MEMORY;
 				break;
 			}
 			memcpy(buf, &ROOT_DIR[i], sizeof(DirectoryEntry));
 			sm.data.fs.buf = buf;
+			sm.result = OK;
 			break;
 		}
 	}
 
-	kernel::task::send_message(m.sender, sm);
+	kernel::task::reply(m, &sm);
 }
 
 void handle_read_file_data(const Message& m)
 {
-	if (!kernel::task::CURRENT_TASK->is_initialized) {
-		pending_messages.push(m);
-		return;
-	}
-
-	if (m.sender == process_ids::VIRTIO_BLK) {
-		process_read_data_response(m, false);
-		return;
-	}
-
-	DirectoryEntry* entry = reinterpret_cast<DirectoryEntry*>(m.data.fs.buf);
+	const DirectoryEntry* entry =
+			reinterpret_cast<const DirectoryEntry*>(m.data.fs.buf);
 	if (entry == nullptr) {
 		LOG_ERROR("entry is null");
+		reply_error(m, ERR_INVALID_ARG);
 		return;
 	}
 
-	process_file_read_request(m, entry, false);
+	reply_read_result(m, entry, false);
 }
 
 void handle_fs_open(const Message& m)
 {
 	Message req = { .type = MsgType::FS_OPEN, .sender = process_ids::FS_FAT32 };
+	req.data.fs.fd = -1;
 
 	const char* name = reinterpret_cast<const char*>(m.data.fs.name);
 	kernel::graphics::to_upper(const_cast<char*>(name));
 
 	DirectoryEntry* entry = find_dir_entry(ROOT_DIR, name);
 	if (entry == nullptr) {
-		req.data.fs.fd = -1;
-		kernel::task::send_message(m.sender, req);
+		req.result = ERR_NO_FILE;
+		kernel::task::reply(m, &req);
 		return;
 	}
 
 	// Get the requesting process's task
 	kernel::task::Task* t = kernel::task::get_task(m.sender);
 	if (t == nullptr) {
-		req.data.fs.fd = -1;
-		kernel::task::send_message(m.sender, req);
+		req.result = ERR_INVALID_TASK;
+		kernel::task::reply(m, &req);
 		return;
 	}
 
@@ -266,46 +194,35 @@ void handle_fs_open(const Message& m)
 											  name, entry->file_size, m.sender);
 
 	req.data.fs.fd = fd;
-	kernel::task::send_message(m.sender, req);
+	req.result = fd < 0 ? ERR_INVALID_FD : OK;
+	kernel::task::reply(m, &req);
 }
 
 void handle_fs_read(const Message& m)
 {
-	if (m.sender == process_ids::VIRTIO_BLK) {
-		process_read_data_response(m, true);
-		return;
-	}
-
-	Message req = { .type = MsgType::FS_READ, .sender = process_ids::FS_FAT32 };
-
 	kernel::task::Task* t = kernel::task::get_task(m.sender);
 	if (t == nullptr) {
 		LOG_ERROR("Task not found: %d", m.sender.raw());
-		req.data.fs.len = 0;
-		kernel::task::send_message(m.sender, req);
+		reply_error(m, ERR_INVALID_TASK);
 		return;
 	}
 
-	FileDescriptor* fd_entry = kernel::fs::get_process_fd(
+	FileDescriptor* fd = kernel::fs::get_process_fd(
 			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, m.data.fs.fd);
-	if (fd_entry == nullptr) {
+	if (fd == nullptr) {
 		LOG_ERROR("fd not found");
-		req.data.fs.len = 0;
-		kernel::task::send_message(m.sender, req);
+		reply_error(m, ERR_INVALID_FD);
 		return;
 	}
-
-	FileDescriptor* fd = fd_entry;
 
 	DirectoryEntry* entry = find_dir_entry(ROOT_DIR, fd->name);
 	if (entry == nullptr) {
 		LOG_ERROR("entry not found");
-		req.data.fs.len = 0;
-		kernel::task::send_message(m.sender, req);
+		reply_error(m, ERR_NO_FILE);
 		return;
 	}
 
-	process_file_read_request(m, entry, true);
+	reply_read_result(m, entry, true);
 }
 
 void handle_fs_close(const Message& m)
@@ -327,36 +244,24 @@ void handle_fs_close(const Message& m)
 
 void handle_fs_write(const Message& m)
 {
-	// Completion (or failure) notification from the block device
-	if (m.sender == process_ids::VIRTIO_BLK) {
-		process_write_completion(m);
-		return;
-	}
-
-	Message reply = { .type = MsgType::FS_WRITE, .sender = process_ids::FS_FAT32 };
-
 	kernel::task::Task* t = kernel::task::get_task(m.sender);
 	if (t == nullptr) {
 		LOG_ERROR("Task %d not found - likely already exited", m.sender.raw());
 		return;
 	}
 
-	FileDescriptor* fd_entry = kernel::fs::get_process_fd(
+	FileDescriptor* fd = kernel::fs::get_process_fd(
 			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, m.data.fs.fd);
-	if (fd_entry == nullptr) {
+	if (fd == nullptr) {
 		LOG_ERROR("fd not found");
-		reply.data.fs.len = 0;
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_INVALID_FD);
 		return;
 	}
-
-	FileDescriptor* fd = fd_entry;
 
 	DirectoryEntry* entry = find_dir_entry(ROOT_DIR, fd->name);
 	if (entry == nullptr) {
 		LOG_ERROR("entry not found");
-		reply.data.fs.len = 0;
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_NO_FILE);
 		return;
 	}
 
@@ -366,8 +271,7 @@ void handle_fs_write(const Message& m)
 		cluster_t new_cluster = allocate_cluster_chain(1);
 		if (new_cluster == 0) {
 			LOG_ERROR("disk full: no free clusters available");
-			reply.data.fs.len = 0;
-			kernel::task::send_message(m.sender, reply);
+			reply_error(m, ERR_NO_MEMORY);
 			return;
 		}
 
@@ -385,8 +289,7 @@ void handle_fs_write(const Message& m)
 		if (count_free_clusters() < clusters_to_add) {
 			LOG_ERROR("disk full: need %lu clusters but only %lu free",
 					  clusters_to_add, count_free_clusters());
-			reply.data.fs.len = 0;
-			kernel::task::send_message(m.sender, reply);
+			reply_error(m, ERR_NO_MEMORY);
 			return;
 		}
 
@@ -398,8 +301,7 @@ void handle_fs_write(const Message& m)
 
 		if (extend_cluster_chain(last_cluster, clusters_to_add) == 0) {
 			LOG_ERROR("failed to extend cluster chain");
-			reply.data.fs.len = 0;
-			kernel::task::send_message(m.sender, reply);
+			reply_error(m, ERR_NO_MEMORY);
 			return;
 		}
 		write_fat_table_to_disk();
@@ -418,8 +320,7 @@ void handle_fs_write(const Message& m)
 
 	if (target_cluster == END_OF_CLUSTER_CHAIN) {
 		LOG_ERROR("invalid cluster chain");
-		reply.data.fs.len = 0;
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_INVALID_ARG);
 		return;
 	}
 
@@ -427,8 +328,7 @@ void handle_fs_write(const Message& m)
 													kernel::memory::ALLOC_ZEROED);
 	if (!cluster_buffer) {
 		LOG_ERROR("failed to allocate cluster buffer");
-		reply.data.fs.len = 0;
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_NO_MEMORY);
 		return;
 	}
 
@@ -438,24 +338,24 @@ void handle_fs_write(const Message& m)
 		// buffer
 		if (entry->file_size == 0 || fd->offset == 0) {
 			// Buffer is already zero-filled, just copy the data at the right offset
-			void* write_data = m.tool_desc.present
-									   ? m.tool_desc.addr
-									   : const_cast<char*>(m.data.fs.temp_buf);
+			const void* write_data =
+					m.tool_desc.present
+							? m.tool_desc.addr
+							: static_cast<const void*>(m.data.fs.temp_buf);
 			memcpy(static_cast<char*>(cluster_buffer.get()) + offset_in_cluster,
 				   write_data, write_len);
 		} else {
 			// TODO: For existing data, need to read first
 			LOG_ERROR(
 					"partial cluster writes with existing data not yet implemented");
-			reply.data.fs.len = 0;
-			kernel::task::send_message(m.sender, reply);
+			reply_error(m, ERR_INVALID_ARG);
 			return;
 		}
 	} else {
 		// Full cluster write - copy write data to cluster buffer
-		void* write_data = m.tool_desc.present
-								   ? m.tool_desc.addr
-								   : const_cast<char*>(m.data.fs.temp_buf);
+		const void* write_data =
+				m.tool_desc.present ? m.tool_desc.addr
+									: static_cast<const void*>(m.data.fs.temp_buf);
 		memcpy(cluster_buffer.get(), write_data, write_len);
 	}
 
@@ -465,16 +365,20 @@ void handle_fs_write(const Message& m)
 	entry_cache_key(entry, cache_key);
 	remove_file_cache_by_path(cache_key);
 
-	// Track the write and reply to the requester when the device reports
-	// completion, instead of claiming success before the write happened.
-	const fs_id_t write_request_id = generate_fs_id();
-	pending_writes[write_request_id] = PendingWrite{ m.sender, write_len };
-
-	// Ownership moves to the blk device task, which frees the buffer once
-	// the write completes (see kernel/hardware/virtio/blk.cpp:79).
-	send_write_req_to_blk_device(
-			cluster_buffer.release(), calc_start_sector(target_cluster),
-			BYTES_PER_CLUSTER, MsgType::FS_WRITE, write_request_id);
+	// Synchronous device write (issue #314 Stage B): the reply carries the
+	// real outcome instead of claiming success before the write happened.
+	// Ownership of the buffer moves to the blk task, which frees it.
+	const error_t write_err =
+			write_to_blk(cluster_buffer.release(), calc_start_sector(target_cluster),
+						 BYTES_PER_CLUSTER);
+	if (IS_ERR(write_err)) {
+		LOG_ERROR("block write failed: result=%d", write_err);
+		reply_error(m, write_err);
+		if (m.tool_desc.present) {
+			kernel::memory::free(m.tool_desc.addr);
+		}
+		return;
+	}
 
 	fd->offset += write_len;
 
@@ -514,8 +418,10 @@ void handle_fs_write(const Message& m)
 		persist_directory_entry(entry, fd->name);
 	}
 
-	// The FS_WRITE reply is sent from process_write_completion() once the
-	// block device acknowledges the data write.
+	Message reply = { .type = MsgType::FS_WRITE, .sender = process_ids::FS_FAT32 };
+	reply.result = OK;
+	reply.data.fs.len = write_len;
+	kernel::task::reply(m, &reply);
 
 	if (m.tool_desc.present) {
 		kernel::memory::free(m.tool_desc.addr);
@@ -525,6 +431,7 @@ void handle_fs_write(const Message& m)
 void handle_fs_mkfile(const Message& m)
 {
 	Message reply = { .type = MsgType::FS_MKFILE, .sender = process_ids::FS_FAT32 };
+	reply.data.fs.fd = NO_FD;
 
 	const char* name = reinterpret_cast<const char*>(m.data.fs.name);
 	kernel::graphics::to_upper(const_cast<char*>(name));
@@ -539,16 +446,16 @@ void handle_fs_mkfile(const Message& m)
 	DirectoryEntry* existing_entry = find_dir_entry(ROOT_DIR, name);
 	if (existing_entry != nullptr) {
 		LOG_ERROR("File already exists: %s", name);
-		reply.data.fs.fd = NO_FD;
-		kernel::task::send_message(m.sender, reply);
+		reply.result = ERR_INVALID_ARG;
+		kernel::task::reply(m, &reply);
 		return;
 	}
 
 	DirectoryEntry* entry = find_empty_dir_entry();
 	if (entry == nullptr) {
 		LOG_ERROR("No empty directory entry found");
-		reply.data.fs.fd = NO_FD;
-		kernel::task::send_message(m.sender, reply);
+		reply.result = ERR_NO_MEMORY;
+		kernel::task::reply(m, &reply);
 		return;
 	}
 
@@ -562,7 +469,8 @@ void handle_fs_mkfile(const Message& m)
 											  name, 0, m.sender);
 
 	reply.data.fs.fd = fd;
-	kernel::task::send_message(m.sender, reply);
+	reply.result = fd < 0 ? ERR_INVALID_FD : OK;
+	kernel::task::reply(m, &reply);
 }
 
 void handle_fs_dup2(const Message& m)
@@ -574,23 +482,20 @@ void handle_fs_dup2(const Message& m)
 
 	kernel::task::Task* t = kernel::task::get_task(m.sender);
 	if (t == nullptr) {
-		reply.data.fs.result = -1;
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_INVALID_TASK);
 		return;
 	}
 
 	kernel::fs::FileDescriptor* old_entry = kernel::fs::get_process_fd(
 			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, oldfd);
 	if (old_entry == nullptr) {
-		reply.data.fs.result = -1;
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_INVALID_FD);
 		return;
 	}
 
 	// TODO: Support for other file descriptors
 	if (newfd != STDOUT_FILENO && newfd != STDERR_FILENO) {
-		reply.data.fs.result = -1;
-		kernel::task::send_message(m.sender, reply);
+		reply_error(m, ERR_INVALID_FD);
 		return;
 	}
 
@@ -598,9 +503,9 @@ void handle_fs_dup2(const Message& m)
 		t->fd_table[newfd] = *old_entry;
 	}
 
-	reply.data.fs.result = newfd;
-	reply.data.fs.fd = oldfd;
-	kernel::task::send_message(m.sender, reply);
+	reply.result = OK;
+	reply.data.fs.fd = newfd;
+	kernel::task::reply(m, &reply);
 }
 
 } // namespace kernel::fs::fat

--- a/kernel/fs/fat/init.cpp
+++ b/kernel/fs/fat/init.cpp
@@ -8,7 +8,6 @@
 #include <cstring>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
-#include <queue>
 #include "fat.hpp"
 #include "fs/path.hpp"
 #include "internal_common.hpp"
@@ -26,68 +25,64 @@ unsigned long ENTRIES_PER_CLUSTER = 0;
 uint32_t* FAT_TABLE = nullptr;
 unsigned int FAT_TABLE_SECTOR = 0;
 kernel::fs::DirectoryEntry* ROOT_DIR = nullptr;
-std::queue<Message> pending_messages;
 
-void handle_initialize(const Message& m)
+error_t initialize_fat32()
 {
-	if (IS_ERR(m.data.blk_io.result) || m.data.blk_io.buf == nullptr) {
-		LOG_ERROR("FAT32 init read failed: sector=%u result=%d",
-				  m.data.blk_io.sector, m.data.blk_io.result);
-		return;
+	// Straight-line synchronous init (issue #314 Stage B): BPB -> FAT ->
+	// root directory, each a call to the blk service. The old async
+	// bootstrap (INITIALIZE_TASK-tagged replies, pending_messages backlog
+	// and its queue re-injection) is gone; requests that arrive while this
+	// runs simply wait in the ring until process_messages starts.
+	auto bpb_buf = read_from_blk(BOOT_SECTOR, SECTOR_SIZE);
+	if (!bpb_buf) {
+		return ERR_FAILED_READ_FROM_DEVICE;
 	}
+	VOLUME_BPB =
+			reinterpret_cast<kernel::fs::BiosParameterBlock*>(bpb_buf.release());
 
-	if (m.data.blk_io.sector == BOOT_SECTOR) {
-		VOLUME_BPB =
-				reinterpret_cast<kernel::fs::BiosParameterBlock*>(m.data.blk_io.buf);
-		BYTES_PER_CLUSTER =
-				static_cast<unsigned long>(VOLUME_BPB->bytes_per_sector) *
-				VOLUME_BPB->sectors_per_cluster;
-		ENTRIES_PER_CLUSTER = BYTES_PER_CLUSTER / sizeof(kernel::fs::DirectoryEntry);
-		FAT_TABLE_SECTOR = VOLUME_BPB->reserved_sector_count;
+	BYTES_PER_CLUSTER = static_cast<unsigned long>(VOLUME_BPB->bytes_per_sector) *
+						VOLUME_BPB->sectors_per_cluster;
+	ENTRIES_PER_CLUSTER = BYTES_PER_CLUSTER / sizeof(kernel::fs::DirectoryEntry);
+	FAT_TABLE_SECTOR = VOLUME_BPB->reserved_sector_count;
 
-		const size_t table_size = static_cast<size_t>(VOLUME_BPB->fat_size_32) *
-								  static_cast<size_t>(SECTOR_SIZE);
-
-		send_read_req_to_blk_device(FAT_TABLE_SECTOR, table_size,
-									MsgType::INITIALIZE_TASK);
-	} else if (m.data.blk_io.sector == FAT_TABLE_SECTOR) {
-		FAT_TABLE = reinterpret_cast<uint32_t*>(m.data.blk_io.buf);
-		const unsigned int root_cluster = VOLUME_BPB->root_cluster;
-
-		send_read_req_to_blk_device(calc_start_sector(root_cluster),
-									BYTES_PER_CLUSTER, MsgType::INITIALIZE_TASK);
-	} else {
-		ROOT_DIR = reinterpret_cast<kernel::fs::DirectoryEntry*>(m.data.blk_io.buf);
-		kernel::task::CURRENT_TASK->is_initialized = true;
-
-		// Replay the backlog by dispatching directly: the message ring is
-		// sealed against direct pushes (issue #314), and these messages
-		// would only come back to this task's own handler table anyway
-		while (!pending_messages.empty()) {
-			const Message msg = pending_messages.front();
-			pending_messages.pop();
-			kernel::task::CURRENT_TASK->dispatch_message(msg);
-		}
+	const size_t table_size = static_cast<size_t>(VOLUME_BPB->fat_size_32) *
+							  static_cast<size_t>(SECTOR_SIZE);
+	auto fat_buf = read_from_blk(FAT_TABLE_SECTOR, table_size);
+	if (!fat_buf) {
+		return ERR_FAILED_READ_FROM_DEVICE;
 	}
+	FAT_TABLE = reinterpret_cast<uint32_t*>(fat_buf.release());
+
+	auto root_buf = read_from_blk(calc_start_sector(VOLUME_BPB->root_cluster),
+								  BYTES_PER_CLUSTER);
+	if (!root_buf) {
+		return ERR_FAILED_READ_FROM_DEVICE;
+	}
+	ROOT_DIR = reinterpret_cast<kernel::fs::DirectoryEntry*>(root_buf.release());
+
+	return OK;
 }
 
 void handle_fs_register_path(const Message& m)
 {
-	if (!kernel::task::CURRENT_TASK->is_initialized) {
-		pending_messages.push(m);
+	Message reply = { .type = MsgType::FS_REGISTER_PATH,
+					  .sender = process_ids::FS_FAT32 };
+
+	kernel::task::Task* t = kernel::task::get_task(m.sender);
+	if (t == nullptr) {
+		LOG_ERROR("Task %d not found", m.sender.raw());
 		return;
 	}
 
-	Message reply = { .type = MsgType::FS_REGISTER_PATH, .sender = m.sender };
+	// Root tasks start at the root directory. The FS runs in ring 0, so it
+	// sets the task's fs_path directly; the old forward-to-KERNEL hop (and
+	// its heap-allocated Path hand-off) is gone (issue #314 Stage B).
+	if (t->parent_id == process_ids::INVALID) {
+		t->fs_path = init_path(ROOT_DIR);
+	}
 
-	void* buf;
-	ALLOC_OR_RETURN(buf, sizeof(Path), kernel::memory::ALLOC_ZEROED);
-
-	Path p = init_path(ROOT_DIR);
-	memcpy(buf, &p, sizeof(Path));
-	reply.data.fs.buf = buf;
-
-	kernel::task::send_message(process_ids::KERNEL, reply);
+	reply.result = OK;
+	kernel::task::reply(m, &reply);
 }
 
 } // namespace kernel::fs::fat

--- a/kernel/fs/fat/internal_common.hpp
+++ b/kernel/fs/fat/internal_common.hpp
@@ -9,10 +9,8 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include <map>
-#include <queue>
-#include <string>
 #include "fat.hpp"
+#include "memory/slab.hpp"
 
 namespace kernel::fs::fat
 {
@@ -24,19 +22,12 @@ extern unsigned long ENTRIES_PER_CLUSTER;
 extern uint32_t* FAT_TABLE;
 extern unsigned int FAT_TABLE_SECTOR;
 extern kernel::fs::DirectoryEntry* ROOT_DIR;
-extern std::queue<Message> pending_messages;
 
 // FAT table write optimization constants
 constexpr size_t FAT_WRITE_CHUNK_SIZE = 65536; // 64KB chunks for batch writes
 
 /// Space character used to right-pad the 8.3 short file name fields.
 constexpr char SFN_PAD = 0x20;
-
-// Change directory request tracking
-extern std::map<fs_id_t, ProcessId> change_dir_requests;
-extern std::map<fs_id_t, std::string> change_dir_names;
-extern std::map<fs_id_t, std::string> parent_dir_names;
-extern fs_id_t next_change_dir_id;
 
 // Common utility functions
 void read_dir_entry_name_raw(const kernel::fs::DirectoryEntry& entry, char* dest);
@@ -66,36 +57,45 @@ size_t count_free_clusters(const uint32_t* fat, size_t total_clusters);
 size_t count_free_clusters();
 size_t total_fat_clusters();
 
-// Communication with block device
-void send_read_req_to_blk_device(unsigned int sector,
-								 size_t len,
-								 MsgType dst_type,
-								 fs_id_t request_id = 0,
-								 size_t sequence = 0);
+/**
+ * @brief Synchronously read len bytes starting at sector from the block
+ * device (call/reply RPC, issue #314 Stage B)
+ * @return Owning buffer, or empty on delivery/device failure (logged)
+ */
+kernel::memory::unique_kbuf<> read_from_blk(unsigned int sector, size_t len);
 
-void send_write_req_to_blk_device(void* buffer,
-								  unsigned int sector,
-								  size_t len,
-								  MsgType dst_type,
-								  fs_id_t request_id = 0,
-								  size_t sequence = 0);
+/**
+ * @brief Synchronously write len bytes to the block device
+ * @param buffer Data to write; ownership moves to the blk task, which
+ * frees it once the device write completes (success or failure)
+ * @return OK, or the delivery/device error
+ */
+error_t write_to_blk(void* buffer, unsigned int sector, size_t len);
+
+// Synchronous FAT32 initialization: BPB -> FAT -> root directory
+error_t initialize_fat32();
 
 // FAT table persistence
 void write_fat_table_to_disk();
 
-// Send file data to requester
-void send_file_data(fs_id_t id,
-					void* buf,
-					size_t size,
-					ProcessId requester,
-					MsgType type,
-					bool for_user);
+/**
+ * @brief Reply to a read-style request with file data
+ *
+ * for_user = true copies into a page-aligned OOL buffer (mapped into the
+ * requester's space at delivery); false hands the kernel address itself
+ * (borrowed from the file cache) to a kernel-side requester.
+ */
+void reply_file_data(const Message& req, void* buf, size_t size, bool for_user);
+
+/**
+ * @brief Reply with an error result and no payload
+ */
+void reply_error(const Message& req, error_t result);
 
 // Directory entry persistence
 void persist_directory_entry(kernel::fs::DirectoryEntry* entry, const char* name);
 
 // Message handlers declarations
-void handle_initialize(const Message& m);
 void handle_get_file_info(const Message& m);
 void handle_read_file_data(const Message& m);
 void handle_get_directory_contents(const Message& m);

--- a/kernel/fs/fat/utils.cpp
+++ b/kernel/fs/fat/utils.cpp
@@ -232,61 +232,40 @@ void free_cluster_chain(cluster_t start_cluster)
 	free_cluster_chain(FAT_TABLE, start_cluster);
 }
 
-void send_read_req_to_blk_device(unsigned int sector,
-								 size_t len,
-								 MsgType dst_type,
-								 fs_id_t request_id,
-								 size_t sequence)
+kernel::memory::unique_kbuf<> read_from_blk(unsigned int sector, size_t len)
 {
 	Message m = { .type = MsgType::IPC_READ_FROM_BLK_DEVICE,
 				  .sender = process_ids::FS_FAT32 };
 	m.data.blk_io.sector = sector;
 	m.data.blk_io.len = len;
-	m.data.blk_io.dst_type = dst_type;
-	m.data.blk_io.request_id = request_id;
-	m.data.blk_io.sequence = sequence;
 
-	kernel::task::send_message(process_ids::VIRTIO_BLK, m);
+	const error_t err = kernel::task::call(process_ids::VIRTIO_BLK, &m);
+	if (IS_ERR(err) || IS_ERR(m.result) || m.data.blk_io.buf == nullptr) {
+		LOG_ERROR("block read failed: sector=%u len=%lu err=%d result=%d", sector,
+				  len, err, m.result);
+		return kernel::memory::unique_kbuf<>{};
+	}
+
+	return kernel::memory::unique_kbuf<>{ m.data.blk_io.buf };
 }
 
-void send_write_req_to_blk_device(void* buffer,
-								  unsigned int sector,
-								  size_t len,
-								  MsgType dst_type,
-								  fs_id_t request_id,
-								  size_t sequence)
+error_t write_to_blk(void* buffer, unsigned int sector, size_t len)
 {
 	Message m = { .type = MsgType::IPC_WRITE_TO_BLK_DEVICE,
 				  .sender = process_ids::FS_FAT32 };
 	m.data.blk_io.buf = buffer;
 	m.data.blk_io.sector = sector;
 	m.data.blk_io.len = len;
-	m.data.blk_io.dst_type = dst_type;
-	m.data.blk_io.request_id = request_id;
-	m.data.blk_io.sequence = sequence;
 
-	kernel::task::send_message(process_ids::VIRTIO_BLK, m);
-}
-
-void write_fat_sectors_fallback(unsigned int base_sector,
-								size_t start_sector,
-								size_t end_sector)
-{
-	const size_t bytes_per_sector = VOLUME_BPB->bytes_per_sector;
-
-	for (size_t i = start_sector; i < end_sector; i++) {
-		void* sector_buffer = kernel::memory::alloc(bytes_per_sector,
-													kernel::memory::ALLOC_ZEROED);
-		if (sector_buffer == nullptr) {
-			LOG_ERROR("Failed to allocate sector buffer for FAT write");
-			continue;
-		}
-		void* fat_sector =
-				reinterpret_cast<uint8_t*>(FAT_TABLE) + (i * bytes_per_sector);
-		memcpy(sector_buffer, fat_sector, bytes_per_sector);
-		send_write_req_to_blk_device(sector_buffer, base_sector + i,
-									 bytes_per_sector, MsgType::FS_WRITE, 0, i);
+	// Ownership of buffer moves to the blk task, which frees it after the
+	// device write; delivery failure means it was never handed over.
+	const error_t err = kernel::task::call(process_ids::VIRTIO_BLK, &m);
+	if (IS_ERR(err)) {
+		kernel::memory::free(buffer);
+		return err;
 	}
+
+	return m.result;
 }
 
 void write_fat_sectors_chunked(unsigned int base_sector, size_t sectors_per_fat)
@@ -305,8 +284,30 @@ void write_fat_sectors_chunked(unsigned int base_sector, size_t sectors_per_fat)
 		void* chunk_buffer =
 				kernel::memory::alloc(chunk_size, kernel::memory::ALLOC_ZEROED);
 		if (chunk_buffer == nullptr) {
-			write_fat_sectors_fallback(base_sector, sector_offset,
-									   sector_offset + current_chunk_sectors);
+			// Fall back to sector-sized writes: a 512B buffer can still
+			// succeed when the 64KB chunk cannot
+			for (size_t i = 0; i < current_chunk_sectors; ++i) {
+				void* sector_buffer = kernel::memory::alloc(
+						bytes_per_sector, kernel::memory::ALLOC_ZEROED);
+				if (sector_buffer == nullptr) {
+					LOG_ERROR("Failed to allocate sector buffer for FAT write");
+					continue;
+				}
+				memcpy(sector_buffer,
+					   reinterpret_cast<uint8_t*>(FAT_TABLE) +
+							   ((sector_offset + i) * bytes_per_sector),
+					   bytes_per_sector);
+				const error_t err = write_to_blk(
+						sector_buffer,
+						base_sector + static_cast<unsigned int>(sector_offset + i),
+						bytes_per_sector);
+				if (IS_ERR(err)) {
+					LOG_ERROR("FAT write failed: sector=%u err=%d",
+							  base_sector +
+									  static_cast<unsigned int>(sector_offset + i),
+							  err);
+				}
+			}
 			sector_offset += current_chunk_sectors;
 			continue;
 		}
@@ -315,9 +316,12 @@ void write_fat_sectors_chunked(unsigned int base_sector, size_t sectors_per_fat)
 						  (sector_offset * bytes_per_sector);
 		memcpy(chunk_buffer, fat_chunk, chunk_size);
 
-		send_write_req_to_blk_device(chunk_buffer, base_sector + sector_offset,
-									 chunk_size, MsgType::FS_WRITE, 0,
-									 sector_offset);
+		const error_t err =
+				write_to_blk(chunk_buffer, base_sector + sector_offset, chunk_size);
+		if (IS_ERR(err)) {
+			LOG_ERROR("FAT write failed: sector=%u err=%d",
+					  base_sector + static_cast<unsigned int>(sector_offset), err);
+		}
 
 		sector_offset += current_chunk_sectors;
 	}
@@ -340,22 +344,17 @@ void write_fat_table_to_disk()
 	}
 }
 
-void send_file_data(fs_id_t id,
-					void* buf,
-					size_t size,
-					ProcessId requester,
-					MsgType type,
-					bool for_user)
+void reply_file_data(const Message& req, void* buf, size_t size, bool for_user)
 {
-	Message m = { .type = type, .sender = process_ids::FS_FAT32 };
-	m.data.fs.request_id = id;
+	Message m = { .type = req.type, .sender = process_ids::FS_FAT32 };
+	m.result = OK;
 
 	if (for_user) {
 		if (size == 0) {
 			// Nothing to transfer (e.g. empty file): reply without an OOL
 			// buffer so the requester is not left blocking forever.
 			m.data.fs.len = 0;
-			kernel::task::send_message(requester, m);
+			kernel::task::reply(req, &m);
 			return;
 		}
 
@@ -364,7 +363,8 @@ void send_file_data(fs_id_t id,
 		if (user_buf == nullptr) {
 			LOG_ERROR("failed to allocate memory");
 			m.data.fs.len = 0;
-			kernel::task::send_message(requester, m);
+			m.result = ERR_NO_MEMORY;
+			kernel::task::reply(req, &m);
 			return;
 		}
 
@@ -377,7 +377,14 @@ void send_file_data(fs_id_t id,
 		m.data.fs.len = size;
 	}
 
-	kernel::task::send_message(requester, m);
+	kernel::task::reply(req, &m);
+}
+
+void reply_error(const Message& req, error_t result)
+{
+	Message m = { .type = req.type, .sender = process_ids::FS_FAT32 };
+	m.result = result;
+	kernel::task::reply(req, &m);
 }
 
 } // namespace kernel::fs::fat

--- a/kernel/hardware/virtio/blk.cpp
+++ b/kernel/hardware/virtio/blk.cpp
@@ -15,19 +15,16 @@
 
 namespace
 {
-// Pre-fill a reply so error responses always carry the request id and the
-// error kind: an all-zero reply used to collide with cached request id 0 and
-// made the FS side memcpy from a null buffer (issue #313).
+// Pre-fill a reply that echoes the request geometry; the request/reply
+// pairing itself is Message::correlation now (issue #314 Stage B), so the
+// old dst_type/request_id/sequence bookkeeping is gone.
 Message make_blk_reply(const Message& m)
 {
-	Message reply = { .type = m.data.blk_io.dst_type,
-					  .sender = process_ids::VIRTIO_BLK };
+	Message reply = { .type = m.type, .sender = process_ids::VIRTIO_BLK };
 	reply.data.blk_io.buf = nullptr;
 	reply.data.blk_io.sector = m.data.blk_io.sector;
 	reply.data.blk_io.len = m.data.blk_io.len;
-	reply.data.blk_io.sequence = m.data.blk_io.sequence;
-	reply.data.blk_io.request_id = m.data.blk_io.request_id;
-	reply.data.blk_io.result = OK;
+	reply.result = OK;
 
 	return reply;
 }
@@ -42,8 +39,8 @@ void handle_read_request(const Message& m)
 	void* buf_ptr = kernel::memory::alloc(len, kernel::memory::ALLOC_ZEROED);
 	if (buf_ptr == nullptr) {
 		LOG_ERROR("failed to allocate read buffer: len=%d", len);
-		reply.data.blk_io.result = ERR_NO_MEMORY;
-		kernel::task::send_message(m.sender, reply);
+		reply.result = ERR_NO_MEMORY;
+		kernel::task::reply(m, &reply);
 		return;
 	}
 
@@ -53,14 +50,15 @@ void handle_read_request(const Message& m)
 	if (IS_ERR(err)) {
 		LOG_ERROR("failed to read from blk device: %d", err);
 		kernel::memory::free(buf);
-		reply.data.blk_io.result = err;
-		kernel::task::send_message(m.sender, reply);
+		reply.result = err;
+		kernel::task::reply(m, &reply);
 		return;
 	}
 
+	// Ownership of buf moves to the caller with the reply
 	reply.data.blk_io.buf = buf;
 
-	kernel::task::send_message(m.sender, reply);
+	kernel::task::reply(m, &reply);
 }
 
 void handle_write_request(const Message& m)
@@ -75,14 +73,14 @@ void handle_write_request(const Message& m)
 			static_cast<const char*>(m.data.blk_io.buf), sector, len);
 	if (IS_ERR(err)) {
 		LOG_ERROR("failed to write to blk device: %d", err);
-		reply.data.blk_io.result = err;
+		reply.result = err;
 	}
 
 	kernel::memory::free(m.data.blk_io.buf);
 
 	// Always report completion so the FS side can acknowledge the requester
 	// instead of claiming success before the device write finished.
-	kernel::task::send_message(m.sender, reply);
+	kernel::task::reply(m, &reply);
 }
 } // namespace
 

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -7,6 +7,7 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
+#include "error.hpp"
 #include "fs/fat/fat.hpp"
 #include "graphics/font.hpp"
 #include "graphics/screen.hpp"
@@ -80,27 +81,31 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 			return copy_size;
 		}
 		// File output - fd contains actual file info after dup2
-		Message m = { .type = MsgType::FS_WRITE, .sender = t->id };
-		m.data.fs.fd = fd;
-		m.data.fs.len = count;
+		Message req = { .type = MsgType::FS_WRITE, .sender = t->id };
+		req.data.fs.fd = fd;
+		req.data.fs.len = count;
 
 		// For small writes, use inline buffer temporarily
-		if (count <= sizeof(m.data.fs.temp_buf) - 1) {
-			copy_from_user(m.data.fs.temp_buf, buf, count);
-			m.data.fs.temp_buf[count] = '\0';
+		if (count <= sizeof(req.data.fs.temp_buf) - 1) {
+			copy_from_user(req.data.fs.temp_buf, buf, count);
+			req.data.fs.temp_buf[count] = '\0';
 		} else {
-			// Large writes not supported currently
+			// Large writes land with OOL transfer in issue #314 Stage C
 			LOG_ERROR("Large write not supported: %d bytes", count);
 			return ERR_INVALID_ARG;
 		}
 
-		kernel::task::send_message(process_ids::FS_FAT32, m);
+		// Correlation-matched RPC: the reply cannot be confused with any
+		// other FS_WRITE traffic (issue #314 Stage B)
+		const error_t err = kernel::task::call(process_ids::FS_FAT32, &req);
+		if (IS_ERR(err)) {
+			return err;
+		}
+		if (IS_ERR(req.result)) {
+			return req.result;
+		}
 
-		// Wait for response from file system
-		Message reply = kernel::task::wait_for_message(MsgType::FS_WRITE);
-
-		// The FS process will deallocate the OOL memory
-		return reply.data.fs.len;
+		return req.data.fs.len;
 	}
 
 	// For file descriptors, the user process should use fs_write() through IPC
@@ -198,10 +203,53 @@ error_t sys_ipc(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
 			copy_m.sender = t->id;
 		}
 
-		kernel::task::send_message(ProcessId::from_raw(dest), copy_m);
+		// One-way sends never carry the reply flag; IPC_REPLY is the only
+		// door to the reply-slot delivery path
+		copy_m.flags &= ~MSG_FLAG_REPLY;
+
+		return kernel::task::send_message(ProcessId::from_raw(dest), copy_m);
 	}
 
-	return OK;
+	if (flags == IPC_CALL) {
+		Message copy_m;
+		if (copy_from_user(&copy_m, m, sizeof(copy_m)) != sizeof(copy_m)) {
+			return ERR_INVALID_ARG;
+		}
+
+		// call() forces the sender and manages the correlation id; the
+		// caller never sees either. The reply overwrites the user message.
+		const error_t err = kernel::task::call(ProcessId::from_raw(dest), &copy_m);
+		if (IS_ERR(err)) {
+			return err;
+		}
+
+		if (copy_to_user(m, &copy_m, sizeof(copy_m)) != sizeof(copy_m)) {
+			return ERR_INVALID_ARG;
+		}
+
+		return OK;
+	}
+
+	if (flags == IPC_REPLY) {
+		Message copy_m;
+		if (copy_from_user(&copy_m, m, sizeof(copy_m)) != sizeof(copy_m)) {
+			return ERR_INVALID_ARG;
+		}
+
+		if (copy_m.correlation == 0) {
+			// The request was fire-and-forget: nothing to answer
+			return OK;
+		}
+
+		// The server runtime echoes the request's correlation into the
+		// reply; the kernel stamps the flag and the true sender
+		copy_m.sender = t->id;
+		copy_m.flags |= MSG_FLAG_REPLY;
+
+		return kernel::task::send_message(ProcessId::from_raw(dest), copy_m);
+	}
+
+	return ERR_INVALID_ARG;
 }
 
 ProcessId sys_fork(void)
@@ -248,26 +296,21 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 		return ERR_INVALID_ARG;
 	}
 
-	kernel::task::send_message(process_ids::FS_FAT32, msg);
+	RETURN_IF_ERROR(kernel::task::call(process_ids::FS_FAT32, &msg));
 
-	const Message info_m =
-			kernel::task::wait_for_message(MsgType::IPC_GET_FILE_INFO);
-
-	auto* entry = reinterpret_cast<kernel::fs::DirectoryEntry*>(info_m.data.fs.buf);
-	if (entry == nullptr) {
+	auto* entry = reinterpret_cast<kernel::fs::DirectoryEntry*>(msg.data.fs.buf);
+	if (IS_ERR(msg.result) || entry == nullptr) {
 		return ERR_NO_FILE;
 	}
 
 	Message read_msg{ .type = MsgType::IPC_READ_FILE_DATA,
 					  .sender = kernel::task::CURRENT_TASK->id };
 	read_msg.data.fs.buf = entry;
-	kernel::task::send_message(process_ids::FS_FAT32, read_msg);
-
-	const Message data_m =
-			kernel::task::wait_for_message(MsgType::IPC_READ_FILE_DATA);
+	const error_t read_err = kernel::task::call(process_ids::FS_FAT32, &read_msg);
 	kernel::memory::free(entry);
+	RETURN_IF_ERROR(read_err);
 
-	if (data_m.data.fs.buf == nullptr) {
+	if (IS_ERR(read_msg.result) || read_msg.data.fs.buf == nullptr) {
 		LOG_ERROR("failed to read file data for exec");
 		return ERR_FAILED_READ_FROM_DEVICE;
 	}
@@ -290,7 +333,7 @@ error_t sys_exec(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	kernel::memory::clean_page_tables(old_page_table);
 
 	// TODO: fix this
-	kernel::fs::fat::execute_file(data_m.data.fs.buf, "", copy_args);
+	kernel::fs::fat::execute_file(read_msg.data.fs.buf, "", copy_args);
 
 	return OK;
 }
@@ -300,17 +343,40 @@ void sys_exit(uint64_t arg1) { kernel::task::exit_task(arg1); }
 ProcessId sys_wait(uint64_t arg1)
 {
 	auto __user* status = reinterpret_cast<int*>(arg1);
+	kernel::task::Task* t = kernel::task::CURRENT_TASK;
 
-	// Sleep until the child exits instead of busy-waiting (issue #313)
-	Message m = kernel::task::wait_for_message(MsgType::IPC_EXIT_TASK);
+	// Child exits are parent-side records now, not IPC messages (issue
+	// #314 Stage B): pop the oldest one, sleeping until a child exits.
+	// The old "forward the exit message to SHELL" hack is gone; the shell
+	// acts on sys_wait's return instead.
+	kernel::task::ChildExitRecord record{};
+	while (true) {
+		__asm__("cli");
+		if (t->num_exit_records > 0) {
+			record = t->exit_records[0];
+			for (int i = 1; i < t->num_exit_records; ++i) {
+				t->exit_records[i - 1] = t->exit_records[i];
+			}
+			--t->num_exit_records;
+			t->state = kernel::task::TASK_RUNNING;
+			t->wait_reason = kernel::task::WaitReason::NONE;
+			__asm__("sti");
+			break;
+		}
 
-	task::send_message(process_ids::SHELL, m);
+		// Declare WAITING while interrupts are off (lost-wakeup
+		// discipline); record_child_exit wakes CHILD waiters
+		t->wait_reason = kernel::task::WaitReason::CHILD;
+		t->state = kernel::task::TASK_WAITING;
+		__asm__("sti");
+		kernel::task::switch_next_task(false);
+	}
 
-	if (copy_to_user(status, &m.data.exit_task.status, sizeof(int)) != sizeof(int)) {
+	if (copy_to_user(status, &record.status, sizeof(int)) != sizeof(int)) {
 		return ProcessId::from_raw(-1);
 	}
 
-	return m.sender;
+	return ProcessId::from_raw(record.pid);
 }
 
 ProcessId sys_getpid(void) { return kernel::task::CURRENT_TASK->id; }

--- a/kernel/task/builtin.cpp
+++ b/kernel/task/builtin.cpp
@@ -33,18 +33,19 @@ void handle_initialize_task(const Message& m)
 
 void handle_memory_usage(const Message& m)
 {
-	Message send_m = { .type = MsgType::IPC_MEMORY_USAGE,
-					   .sender = process_ids::KERNEL };
+	Message resp = { .type = MsgType::IPC_MEMORY_USAGE,
+					 .sender = process_ids::KERNEL };
 
 	size_t used_mem = 0;
 	size_t total_mem = 0;
 
 	kernel::memory::get_memory_usage(&total_mem, &used_mem);
 
-	send_m.data.memory_usage.total = total_mem;
-	send_m.data.memory_usage.used = used_mem;
+	resp.data.memory_usage.total = total_mem;
+	resp.data.memory_usage.used = used_mem;
+	resp.result = OK;
 
-	kernel::task::send_message(m.sender, send_m);
+	kernel::task::reply(m, &resp);
 }
 
 void handle_pci(const Message& m)
@@ -67,26 +68,6 @@ void handle_pci(const Message& m)
 	}
 }
 
-void handle_fs_register_path(const Message& m)
-{
-	Path* p = reinterpret_cast<Path*>(m.data.fs.buf);
-	if (p == nullptr) {
-		LOG_ERROR("failed to allocate memory");
-		return;
-	}
-
-	kernel::task::Task* t = kernel::task::get_task(m.sender);
-	if (t->parent_id == process_ids::INVALID) {
-		memcpy(&t->fs_path, p, sizeof(Path));
-	}
-
-	kernel::memory::free(p);
-
-	Message reply = { .type = MsgType::FS_REGISTER_PATH,
-					  .sender = process_ids::KERNEL };
-	reply.data.fs.result = 0;
-	kernel::task::send_message(m.sender, reply);
-};
 } // namespace
 
 namespace kernel::task
@@ -106,7 +87,6 @@ void kernel_service()
 	t->add_msg_handler(MsgType::INITIALIZE_TASK, handle_initialize_task);
 	t->add_msg_handler(MsgType::IPC_MEMORY_USAGE, handle_memory_usage);
 	t->add_msg_handler(MsgType::IPC_PCI, handle_pci);
-	t->add_msg_handler(MsgType::FS_REGISTER_PATH, handle_fs_register_path);
 
 	kernel::task::process_messages(t);
 }
@@ -116,12 +96,10 @@ void shell_service()
 	Message m = { .type = MsgType::IPC_GET_FILE_INFO, .sender = process_ids::SHELL };
 	char path[6] = "shell";
 	memcpy(m.data.fs.name, path, 6);
-	kernel::task::send_message(process_ids::FS_FAT32, m);
 
-	const Message info_m =
-			kernel::task::wait_for_message(MsgType::IPC_GET_FILE_INFO);
-	auto* entry = reinterpret_cast<kernel::fs::DirectoryEntry*>(info_m.data.fs.buf);
-	if (entry == nullptr) {
+	const error_t info_err = kernel::task::call(process_ids::FS_FAT32, &m);
+	auto* entry = reinterpret_cast<kernel::fs::DirectoryEntry*>(m.data.fs.buf);
+	if (IS_ERR(info_err) || IS_ERR(m.result) || entry == nullptr) {
 		LOG_ERROR("failed to find shell");
 		while (true) {
 			__asm__("hlt");
@@ -130,12 +108,10 @@ void shell_service()
 
 	Message read_m = { .type = MsgType::IPC_READ_FILE_DATA,
 					   .sender = process_ids::SHELL };
-	read_m.data.fs.buf = info_m.data.fs.buf;
-	kernel::task::send_message(process_ids::FS_FAT32, read_m);
-
-	const Message data_m =
-			kernel::task::wait_for_message(MsgType::IPC_READ_FILE_DATA);
-	if (data_m.data.fs.buf == nullptr) {
+	read_m.data.fs.buf = entry;
+	const error_t read_err = kernel::task::call(process_ids::FS_FAT32, &read_m);
+	kernel::memory::free(entry);
+	if (IS_ERR(read_err) || IS_ERR(read_m.result) || read_m.data.fs.buf == nullptr) {
 		LOG_ERROR("failed to read shell binary");
 		while (true) {
 			__asm__("hlt");
@@ -143,7 +119,7 @@ void shell_service()
 	}
 
 	CURRENT_TASK->is_initialized = true;
-	kernel::fs::fat::execute_file(data_m.data.fs.buf, "shell", nullptr);
+	kernel::fs::fat::execute_file(read_m.data.fs.buf, "shell", nullptr);
 }
 
 void usb_handler_service()

--- a/kernel/task/ipc.cpp
+++ b/kernel/task/ipc.cpp
@@ -114,9 +114,32 @@ error_t send_message(ProcessId dst_id, Message& m)
 		RETURN_IF_ERROR(handle_ool_memory_alloc(m, dst));
 	}
 
-	// Keep the push and the wakeup check atomic so a receiver going to
+	// Keep the delivery and the wakeup check atomic so a receiver going to
 	// sleep cannot miss the message (lost wakeup)
 	const kernel::interrupt::IrqGuard guard;
+
+	// Replies bypass the ring: they are delivered to the caller's reply
+	// slot if and only if the correlation matches its outstanding call.
+	// Anything else is a protocol bug surfaced here instead of sitting in
+	// a queue confusing later receives (issue #314 Stage B).
+	if ((m.flags & MSG_FLAG_REPLY) != 0) {
+		if (dst->call_correlation == 0 || dst->call_correlation != m.correlation ||
+			dst->reply_pending) {
+			LOG_ERROR_CODE(ERR_INVALID_ARG,
+						   "stale reply dropped: dest = %d, type = %d, corr = %u",
+						   dst_raw, static_cast<int>(m.type), m.correlation);
+			return ERR_INVALID_ARG;
+		}
+
+		dst->reply_slot = m;
+		dst->reply_pending = true;
+
+		if (dst->state == TASK_WAITING && dst->wait_reason == WaitReason::REPLY) {
+			schedule_task(dst_id);
+		}
+
+		return OK;
+	}
 
 	if (!dst->messages.push(m)) {
 		LOG_ERROR_CODE(ERR_QUEUE_FULL, "message queue full: dest = %d, type = %d",
@@ -124,14 +147,81 @@ error_t send_message(ProcessId dst_id, Message& m)
 		return ERR_QUEUE_FULL;
 	}
 
-	// A NOTIFY waiter is parked until its doorbell fires; waking it here
-	// would resume a device wait before the device finished (the queued
-	// message is handled once the waiter returns to its receive loop)
-	if (dst->state == TASK_WAITING && dst->wait_reason != WaitReason::NOTIFY) {
+	// Wake only receive-style waits: a NOTIFY waiter is parked until its
+	// doorbell fires (waking it would resume a device wait early), and a
+	// REPLY waiter only cares about its reply slot — for both, the queued
+	// message is handled once the waiter returns to its receive loop
+	if (dst->state == TASK_WAITING && (dst->wait_reason == WaitReason::RECEIVE ||
+									   dst->wait_reason == WaitReason::NONE)) {
 		schedule_task(dst_id);
 	}
 
 	return OK;
+}
+
+error_t call(ProcessId dst, Message* inout)
+{
+	Task* t = CURRENT_TASK;
+
+	// Correlation 0 is reserved for fire-and-forget, so skip it on wrap
+	uint32_t correlation = ++t->next_correlation;
+	if (correlation == 0) {
+		correlation = ++t->next_correlation;
+	}
+
+	// The reply is routed by (sender, correlation); force the sender so a
+	// forged value cannot direct someone else's reply slot
+	inout->sender = t->id;
+	inout->correlation = correlation;
+	inout->flags &= ~MSG_FLAG_REPLY;
+	inout->result = OK;
+
+	{
+		const kernel::interrupt::IrqGuard guard;
+		t->call_correlation = correlation;
+		t->reply_pending = false;
+	}
+
+	const error_t err = send_message(dst, *inout);
+	if (IS_ERR(err)) {
+		t->call_correlation = 0;
+		return err;
+	}
+
+	while (true) {
+		__asm__("cli");
+		if (t->reply_pending) {
+			*inout = t->reply_slot;
+			t->reply_pending = false;
+			t->call_correlation = 0;
+			t->state = TASK_RUNNING;
+			t->wait_reason = WaitReason::NONE;
+			__asm__("sti");
+			return OK;
+		}
+
+		// Same lost-wakeup discipline as receive_blocking; new requests
+		// arriving meanwhile queue in the ring without waking us, which
+		// serializes a server's request handling naturally
+		t->wait_reason = WaitReason::REPLY;
+		t->state = TASK_WAITING;
+		__asm__("sti");
+		switch_next_task(false);
+	}
+}
+
+error_t reply(const Message& req, Message* resp)
+{
+	if (req.correlation == 0) {
+		// Fire-and-forget request: nobody is waiting
+		return OK;
+	}
+
+	resp->sender = CURRENT_TASK->id;
+	resp->correlation = req.correlation;
+	resp->flags |= MSG_FLAG_REPLY;
+
+	return send_message(req.sender, *resp);
 }
 
 [[gnu::no_caller_saved_registers]] void notify(ProcessId dst_id, NotifyType type)

--- a/kernel/task/ipc.cpp
+++ b/kernel/task/ipc.cpp
@@ -92,7 +92,7 @@ error_t handle_ool_memory_alloc(Message& m, Task* dst)
 error_t send_message(ProcessId dst_id, Message& m)
 {
 	const pid_t dst_raw = dst_id.raw();
-	if (dst_raw == -1 || m.sender.raw() == dst_raw) {
+	if (dst_raw == -1) {
 		LOG_ERROR_CODE(ERR_INVALID_ARG,
 					   "invalid destination task id : dest = %d, sender = %d",
 					   dst_raw, m.sender.raw());
@@ -162,6 +162,15 @@ error_t send_message(ProcessId dst_id, Message& m)
 error_t call(ProcessId dst, Message* inout)
 {
 	Task* t = CURRENT_TASK;
+
+	// A one-way send to yourself is a legitimate event-loop pattern (the
+	// shell orders its prompt restore behind queued output this way), but
+	// calling yourself can only deadlock: nobody is left to reply.
+	if (dst.raw() == t->id.raw()) {
+		LOG_ERROR_CODE(ERR_INVALID_ARG, "call to self would deadlock: task %d",
+					   t->id.raw());
+		return ERR_INVALID_ARG;
+	}
 
 	// Correlation 0 is reserved for fire-and-forget, so skip it on wrap
 	uint32_t correlation = ++t->next_correlation;

--- a/kernel/task/ipc.hpp
+++ b/kernel/task/ipc.hpp
@@ -82,6 +82,40 @@ error_t send_message(ProcessId dst, Message& m);
 [[gnu::no_caller_saved_registers]] void notify(ProcessId dst, NotifyType type);
 
 /**
+ * @brief Synchronous RPC: send a request and block until its reply
+ *
+ * The kernel assigns a per-task correlation id to the request and parks the
+ * caller in WAITING (WaitReason::REPLY). The reply bypasses the message
+ * ring and lands in the caller's dedicated reply slot, so it can never be
+ * confused with other traffic and never disturbs queued messages.
+ *
+ * The call graph must stay acyclic (user → {KERNEL, FS}, FS → BLK);
+ * a service must never call() one of its clients.
+ *
+ * @param dst Destination (server) task
+ * @param inout Request on entry; overwritten with the reply on success
+ * @return OK when a reply was delivered (check inout->result for the
+ * server-side outcome), or the send_message() delivery error
+ */
+error_t call(ProcessId dst, Message* inout);
+
+/**
+ * @brief Reply to a received request (server side)
+ *
+ * Inherits the request's correlation and stamps MSG_FLAG_REPLY, then
+ * delivers to the requester's reply slot. A request with correlation 0
+ * expects no reply and makes this a no-op. Every request with a nonzero
+ * correlation must be answered exactly once — success or error — with the
+ * outcome in resp->result.
+ *
+ * @param req The request being answered
+ * @param resp Reply message (type/payload set by the caller)
+ * @return OK on delivery (or no-op), error code otherwise; a reply nobody
+ * is waiting for is dropped with a log (protocol bug made visible)
+ */
+error_t reply(const Message& req, Message* resp);
+
+/**
  * @brief Non-blocking receive: pending notifications first, then the ring
  *
  * Notification bits are converted into synthesized NOTIFY_* messages with

--- a/kernel/task/message_queue.cpp
+++ b/kernel/task/message_queue.cpp
@@ -53,25 +53,4 @@ bool MessageQueue::pop(Message* out)
 	return true;
 }
 
-bool MessageQueue::pop_first_of_type(MsgType type, Message* out)
-{
-	for (size_t i = 0; i < count_; ++i) {
-		if (ring_[(head_ + i) % CAPACITY].type != type) {
-			continue;
-		}
-
-		*out = ring_[(head_ + i) % CAPACITY];
-
-		// Close the gap so the remaining messages keep their FIFO order
-		for (size_t j = i; j + 1 < count_; ++j) {
-			ring_[(head_ + j) % CAPACITY] = ring_[(head_ + j + 1) % CAPACITY];
-		}
-		--count_;
-
-		return true;
-	}
-
-	return false;
-}
-
 } // namespace kernel::task

--- a/kernel/task/message_queue.hpp
+++ b/kernel/task/message_queue.hpp
@@ -25,7 +25,6 @@ struct Task;
 error_t send_message(ProcessId dst, Message& m);
 bool try_receive(Task* t, Message* out);
 Message receive_blocking();
-Message wait_for_message(MsgType type);
 
 /**
  * @brief Bounded FIFO message ring owned by a Task
@@ -69,15 +68,6 @@ private:
 	 */
 	bool pop(Message* out);
 
-	/**
-	 * @brief Extract the oldest message of the given type, keeping the
-	 * relative order of everything else
-	 *
-	 * Transitional: only wait_for_message() needs the type scan, and both
-	 * disappear with correlation-id call/reply (issue #314 Stage B).
-	 */
-	bool pop_first_of_type(MsgType type, Message* out);
-
 	Message* ring_; ///< CAPACITY slots, allocated once at construction
 	size_t head_;	///< Index of the oldest message
 	size_t count_;	///< Number of queued messages
@@ -85,7 +75,6 @@ private:
 	friend error_t send_message(ProcessId, Message&);
 	friend bool try_receive(Task*, Message*);
 	friend Message receive_blocking();
-	friend Message wait_for_message(MsgType);
 };
 
 } // namespace kernel::task

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -318,6 +318,25 @@ void switch_next_task(bool sleep_current_task)
 	asm("int %0" : : "i"(kernel::interrupt::InterruptVector::SWITCH_TASK));
 }
 
+void record_child_exit(Task* parent, ProcessId child, int status)
+{
+	const kernel::interrupt::IrqGuard guard;
+
+	if (parent->num_exit_records >= Task::MAX_CHILD_EXIT_RECORDS) {
+		LOG_ERROR("exit records full: parent = %d, child = %d dropped",
+				  parent->id.raw(), child.raw());
+		return;
+	}
+
+	parent->exit_records[parent->num_exit_records] =
+			ChildExitRecord{ child.raw(), status };
+	++parent->num_exit_records;
+
+	if (parent->state == TASK_WAITING && parent->wait_reason == WaitReason::CHILD) {
+		schedule_task(parent->id);
+	}
+}
+
 void exit_task(int status)
 {
 	Task* t = CURRENT_TASK;
@@ -325,10 +344,13 @@ void exit_task(int status)
 	// Release all file descriptors before exiting
 	kernel::fs::release_all_process_fds(t->fd_table.data(), MAX_FDS_PER_PROCESS);
 
+	// Child termination is parent/child bookkeeping, not IPC (issue #314
+	// Stage B): park the status on the parent for sys_wait to collect
 	if (t->has_parent()) {
-		Message m = { .type = MsgType::IPC_EXIT_TASK, .sender = t->id };
-		m.data.exit_task.status = status;
-		send_message(t->parent_id, m);
+		Task* parent = get_task(t->parent_id);
+		if (parent != nullptr) {
+			record_child_exit(parent, t->id, status);
+		}
 	}
 
 	t->state = TASK_EXITED;
@@ -398,6 +420,12 @@ Task::Task(int raw_id,
 	  pending_notifications{ 0 },
 	  wait_reason{ WaitReason::NONE },
 	  wait_notify_mask{ 0 },
+	  next_correlation{ 0 },
+	  call_correlation{ 0 },
+	  reply_pending{ false },
+	  reply_slot{},
+	  exit_records{},
+	  num_exit_records{ 0 },
 	  message_handlers({ std::array<message_handler_t, TOTAL_MESSAGE_TYPES>() }),
 	  fd_table()
 {
@@ -435,33 +463,6 @@ Task::Task(int raw_id,
 	ctx.cs = kernel::memory::KERNEL_CS;
 	ctx.ss = kernel::memory::KERNEL_SS;
 	*reinterpret_cast<uint32_t*>(&ctx.fxsave_area[24]) = MXCSR_DEFAULT;
-}
-
-Message wait_for_message(MsgType type)
-{
-	Task* t = CURRENT_TASK;
-	Message m;
-
-	while (true) {
-		__asm__("cli");
-		if (t->messages.pop_first_of_type(type, &m)) {
-			t->state = TASK_RUNNING;
-			t->wait_reason = WaitReason::NONE;
-			__asm__("sti");
-			return m;
-		}
-
-		// No matching message yet: sleep instead of spinning, and leave
-		// the other queued messages untouched (issue #313 livelock).
-		// WAITING is declared while interrupts are off so a sender cannot
-		// slip in between the scan and the sleep. RECEIVE so any new
-		// message triggers a rescan; pending notification bits are left
-		// alone here (they are drained by receive_blocking only).
-		t->wait_reason = WaitReason::RECEIVE;
-		t->state = TASK_WAITING;
-		__asm__("sti");
-		switch_next_task(false);
-	}
 }
 
 } // namespace kernel::task

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -36,14 +36,29 @@ enum TaskState : uint8_t { TASK_RUNNING, TASK_READY, TASK_WAITING, TASK_EXITED }
  * @brief Why a TASK_WAITING task is asleep; gates who may wake it
  *
  * send_message() wakes RECEIVE and NONE waiters; notify() additionally
- * wakes a NOTIFY waiter only when the raised bit is in its mask. This
- * keeps a device wait (e.g. virtio-blk kick-and-wait) from being resumed
- * spuriously by an unrelated incoming message (issue #314 Stage A).
+ * wakes a NOTIFY waiter only when the raised bit is in its mask; a reply
+ * wakes only the REPLY waiter it correlates with; a child's exit wakes
+ * only a CHILD waiter. The gating keeps device waits and RPC waits from
+ * being resumed spuriously by unrelated traffic (issue #314).
  */
 enum class WaitReason : uint8_t {
 	NONE,	 ///< Bare sleep via switch_next_task(true); any sender wakes it
 	RECEIVE, ///< Blocked in a receive; messages and notifications wake it
 	NOTIFY,	 ///< Blocked in wait_notification(); only masked doorbells wake it
+	REPLY,	 ///< Blocked in call(); only the matching reply wakes it
+	CHILD,	 ///< Blocked in sys_wait; only a child's exit wakes it
+};
+
+/**
+ * @brief One child's exit, parked on the parent until sys_wait collects it
+ *
+ * Replaces the IPC_EXIT_TASK message: child termination is parent/child
+ * bookkeeping, not IPC, so it no longer competes with real messages for
+ * ring slots (issue #314 Stage B).
+ */
+struct ChildExitRecord {
+	pid_t pid;
+	int status;
 };
 
 static constexpr int MAX_FDS_PER_PROCESS = 32;
@@ -65,6 +80,13 @@ struct Task {
 	uint32_t pending_notifications; ///< Sticky doorbell bits (see NotifyType)
 	WaitReason wait_reason;			///< Valid while state == TASK_WAITING
 	uint32_t wait_notify_mask;		///< Doorbells awaited (WaitReason::NOTIFY)
+	uint32_t next_correlation;		///< call() id counter (0 is never issued)
+	uint32_t call_correlation;		///< Outstanding call's id, 0 = no call
+	bool reply_pending;				///< reply_slot holds an undelivered reply
+	Message reply_slot;				///< Reply delivery slot, bypasses the ring
+	static constexpr int MAX_CHILD_EXIT_RECORDS = 8;
+	std::array<ChildExitRecord, MAX_CHILD_EXIT_RECORDS> exit_records;
+	int num_exit_records; ///< Occupied prefix of exit_records (FIFO)
 	std::array<message_handler_t, TOTAL_MESSAGE_TYPES> message_handlers;
 	std::array<kernel::fs::FileDescriptor, MAX_FDS_PER_PROCESS> fd_table;
 
@@ -161,9 +183,15 @@ void switch_next_task(bool sleep_current_task);
 
 void exit_task(int status);
 
-[[noreturn]] void process_messages(Task* t);
+/**
+ * @brief Park a child's exit on the parent and wake a waiting sys_wait
+ *
+ * Appends to the parent's exit_records (FIFO; overflow is dropped with a
+ * log) and wakes the parent when it is blocked in WAITING(CHILD).
+ */
+void record_child_exit(Task* parent, ProcessId child, int status);
 
-Message wait_for_message(MsgType type);
+[[noreturn]] void process_messages(Task* t);
 
 } // namespace kernel::task
 

--- a/kernel/tests/runner.cpp
+++ b/kernel/tests/runner.cpp
@@ -5,6 +5,9 @@
 
 #include "tests/runner.hpp"
 #include <array>
+#include <libs/common/message.hpp>
+#include <libs/common/process_id.hpp>
+#include "task/ipc.hpp"
 #include "task/task.hpp"
 #include "tests/framework.hpp"
 #include "tests/test_cases/bit_utils_test.hpp"
@@ -114,6 +117,18 @@ void run_main_stage_tests()
 #ifdef KERNEL_HEAP_DEBUG_ENABLED
 	run_test_suite(register_heap_debug_tests);
 #endif
+
+	// The stdio suites exercise sys_write(stdout/stderr), which queues
+	// NOTIFY_WRITE on the real SHELL task. Drain it so boot-time tests
+	// never leak output into the interactive shell: the leak used to be
+	// masked by userland's discard-on-mismatch receive loop, which is gone
+	// with the correlation-matched call of issue #314 Stage B.
+	kernel::task::Task* shell = kernel::task::get_task(process_ids::SHELL);
+	if (shell != nullptr) {
+		Message leftover;
+		while (kernel::task::try_receive(shell, &leftover)) {
+		}
+	}
 
 	test_print_summary();
 

--- a/kernel/tests/test_cases/ipc_test.cpp
+++ b/kernel/tests/test_cases/ipc_test.cpp
@@ -295,6 +295,24 @@ void test_ipc_irq_routing_delivers_registered_doorbell()
 	ASSERT_FALSE(kernel::task::try_receive(t, &out));
 }
 
+void test_ipc_self_send_queues()
+{
+	Task* t = create_parked_task("ipc_self_send");
+	ASSERT_NOT_NULL(t);
+
+	const kernel::tests::ScopedCurrentTask scoped_task(t);
+
+	// Posting to your own queue is a legitimate event-loop pattern (the
+	// shell orders its prompt restore this way); only call-to-self is
+	// rejected (it would deadlock)
+	Message m = make_test_message(11);
+	ASSERT_EQ(kernel::task::send_message(t->id, m), OK);
+
+	Message out;
+	ASSERT_TRUE(kernel::task::try_receive(t, &out));
+	ASSERT_EQ(out.data.init.task_id, 11);
+}
+
 void test_ipc_reply_delivered_to_slot()
 {
 	Task* caller = create_parked_task("ipc_reply_slot");
@@ -477,6 +495,7 @@ void register_ipc_tests()
 				  test_ipc_wait_notification_consumes_pending_bit);
 	test_register("ipc_irq_routing_delivers_registered_doorbell",
 				  test_ipc_irq_routing_delivers_registered_doorbell);
+	test_register("ipc_self_send_queues", test_ipc_self_send_queues);
 	test_register("ipc_reply_delivered_to_slot", test_ipc_reply_delivered_to_slot);
 	test_register("ipc_reply_noop_for_fire_and_forget",
 				  test_ipc_reply_noop_for_fire_and_forget);

--- a/kernel/tests/test_cases/ipc_test.cpp
+++ b/kernel/tests/test_cases/ipc_test.cpp
@@ -1,8 +1,8 @@
 /**
  * @file tests/test_cases/ipc_test.cpp
- * @brief Tests for the IPC v2 Stage A primitives (issue #314):
- * fixed-capacity message ring, doorbell notifications, wakeup gating and
- * the IRQ routing table.
+ * @brief Tests for the IPC v2 primitives (issue #314): fixed-capacity
+ * message ring, doorbell notifications, wakeup gating, the IRQ routing
+ * table, reply-slot delivery (correlation matching) and child-exit records.
  */
 
 #include "tests/test_cases/ipc_test.hpp"
@@ -19,6 +19,12 @@
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
 #include "tests/test_utils.hpp"
+
+// Forward declaration for the syscall under test
+namespace kernel::syscall
+{
+extern ProcessId sys_wait(uint64_t arg1);
+} // namespace kernel::syscall
 
 using kernel::task::create_task;
 using kernel::task::MessageQueue;
@@ -289,6 +295,167 @@ void test_ipc_irq_routing_delivers_registered_doorbell()
 	ASSERT_FALSE(kernel::task::try_receive(t, &out));
 }
 
+void test_ipc_reply_delivered_to_slot()
+{
+	Task* caller = create_parked_task("ipc_reply_slot");
+	ASSERT_NOT_NULL(caller);
+
+	// Simulate a task blocked in call(): outstanding correlation + REPLY wait
+	caller->call_correlation = 42;
+	caller->reply_pending = false;
+	caller->wait_reason = WaitReason::REPLY;
+	caller->state = kernel::task::TASK_WAITING;
+
+	Message req = { .type = MsgType::IPC_MEMORY_USAGE, .sender = caller->id };
+	req.correlation = 42;
+
+	Message resp = { .type = MsgType::IPC_MEMORY_USAGE,
+					 .sender = kernel::task::CURRENT_TASK->id };
+	resp.result = OK;
+	ASSERT_EQ(kernel::task::reply(req, &resp), OK);
+
+	// Delivered to the slot (not the ring), correlation echoed, caller woken
+	ASSERT_TRUE(caller->reply_pending);
+	ASSERT_TRUE(caller->messages.empty());
+	ASSERT_EQ(caller->reply_slot.correlation, 42U);
+	ASSERT_EQ(caller->reply_slot.flags & MSG_FLAG_REPLY, MSG_FLAG_REPLY);
+	ASSERT_EQ(caller->state, kernel::task::TASK_READY);
+
+	remove_from_run_queue(caller);
+	caller->state = kernel::task::TASK_RUNNING;
+	caller->call_correlation = 0;
+	caller->reply_pending = false;
+	caller->wait_reason = WaitReason::NONE;
+}
+
+void test_ipc_reply_noop_for_fire_and_forget()
+{
+	Task* t = create_parked_task("ipc_reply_noop");
+	ASSERT_NOT_NULL(t);
+
+	// A request with correlation 0 expects no reply: reply() is a no-op
+	Message req = { .type = MsgType::FS_CLOSE, .sender = t->id };
+	req.correlation = 0;
+
+	Message resp = { .type = MsgType::FS_CLOSE,
+					 .sender = kernel::task::CURRENT_TASK->id };
+	ASSERT_EQ(kernel::task::reply(req, &resp), OK);
+
+	ASSERT_FALSE(t->reply_pending);
+	ASSERT_TRUE(t->messages.empty());
+}
+
+void test_ipc_stale_reply_dropped()
+{
+	Task* t = create_parked_task("ipc_stale");
+	ASSERT_NOT_NULL(t);
+
+	// No outstanding call: a reply-flagged message must be dropped with an
+	// error, never queued (a late reply is a protocol bug made visible)
+	Message stale = { .type = MsgType::FS_READ,
+					  .sender = kernel::task::CURRENT_TASK->id };
+	stale.correlation = 7;
+	stale.flags = MSG_FLAG_REPLY;
+
+	ASSERT_EQ(kernel::task::send_message(t->id, stale), ERR_INVALID_ARG);
+	ASSERT_TRUE(t->messages.empty());
+	ASSERT_FALSE(t->reply_pending);
+
+	// Wrong correlation while a call is outstanding: also dropped
+	t->call_correlation = 9;
+	ASSERT_EQ(kernel::task::send_message(t->id, stale), ERR_INVALID_ARG);
+	ASSERT_FALSE(t->reply_pending);
+	t->call_correlation = 0;
+}
+
+void test_ipc_send_does_not_wake_reply_waiter()
+{
+	Task* caller = create_parked_task("ipc_reply_gate");
+	ASSERT_NOT_NULL(caller);
+
+	caller->call_correlation = 5;
+	caller->reply_pending = false;
+	caller->wait_reason = WaitReason::REPLY;
+	caller->state = kernel::task::TASK_WAITING;
+
+	// An ordinary message queues without waking the REPLY waiter; it is
+	// handled after the call completes (natural server serialization)
+	Message m = make_test_message(1);
+	ASSERT_EQ(kernel::task::send_message(caller->id, m), OK);
+	ASSERT_EQ(caller->state, kernel::task::TASK_WAITING);
+	ASSERT_EQ(caller->messages.size(), 1UL);
+
+	// The matching reply is what wakes it
+	Message req = { .type = MsgType::FS_READ, .sender = caller->id };
+	req.correlation = 5;
+	Message resp = { .type = MsgType::FS_READ,
+					 .sender = kernel::task::CURRENT_TASK->id };
+	ASSERT_EQ(kernel::task::reply(req, &resp), OK);
+	ASSERT_EQ(caller->state, kernel::task::TASK_READY);
+	ASSERT_TRUE(caller->reply_pending);
+	ASSERT_EQ(caller->messages.size(), 1UL);
+
+	remove_from_run_queue(caller);
+	caller->state = kernel::task::TASK_RUNNING;
+	caller->call_correlation = 0;
+	caller->reply_pending = false;
+	caller->wait_reason = WaitReason::NONE;
+	Message drained;
+	while (kernel::task::try_receive(caller, &drained)) {
+	}
+}
+
+void test_ipc_child_exit_records()
+{
+	Task* parent = create_parked_task("ipc_child_rec");
+	ASSERT_NOT_NULL(parent);
+
+	// Records accumulate FIFO while the parent is not waiting
+	kernel::task::record_child_exit(parent, ProcessId::from_raw(90), 3);
+	kernel::task::record_child_exit(parent, ProcessId::from_raw(91), 0);
+	ASSERT_EQ(parent->num_exit_records, 2);
+	ASSERT_EQ(parent->exit_records[0].pid, 90);
+	ASSERT_EQ(parent->exit_records[0].status, 3);
+	ASSERT_EQ(parent->exit_records[1].pid, 91);
+
+	// A CHILD waiter is woken by a new record
+	parent->num_exit_records = 0;
+	parent->wait_reason = WaitReason::CHILD;
+	parent->state = kernel::task::TASK_WAITING;
+	kernel::task::record_child_exit(parent, ProcessId::from_raw(92), 1);
+	ASSERT_EQ(parent->state, kernel::task::TASK_READY);
+	ASSERT_EQ(parent->num_exit_records, 1);
+
+	remove_from_run_queue(parent);
+	parent->state = kernel::task::TASK_RUNNING;
+	parent->wait_reason = WaitReason::NONE;
+	parent->num_exit_records = 0;
+}
+
+void test_ipc_sys_wait_pops_record()
+{
+	Task* parent = create_parked_task("ipc_sys_wait");
+	ASSERT_NOT_NULL(parent);
+
+	// Pre-fill the record BEFORE calling sys_wait: with none present the
+	// call would block forever in this single-threaded test
+	kernel::task::record_child_exit(parent, ProcessId::from_raw(93), 0);
+
+	const kernel::tests::ScopedCurrentTask scoped_task(parent);
+
+	// The status out-pointer is a kernel address, so the copy_to_user at
+	// the end fails and the pid comes back -1; popping the record and
+	// staying RUNNING are what this asserts. Captured first: the assert
+	// macros re-evaluate on failure and a second sys_wait would block.
+	int status = 0;
+	const ProcessId pid =
+			kernel::syscall::sys_wait(reinterpret_cast<uint64_t>(&status));
+	(void)pid;
+
+	ASSERT_EQ(parent->num_exit_records, 0);
+	ASSERT_EQ(parent->state, kernel::task::TASK_RUNNING);
+}
+
 void register_ipc_tests()
 {
 	test_register("ipc_ring_fifo_order", test_ipc_ring_fifo_order);
@@ -310,4 +477,12 @@ void register_ipc_tests()
 				  test_ipc_wait_notification_consumes_pending_bit);
 	test_register("ipc_irq_routing_delivers_registered_doorbell",
 				  test_ipc_irq_routing_delivers_registered_doorbell);
+	test_register("ipc_reply_delivered_to_slot", test_ipc_reply_delivered_to_slot);
+	test_register("ipc_reply_noop_for_fire_and_forget",
+				  test_ipc_reply_noop_for_fire_and_forget);
+	test_register("ipc_stale_reply_dropped", test_ipc_stale_reply_dropped);
+	test_register("ipc_send_does_not_wake_reply_waiter",
+				  test_ipc_send_does_not_wake_reply_waiter);
+	test_register("ipc_child_exit_records", test_ipc_child_exit_records);
+	test_register("ipc_sys_wait_pops_record", test_ipc_sys_wait_pops_record);
 }

--- a/kernel/tests/test_cases/task_test.cpp
+++ b/kernel/tests/test_cases/task_test.cpp
@@ -160,35 +160,6 @@ void test_task_memory_management()
 	ASSERT_FALSE(kernel::memory::is_slab_object_in_use(stack));
 }
 
-void test_wait_for_message_preserves_other_messages()
-{
-	Task* t = create_task("wait_msg_test", 0, true, true);
-	ASSERT_NOT_NULL(t);
-
-	t->state = kernel::task::TASK_RUNNING;
-
-	Message other = { .type = MsgType::NOTIFY_WRITE,
-					  .sender = ProcessId::from_raw(1) };
-	Message target = { .type = MsgType::IPC_EXIT_TASK,
-					   .sender = ProcessId::from_raw(2) };
-	ASSERT_EQ(kernel::task::send_message(t->id, other), OK);
-	ASSERT_EQ(kernel::task::send_message(t->id, target), OK);
-
-	const kernel::tests::ScopedCurrentTask scoped_task(t);
-
-	// The matching message is extracted even when it is not at the front
-	const Message m = kernel::task::wait_for_message(MsgType::IPC_EXIT_TASK);
-	ASSERT_TRUE(m.type == MsgType::IPC_EXIT_TASK);
-	ASSERT_EQ(m.sender.raw(), 2);
-
-	// The unrelated message is still queued (issue #313: the old
-	// implementation spun on and reordered non-matching messages)
-	ASSERT_EQ(t->messages.size(), 1UL);
-	Message remaining;
-	ASSERT_TRUE(kernel::task::try_receive(t, &remaining));
-	ASSERT_TRUE(remaining.type == MsgType::NOTIFY_WRITE);
-}
-
 void test_send_message_queue_cap()
 {
 	Task* t = create_task("queue_cap_test", 0, true, true);
@@ -254,8 +225,6 @@ void register_task_tests()
 	test_register("task_message_handling", test_task_message_handling);
 	test_register("task_copy", test_task_copy);
 	test_register("task_memory_management", test_task_memory_management);
-	test_register("wait_for_message_preserves_other_messages",
-				  test_wait_for_message_preserves_other_messages);
 	test_register("send_message_queue_cap", test_send_message_queue_cap);
 	test_register("ipc_recv_returns_queued_message",
 				  test_ipc_recv_returns_queued_message);

--- a/libs/common/message.hpp
+++ b/libs/common/message.hpp
@@ -10,6 +10,12 @@
 // flags for sys_ipc
 constexpr int IPC_RECV = 0;
 constexpr int IPC_SEND = 1;
+constexpr int IPC_CALL = 2;	 ///< send + block until the matching reply
+constexpr int IPC_REPLY = 3; ///< reply to a received request (server side)
+
+/// Message::flags bit marking a reply; correlation then names the request
+/// it answers. Set by the kernel reply path, never by hand.
+constexpr uint32_t MSG_FLAG_REPLY = 1U << 0;
 
 // Sector size of the block-device IPC contract: blk_io.sector is expressed in
 // this unit and blk_io.len is expected to be a multiple of it.
@@ -72,6 +78,14 @@ struct MsgOolDescT {
 struct Message {
 	MsgType type;
 	ProcessId sender;
+	/// Request/reply pairing id, assigned by the kernel in call(): a reply
+	/// is delivered only to the caller whose outstanding call carries the
+	/// same value. 0 = fire-and-forget (reply() becomes a no-op).
+	uint32_t correlation;
+	uint32_t flags; ///< MSG_FLAG_* bits
+	/// Reply: OK or a negative error_t describing the server-side outcome;
+	/// payload fields are only valid when this is OK. Requests carry OK.
+	int32_t result;
 	MsgOolDescT tool_desc;
 
 	union {
@@ -114,25 +128,22 @@ struct Message {
 			char bus_address[8];
 		} pci;
 
+		// The request_id/sequence/dst_type correlation fields are gone:
+		// request/reply pairing is Message::correlation, and the outcome is
+		// Message::result (issue #314 Stage B).
 		struct {
-			fs_id_t request_id;
 			void* buf;
 			unsigned int sector;
 			size_t len;
-			size_t sequence;
-			MsgType dst_type;
-			int result; ///< OK on success, negative error code on failure
 		} blk_io;
 
 		struct {
-			fs_id_t request_id;
 			fd_t fd;
 			void* buf;
 			char temp_buf[256];
 			char name[30];
 			size_t len;
 			int operation;
-			int result;
 		} fs;
 
 		struct {

--- a/libs/common/message.hpp
+++ b/libs/common/message.hpp
@@ -58,6 +58,10 @@ enum class MsgType : int32_t {
 	// keep matching userland binaries built before this entry existed; the
 	// MsgType reorganization happens in issue #314 Stage C.
 	NOTIFY_VIRTIO_BLK,
+	// Shell-internal marker the shell sends to itself after sys_wait: FIFO
+	// delivery queues it behind everything the finished command printed,
+	// so the prompt is restored only after that output is drawn.
+	SHELL_COMMAND_DONE,
 	MAX_MESSAGE_TYPE, // must be the last
 };
 

--- a/libs/user/file.cpp
+++ b/libs/user/file.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstring>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
@@ -13,7 +14,7 @@ fd_t fs_open(const char* path, int flags)
 
 	Message res = call(process_ids::FS_FAT32, &m);
 
-	return res.data.fs.fd;
+	return IS_ERR(res.result) ? -1 : res.data.fs.fd;
 }
 
 size_t fs_read(fd_t fd, void* buf, size_t count)
@@ -23,12 +24,16 @@ size_t fs_read(fd_t fd, void* buf, size_t count)
 	m.data.fs.len = count;
 
 	Message res = call(process_ids::FS_FAT32, &m);
+	if (IS_ERR(res.result) || !res.tool_desc.present) {
+		return 0;
+	}
 
-	memcpy(buf, res.tool_desc.addr, res.tool_desc.size);
+	const size_t copy_len = std::min(count, res.tool_desc.size);
+	memcpy(buf, res.tool_desc.addr, copy_len);
 
 	deallocate_ool_memory(m.sender, res.tool_desc.addr, res.tool_desc.size);
 
-	return res.tool_desc.size;
+	return copy_len;
 }
 
 void fs_close(fd_t fd)
@@ -46,7 +51,7 @@ fd_t fs_create(const char* path)
 
 	Message res = call(process_ids::FS_FAT32, &m);
 
-	return res.data.fs.fd;
+	return IS_ERR(res.result) ? -1 : res.data.fs.fd;
 }
 
 void fs_pwd(char* buf, size_t size)
@@ -54,6 +59,10 @@ void fs_pwd(char* buf, size_t size)
 	Message m = make_request(MsgType::FS_PWD);
 
 	Message res = call(process_ids::FS_FAT32, &m);
+	if (IS_ERR(res.result)) {
+		buf[0] = '\0';
+		return;
+	}
 
 	memcpy(buf, res.data.fs.name, size);
 }
@@ -64,16 +73,19 @@ size_t fs_write(fd_t fd, const void* buf, size_t count)
 	m.data.fs.fd = fd;
 	m.data.fs.len = count;
 
-	// For small writes, use inline buffer
-	if (count <= sizeof(m.data.fs.buf)) {
-		memcpy(m.data.fs.buf, buf, count);
-	} else {
-		// For larger writes, use OOL (out-of-line) memory
-		// This would require allocating OOL memory - not implemented in Phase 1
+	// Small writes ride the inline buffer; anything larger moves to OOL
+	// transfer with issue #314 Stage C. (This used to memcpy through the
+	// uninitialized fs.buf pointer with an 8-byte threshold.)
+	if (count > sizeof(m.data.fs.temp_buf) - 1) {
 		return 0;
 	}
+	memcpy(m.data.fs.temp_buf, buf, count);
+	m.data.fs.temp_buf[count] = '\0';
 
 	Message res = call(process_ids::FS_FAT32, &m);
+	if (IS_ERR(res.result)) {
+		return 0;
+	}
 
 	return res.data.fs.len;
 }
@@ -85,15 +97,13 @@ void fs_change_dir(char* buf, const char* path)
 	m.data.fs.name[strlen(path)] = '\0';
 
 	Message res = call(process_ids::FS_FAT32, &m);
-	if (IS_ERR(res.data.fs.result)) {
+	if (IS_ERR(res.result)) {
 		buf[0] = '\0';
 		return;
 	}
 
 	memcpy(buf, res.data.fs.name, strlen(res.data.fs.name));
 	buf[strlen(res.data.fs.name)] = '\0';
-
-	send_message(process_ids::SHELL, &res);
 }
 
 int fs_dup2(fd_t oldfd, fd_t newfd)
@@ -104,5 +114,5 @@ int fs_dup2(fd_t oldfd, fd_t newfd)
 
 	Message res = call(process_ids::FS_FAT32, &m);
 
-	return res.data.fs.result;
+	return IS_ERR(res.result) ? -1 : res.data.fs.fd;
 }

--- a/libs/user/ipc.cpp
+++ b/libs/user/ipc.cpp
@@ -14,16 +14,6 @@ void send_message(ProcessId dst, const Message* msg)
 	sys_ipc(dst.raw(), msg->sender.raw(), msg, IPC_SEND);
 }
 
-Message wait_for_message(MsgType type)
-{
-	Message m;
-	do {
-		receive_message(&m);
-	} while (m.type != type);
-
-	return m;
-}
-
 Message make_request(MsgType type)
 {
 	return Message{ .type = type, .sender = ProcessId::from_raw(sys_getpid()) };
@@ -31,8 +21,11 @@ Message make_request(MsgType type)
 
 Message call(ProcessId dst, Message* msg)
 {
-	send_message(dst, msg);
-	return wait_for_message(msg->type);
+	// One correlation-matched RPC in a single syscall (issue #314 Stage B):
+	// the kernel pairs the reply by id and overwrites *msg with it, so a
+	// same-typed message can never be mistaken for the answer.
+	sys_ipc(dst.raw(), msg->sender.raw(), msg, IPC_CALL);
+	return *msg;
 }
 
 void initialize_task()

--- a/libs/user/ipc.hpp
+++ b/libs/user/ipc.hpp
@@ -8,8 +8,6 @@ void receive_message(Message* msg);
 
 void send_message(ProcessId dst, const Message* msg);
 
-Message wait_for_message(MsgType type);
-
 /**
  * @brief Build a request message stamped with this process as the sender
  * @param type Message type of the request
@@ -18,12 +16,12 @@ Message wait_for_message(MsgType type);
 Message make_request(MsgType type);
 
 /**
- * @brief Send a request and block until the reply of the same type arrives
+ * @brief Send a request and block until its reply arrives (IPC_CALL)
  *
- * Wraps the send_message / wait_for_message pair used by every synchronous
- * service call. Replies are matched by message type (the current IPC has no
- * correlation id — see issue #314); when IPC v2 lands, only this function
- * has to change.
+ * The kernel assigns a correlation id and delivers the matching reply into
+ * a dedicated slot, so the answer can never be confused with other
+ * messages (issue #314 Stage B). Check the reply's result field for the
+ * server-side outcome.
  *
  * @param dst Destination process
  * @param msg Request to send (sender must already be set)

--- a/userland/shell/main.cpp
+++ b/userland/shell/main.cpp
@@ -16,10 +16,8 @@ int main(void)
 
 	Message msg;
 	while (true) {
+		// Blocks until a message arrives (issue #314); no NO_TASK polling
 		receive_message(&msg);
-		if (msg.type == MsgType::NO_TASK) {
-			continue;
-		}
 
 		switch (msg.type) {
 			case MsgType::NOTIFY_KEY_INPUT:
@@ -37,15 +35,11 @@ int main(void)
 						break;
 				};
 				break;
-			case MsgType::FS_CHANGE_DIR:
-				term->register_current_dir(msg.data.fs.name);
-				break;
 			case MsgType::INITIALIZE_TASK:
 				set_cursor_timer(500);
 				break;
-			case MsgType::IPC_EXIT_TASK:
-				term->enable_input = true;
-				term->print_user();
+			// Child exits are collected by sys_wait in Shell::process_input
+			// now; the IPC_EXIT_TASK round-trip is gone (issue #314 Stage B)
 			default:
 				break;
 		}

--- a/userland/shell/main.cpp
+++ b/userland/shell/main.cpp
@@ -1,4 +1,5 @@
 #include <libs/common/message.hpp>
+#include <libs/user/file.hpp>
 #include <libs/user/ipc.hpp>
 #include <libs/user/print.hpp>
 #include <libs/user/syscall.hpp>
@@ -38,8 +39,22 @@ int main(void)
 			case MsgType::INITIALIZE_TASK:
 				set_cursor_timer(500);
 				break;
-			// Child exits are collected by sys_wait in Shell::process_input
-			// now; the IPC_EXIT_TASK round-trip is gone (issue #314 Stage B)
+			case MsgType::SHELL_COMMAND_DONE: {
+				// Sent by Shell::process_input after sys_wait; queued behind
+				// the finished command's output, so the prompt reappears
+				// only after that output was drawn. A cd child updated this
+				// task's working directory on the FS side, so refresh it
+				// before showing the prompt.
+				char current_dir[13];
+				fs_pwd(current_dir, sizeof(current_dir) - 1);
+				current_dir[sizeof(current_dir) - 1] = '\0';
+				if (current_dir[0] != '\0') {
+					term->register_current_dir(current_dir);
+				}
+				term->enable_input = true;
+				term->print_user();
+				break;
+			}
 			default:
 				break;
 		}

--- a/userland/shell/shell.cpp
+++ b/userland/shell/shell.cpp
@@ -1,6 +1,9 @@
 #include "shell.hpp"
 #include <cstring>
+#include <libs/common/message.hpp>
+#include <libs/common/process_id.hpp>
 #include <libs/user/file.hpp>
+#include <libs/user/ipc.hpp>
 #include <libs/user/syscall.hpp>
 #include "libs/common/types.hpp"
 #include "terminal.hpp"
@@ -84,19 +87,14 @@ void Shell::process_input(char* input, Terminal& term)
 		term.printf("%s : command not found\n", command_name);
 	}
 
-	// A cd child updates this task's working directory on the FS side, so
-	// refresh the prompt's directory before showing it (this replaces the
-	// old FS_CHANGE_DIR forward through the message loop)
-	char current_dir[13];
-	fs_pwd(current_dir, sizeof(current_dir) - 1);
-	current_dir[sizeof(current_dir) - 1] = '\0';
-	if (current_dir[0] != '\0') {
-		term.register_current_dir(current_dir);
-	}
+	// Everything the child printed (NOTIFY_WRITE) was queued before it
+	// exited, so FIFO delivery keeps this self-marker behind that output:
+	// the main loop restores the prompt only after the output is drawn —
+	// the ordering the old IPC_EXIT_TASK round-trip used to provide.
+	Message done = make_request(MsgType::SHELL_COMMAND_DONE);
+	send_message(process_ids::SHELL, &done);
 
-	// sys_wait already collected the child's exit (issue #314 Stage B), so
-	// re-enable input and show the prompt right here; the old flow parked
-	// input disabled until an IPC_EXIT_TASK message looped back
-	term.enable_input = true;
-	term.print_user();
+	// Input stays disabled until the marker is handled; input_char's
+	// trailing print_user() is a no-op while disabled
+	term.enable_input = false;
 }

--- a/userland/shell/shell.cpp
+++ b/userland/shell/shell.cpp
@@ -82,9 +82,21 @@ void Shell::process_input(char* input, Terminal& term)
 
 	if (child_status != 0) {
 		term.printf("%s : command not found\n", command_name);
-		term.enable_input = false;
-		return;
 	}
 
-	term.enable_input = false;
+	// A cd child updates this task's working directory on the FS side, so
+	// refresh the prompt's directory before showing it (this replaces the
+	// old FS_CHANGE_DIR forward through the message loop)
+	char current_dir[13];
+	fs_pwd(current_dir, sizeof(current_dir) - 1);
+	current_dir[sizeof(current_dir) - 1] = '\0';
+	if (current_dir[0] != '\0') {
+		term.register_current_dir(current_dir);
+	}
+
+	// sys_wait already collected the child's exit (issue #314 Stage B), so
+	// re-enable input and show the prompt right here; the old flow parked
+	// input disabled until an IPC_EXIT_TASK message looped back
+	term.enable_input = true;
+	term.print_user();
 }


### PR DESCRIPTION
## 概要

issue #314(IPC v2)の Stage B(3 PR 分割の 2 本目、[設計文書](docs/developer/ipc-v2.md) §7/§8/§10/§12/§14)。

### call/reply + correlation id(§8)
- `call()`: カーネルがタスク毎の correlation id を採番して送信し、WAITING(REPLY) で休眠。**応答はリングを経由せず専用の応答スロット**に届き、id 一致の応答だけが起床させる
- `reply()`: 要求の correlation を引き継いで応答。**correlation 0 = 応答不要**(fire-and-forget、`fs_close` など)で no-op。宛先が待っていない/id 不一致の応答は**破棄 + LOG_ERROR**(遅延応答をプロトコルバグとして顕在化)
- `Message` ヘッダに `correlation` / `flags` / `result` を追加。全 RPC 応答の結果表現を `result`(error_t)に一本化(§11 のエラー規約決定)
- **`wait_for_message`(型スキャン受信)を カーネル・ユーザーランドとも全廃**。順序すり抜け・ライブロックのクラスごと消滅
- `sys_ipc` に **IPC_CALL**(送信+応答待ちを 1 syscall、correlation はユーザーに見せない)と **IPC_REPLY**(Phase 3 のユーザーランドサービス用)を追加。libs/user の `call()` は IPC_CALL に載せ替え

### FS↔blk 同期化・FS 初期化同期化(§14)
- fat32 はクラスタ毎に blk へ**同期 call**。自前の対応付け(`request_id`/`sequence`/`dst_type`)、部分読み進捗管理(`process_read_data_response`)、`pending_writes`、change_dir の 3 連 map を**すべて削除**
- FS 初期化は BPB → FAT → ルートを起動時に同期読み。`pending_messages` 棚上げと INITIALIZE_TASK 経由の再投入が消滅(初期化中に届いた要求はリングで自然に待つ)
- `FS_REGISTER_PATH` の user→FS→KERNEL→user の 3 ホップ転送を廃止し、ring0 の FS が直接 `fs_path` を設定して応答

### 子プロセス終了の IPC 分離(§12)
- `exit_task` は親の固定長レコード(8 件)に {pid, status} を記録し、WAITING(CHILD) の `sys_wait` を起床
- `IPC_EXIT_TASK` メッセージ・`sys_wait` の SHELL 転送ハック・shell メインループの EXIT 分岐を全廃。shell は `sys_wait` 復帰直後にプロンプト復帰し、作業ディレクトリは `fs_pwd` で取り直す(cd の「応答を SHELL へ転送」ハックも廃止)

### ついでに直った実バグ
- **libs/user `fs_write`**: インライン閾値が `sizeof(void*)`=8 バイトで、しかも**未初期化ポインタ `fs.buf` の指す先へ memcpy** していた(≤8B は UB、>8B は常に 0 を返す)。カーネル側が読む `temp_buf` を使う正しい実装に修正
- **builtin `shell_service`**: `IPC_GET_FILE_INFO` 応答の DirectoryEntry を free していなかったリークを修正

## テスト

`ipc_test.cpp` に 6 ケース追加: 応答スロット配送(correlation 一致・リング非経由・起床)/ correlation 0 の no-op / stale 応答の破棄(未待ち・id 不一致)/ **REPLY 待ちを通常 send が起こさない** / 子終了レコードの FIFO と CHILD 起床 / `sys_wait` のレコード pop。`wait_for_message` のテストは対象ごと削除。

## 確認済み / 未確認

- ✅ カーネルビルド + 変更ファイルの clang-tidy(警告ゼロ。lint 本体の破損は #360)
- ✅ ユーザーランド全ビルド(shell + 全コマンド、`make clean` 込み)
- ⏳ CI ヘッドレステスト(本 PR で実行)
- ⚠️ **QEMU 対話動作は未確認**。`./run_qemu.sh` で シェル起動・ls/cat/echo・リダイレクト write・cd(プロンプト表示含む)・free の確認をお願いします。**Message ABI が変わったためユーザーランドの再ビルドが必須ですが、`run_qemu.sh`(build_kernel.sh)は毎回 clean ビルドするため追加操作は不要**です

残りは Stage C(OOL v2・生ポインタ排除・Message 痩身・MsgType/ool_desc 改名)。#314 は Stage C 完了でクローズ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)