### PR TITLE
docs: エラー規約の決定 — error_t 単一体系を正式 ABI に(#356 Tier B)

### DIFF
--- a/.claude/rules/kernel.md
+++ b/.claude/rules/kernel.md
@@ -20,6 +20,15 @@ paths:
 - 既存コードの一括書き換えはしない。ファイルを触るタイミングで段階的に移行する(issue #322)
 
 ## エラーハンドリング
+
+### エラー規約(2026-07-23 決定、issue #356)
+- **単一体系**: エラーコードは `ErrorCode`(`libs/common/types.hpp`)のみ。カーネル内部・syscall ABI・IPC 応答のすべてで同じ負の `error_t` を使う。errno 等への変換層は作らない
+- **syscall 境界**: 戻り値は RAX 一本。非負 = 成功値、負 = `error_t`(Linux の -errno 方式と同型)。境界でエラーを `-1` や `0` に潰して情報を捨てない
+- **IPC は二層**: ①送達の成否 = `call()` / `send_message` の `error_t` 戻り値、②処理の成否 = 応答 `Message::result`(`OK` または負の `error_t`。payload は `OK` 時のみ有効)。要求を受けたハンドラはエラー時も必ず result にエラーを載せて reply する
+- **層別**: alloc 系 = nullptr 返し(呼び出し元で必ずチェック)/ それ以外 = `error_t` / panic は「続行すると必ずメモリ・状態破壊に至る」場合のみ
+- 成否判定は `IS_ERR` / `IS_OK`(`types.hpp`)に統一。新規コードで戻り値のエラーを黙って破棄しない
+
+### ログ
 - panic は最終手段。リソース枯渇などは `LOG_ERROR` でログを出しエラーを返す
 - ログは `kernel/log/log.hpp` の `LOG_DEBUG` / `LOG_INFO` / `LOG_ERROR`(printf 形式)
 - 例外・RTTI は使用不可(`-fno-exceptions -fno-rtti`)

--- a/.claude/rules/userland.md
+++ b/.claude/rules/userland.md
@@ -32,3 +32,8 @@ cd userland/commands/<名前> && make clean && make
 - カーネルとのやり取りはシステムコール(`libs/user/syscall.o`)と IPC のみ
 - 複雑なロジックはユーザーランドに置くのが UCHos の方針。カーネルに寄せない
 - 新コマンドの追加手順は `/add-userland-command` スキルを参照
+
+## エラー規約(issue #356)
+- syscall・IPC のエラーは負の `error_t`(`libs/common/types.hpp` の `ErrorCode`、カーネルと単一体系)。判定は `IS_ERR` / `IS_OK` を使い、特定の負値(`-1` 等)と比較しない
+- 新規コードでエラーを `-1` や `0` に潰して返さない。`error_t` のまま伝搬する(既存の `libs/user/file.cpp` の -1/0 潰しは issue #315-3a で解消予定)
+- 応答 `Message` の payload は `result == OK` のときのみ読む


### PR DESCRIPTION
## 概要

#356 Tier B の宙に浮いていた「規約決定」を実施(コード変更なし、ルール明文化のみ)。#315-3a の syscall 全面書き直しの前提となる決めごと。

## 設計判断とその理由

**error_t(ErrorCode 単一 enum)をカーネル・syscall ABI・IPC 応答すべての公開規約に昇格。errno 変換層は作らない。**

- 実態調査(Opus 精査)で、現状すでに de facto でこの形だと確認済み: enum は libs/common/types.hpp の単一定義、syscall は負の error_t を RAX 素通し、newlib の errno 経路はスタブ 4 関数のみで実質死んでいる
- 捨てた代替案: errno 相当の公開番号分離。userland は libs/user 独自 API 直であり POSIX 互換の恩恵が当面なく、変換表の維持はカーネル肥大方向で「とにかくシンプル」に反する
- Linux の -errno in RAX と同型なので学習素材としても素直

## 内容

- `.claude/rules/kernel.md`: エラー規約 5 項目(単一体系 / syscall 境界 = 非負成功・負 error_t / IPC 二層 = 送達 vs Message::result / 層別 = alloc は nullptr・他は error_t・panic 条件 / IS_ERR 統一・握りつぶし禁止)
- `.claude/rules/userland.md`: IS_ERR 判定・-1/0 潰し禁止・payload は OK 時のみ

## 危険だと思う箇所 top3 / 触れた危険地帯

ルールファイルのみの変更のため該当なし。危険地帯: なし

## 残作業(#315-3a に随伴、本 PR のスコープ外)

- send_message の読めない戻り値(ISR 用 void ラッパー分離)
- ユーザー側 call() が送達失敗を破棄している問題
- libs/user/file.cpp の -1/0 潰し解消
- sys_fork の ProcessId への error 混載整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)