### PR TITLE
refactor(fs): FAT 走査ループと fd 解決の集約(#339 fs 項目前半、#315 前準備)

### DIFF
--- a/kernel/fs/fat/directory.cpp
+++ b/kernel/fs/fat/directory.cpp
@@ -191,13 +191,18 @@ void handle_normal_directory_change(const Message& m,
 	reply_change_dir(m, upper_name);
 }
 
+/// Resolve the task whose fs state (cwd) an FS request acts on: a forked
+/// child shares its parent's working directory, so requests resolve to the
+/// parent while it is alive, falling back to the sender itself otherwise.
 kernel::task::Task* get_effective_task(ProcessId sender)
 {
 	auto* t = kernel::task::get_task(sender);
-	if (t != nullptr && t->parent_id != process_ids::INVALID) {
-		return kernel::task::get_task(t->parent_id);
+	if (t == nullptr || t->parent_id == process_ids::INVALID) {
+		return t;
 	}
-	return t;
+
+	auto* parent = kernel::task::get_task(t->parent_id);
+	return parent != nullptr ? parent : t;
 }
 
 } // namespace
@@ -227,18 +232,11 @@ void handle_fs_change_dir(const Message& m)
 
 void handle_fs_list_dir(const Message& m)
 {
-	auto* t = kernel::task::get_task(m.sender);
+	auto* t = get_effective_task(m.sender);
 	if (t == nullptr) {
 		// Requester is gone; there is no one to reply to.
 		LOG_ERROR("Task %d not found", m.sender.raw());
 		return;
-	}
-
-	if (t->parent_id != process_ids::INVALID) {
-		kernel::task::Task* parent = kernel::task::get_task(t->parent_id);
-		if (parent != nullptr) {
-			t = parent;
-		}
 	}
 
 	DirectoryEntry* current_dir = t->fs_path.current_dir;
@@ -259,27 +257,16 @@ void handle_fs_list_dir(const Message& m)
 	}
 
 	int entries_count = 0;
-	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (current_dir[i].name[0] == DIR_ENTRY_END) {
-			break;
-		}
-
-		if (current_dir[i].name[0] == DIR_ENTRY_DELETED) {
-			continue;
-		}
-
-		if (current_dir[i].attribute == entry_attribute::LONG_NAME) {
-			continue;
-		}
-
+	scan_valid_entries(current_dir, [&](const DirectoryEntry& entry) {
 		Stat* s = reinterpret_cast<Stat*>(stat_buf.get()) + entries_count;
-		read_dir_entry_name(current_dir[i], s->name);
-		s->size = current_dir[i].file_size;
-		s->type = current_dir[i].attribute == entry_attribute::DIRECTORY
+		read_dir_entry_name(entry, s->name);
+		s->size = entry.file_size;
+		s->type = entry.attribute == entry_attribute::DIRECTORY
 						  ? StatType::DIRECTORY
 						  : StatType::REGULAR_FILE;
 		++entries_count;
-	}
+		return false;
+	});
 
 	Message sm = { .type = MsgType::FS_LIST_DIR, .sender = process_ids::FS_FAT32 };
 	sm.result = OK;
@@ -293,18 +280,11 @@ void handle_fs_pwd(const Message& m)
 {
 	Message reply = { .type = MsgType::FS_PWD, .sender = process_ids::FS_FAT32 };
 
-	kernel::task::Task* t = kernel::task::get_task(m.sender);
+	kernel::task::Task* t = get_effective_task(m.sender);
 	if (t == nullptr) {
 		// Requester is gone; there is no one to reply to.
 		LOG_ERROR("Task %d not found", m.sender.raw());
 		return;
-	}
-
-	if (t->parent_id != process_ids::INVALID) {
-		kernel::task::Task* parent = kernel::task::get_task(t->parent_id);
-		if (parent != nullptr) {
-			t = parent;
-		}
 	}
 
 	if (t->fs_path.current_dir == nullptr) {
@@ -327,18 +307,7 @@ void persist_directory_entry(DirectoryEntry* entry, const char* name)
 		return;
 	}
 
-	DirectoryEntry* disk_entry = nullptr;
-	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (ROOT_DIR[i].name[0] == DIR_ENTRY_END) {
-			break;
-		}
-
-		if (entry_name_is_equal(ROOT_DIR[i], name)) {
-			disk_entry = &ROOT_DIR[i];
-			break;
-		}
-	}
-
+	DirectoryEntry* disk_entry = find_dir_entry(ROOT_DIR, name);
 	if (disk_entry == nullptr) {
 		LOG_ERROR("Directory entry not found in ROOT_DIR");
 		return;

--- a/kernel/fs/fat/file.cpp
+++ b/kernel/fs/fat/file.cpp
@@ -103,6 +103,49 @@ void reply_read_result(const Message& req, const DirectoryEntry* entry)
 	reply_file_data(req, cache->buffer.data(), cache->total_size);
 }
 
+/// Fully resolved fd-based request. entry is non-null iff resolution
+/// succeeded; fd is only valid when entry is set.
+struct OpenFile {
+	FileDescriptor* fd;
+	DirectoryEntry* entry;
+};
+
+/**
+ * @brief Resolve sender task, file descriptor, and directory entry for an
+ * fd-based FS request (FS_READ / FS_WRITE)
+ *
+ * On failure this logs and replies the matching error itself, except when
+ * the requester task is already gone — then there is no one to reply to.
+ *
+ * @return OpenFile with entry != nullptr on success; entry == nullptr means
+ * the error was already handled and the caller just returns
+ */
+OpenFile resolve_open_file(const Message& m)
+{
+	kernel::task::Task* t = kernel::task::get_task(m.sender);
+	if (t == nullptr) {
+		LOG_ERROR("Task %d not found - likely already exited", m.sender.raw());
+		return {};
+	}
+
+	FileDescriptor* fd = kernel::fs::get_process_fd(
+			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, m.data.fs.fd);
+	if (fd == nullptr) {
+		LOG_ERROR("fd not found");
+		reply_error(m, ERR_INVALID_FD);
+		return {};
+	}
+
+	DirectoryEntry* entry = find_dir_entry(ROOT_DIR, fd->name);
+	if (entry == nullptr) {
+		LOG_ERROR("entry not found");
+		reply_error(m, ERR_NO_FILE);
+		return {};
+	}
+
+	return { fd, entry };
+}
+
 } // namespace
 
 void execute_file(kernel::memory::unique_kbuf<> data,
@@ -182,29 +225,12 @@ void handle_fs_open(const Message& m)
 
 void handle_fs_read(const Message& m)
 {
-	kernel::task::Task* t = kernel::task::get_task(m.sender);
-	if (t == nullptr) {
-		LOG_ERROR("Task not found: %d", m.sender.raw());
-		reply_error(m, ERR_INVALID_TASK);
+	const OpenFile of = resolve_open_file(m);
+	if (of.entry == nullptr) {
 		return;
 	}
 
-	FileDescriptor* fd = kernel::fs::get_process_fd(
-			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, m.data.fs.fd);
-	if (fd == nullptr) {
-		LOG_ERROR("fd not found");
-		reply_error(m, ERR_INVALID_FD);
-		return;
-	}
-
-	DirectoryEntry* entry = find_dir_entry(ROOT_DIR, fd->name);
-	if (entry == nullptr) {
-		LOG_ERROR("entry not found");
-		reply_error(m, ERR_NO_FILE);
-		return;
-	}
-
-	reply_read_result(m, entry);
+	reply_read_result(m, of.entry);
 }
 
 void handle_fs_close(const Message& m)
@@ -237,26 +263,12 @@ void handle_fs_write(const Message& m)
 	// Never trust the inline length beyond the payload actually delivered
 	const size_t count = std::min(m.data.fs.len, static_cast<size_t>(m.ool.size));
 
-	kernel::task::Task* t = kernel::task::get_task(m.sender);
-	if (t == nullptr) {
-		LOG_ERROR("Task %d not found - likely already exited", m.sender.raw());
+	const OpenFile of = resolve_open_file(m);
+	if (of.entry == nullptr) {
 		return;
 	}
-
-	FileDescriptor* fd = kernel::fs::get_process_fd(
-			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, m.data.fs.fd);
-	if (fd == nullptr) {
-		LOG_ERROR("fd not found");
-		reply_error(m, ERR_INVALID_FD);
-		return;
-	}
-
-	DirectoryEntry* entry = find_dir_entry(ROOT_DIR, fd->name);
-	if (entry == nullptr) {
-		LOG_ERROR("entry not found");
-		reply_error(m, ERR_NO_FILE);
-		return;
-	}
+	FileDescriptor* fd = of.fd;
+	DirectoryEntry* entry = of.entry;
 
 	const size_t new_size = fd->offset + count;
 

--- a/kernel/fs/fat/internal_common.hpp
+++ b/kernel/fs/fat/internal_common.hpp
@@ -38,6 +38,38 @@ cluster_t next_cluster(cluster_t cluster_id);
 kernel::fs::DirectoryEntry* find_dir_entry(kernel::fs::DirectoryEntry* parent_dir,
 										   const char* name);
 kernel::fs::DirectoryEntry* find_empty_dir_entry();
+
+/**
+ * @brief Iterate the live entries of a single directory cluster
+ *
+ * Single scan primitive for directory clusters: visits slots in order until
+ * the end marker, skipping deleted and long-file-name slots. fn receives a
+ * DirectoryEntry& and returns true to stop at that entry.
+ *
+ * @return The entry fn stopped at, or nullptr when the scan reached the end
+ * marker (or the cluster was exhausted)
+ */
+template<typename Fn>
+kernel::fs::DirectoryEntry* scan_valid_entries(kernel::fs::DirectoryEntry* dir,
+											   Fn fn)
+{
+	for (unsigned long i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
+		if (dir[i].name[0] == DIR_ENTRY_END) {
+			return nullptr;
+		}
+
+		if (dir[i].name[0] == DIR_ENTRY_DELETED ||
+			dir[i].attribute == kernel::fs::entry_attribute::LONG_NAME) {
+			continue;
+		}
+
+		if (fn(dir[i])) {
+			return &dir[i];
+		}
+	}
+
+	return nullptr;
+}
 // The (fat, total_clusters) overloads operate on an explicit FAT so tests
 // can use a private table; the parameterless-FAT overloads wrap the live
 // globals. Tests must never swap the globals themselves: the FS task uses

--- a/kernel/fs/fat/utils.cpp
+++ b/kernel/fs/fat/utils.cpp
@@ -87,17 +87,9 @@ cluster_t next_cluster(cluster_t cluster_id)
 
 DirectoryEntry* find_dir_entry(DirectoryEntry* parent_dir, const char* name)
 {
-	for (int i = 0; i < ENTRIES_PER_CLUSTER; ++i) {
-		if (parent_dir[i].name[0] == DIR_ENTRY_END) {
-			break;
-		}
-
-		if (entry_name_is_equal(parent_dir[i], name)) {
-			return &parent_dir[i];
-		}
-	}
-
-	return nullptr;
+	return scan_valid_entries(parent_dir, [name](const DirectoryEntry& entry) {
+		return entry_name_is_equal(entry, name);
+	});
 }
 
 DirectoryEntry* find_empty_dir_entry()


### PR DESCRIPTION
## 概要

#315(FS ユーザーランド化)の前段リファクタ PR-R1。#339 の fs 項目のうち走査・解決系 3 つを消化する。±200 行、fs のみ。

## 設計判断とその理由

1. **`scan_valid_entries()` を唯一の走査プリミティブに**(internal_common.hpp)。「END で停止・DELETED/LFN スキップ」のイテレーションを 1 箇所に閉じ、`find_dir_entry` / `handle_fs_list_dir` をその上に再構築。`persist_directory_entry` の逐語コピーは `find_dir_entry` 呼び出しに置換
   - 捨てた代替案: DELETED/LFN を見せる低レベル版+valid 版の 2 段構え。find_empty_dir_entry(END スロット自体を探す、目的が異なる)だけは既存ループを残し、プリミティブは 1 個に留めた
2. **`resolve_open_file()`**: FS_READ / FS_WRITE で逐語コピーだった task→fd→entry の 3 段 null チェック+エラー返信を集約。#315-3b で fd 管理を FS サーバへ移すとき、差し替え点がこの 1 関数になる
3. **`get_effective_task` 一本化**: list_dir / pwd のインライン親遡上を既存ヘルパに寄せ、「親が死んでいたら送信者自身へフォールバック」に意味論を統一

## 意図的な微小挙動変更(3 件、いずれも防御方向)

- `find_dir_entry` が DELETED/LFN スロットを名前照合の対象にしなくなった(削除済みエントリへのマッチは元々バグでしか有り得ない)
- FS_READ で送信タスクが既に消えていた場合、存在しないタスクへの reply(到達不能)をやめてログのみに(FS_WRITE と同じ挙動に統一)
- change_dir で親タスクが死んでいた場合、エラーではなく送信者自身の fs_path で続行(null 経路の除去)

## 危険だと思う箇所 top3

1. `kernel/fs/fat/internal_common.hpp` の scan_valid_entries — 走査意味論を 1 箇所に集めたので、ここを間違えると全走査が一斉に壊れる(逆に言えば修正も 1 箇所)
2. `kernel/fs/fat/file.cpp` resolve_open_file — エラー返信の有無が経路で異なる契約(task 消滅時のみ無返信)をコメントに依存
3. `kernel/fs/fat/directory.cpp` get_effective_task — フォールバック統一が change_dir の親死亡コーナーケースの挙動を変えている

## 触れた危険地帯

なし(fs/ のみ)

## 検証

- カーネルビルド緑 / clang-tidy 警告 0(復旧済み lint で確認)
- CI のカーネル内テストは FS サービスを起動できないため、**マージ前に QEMU で ls / cat / write / cd / pwd の対話確認を依頼**(挙動変更ゼロ想定の機械的抽出だが、fs は自動テストの網の外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)