### PR TITLE
refactor(fs,syscall): fd_table アクセスを file_descriptor API に単一路化(#315 前準備 R3)

### DIFF
--- a/kernel/fs/fat/file.cpp
+++ b/kernel/fs/fat/file.cpp
@@ -476,21 +476,17 @@ void handle_fs_dup2(const Message& m)
 		return;
 	}
 
-	kernel::fs::FileDescriptor* old_entry = kernel::fs::get_process_fd(
-			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, oldfd);
-	if (old_entry == nullptr) {
-		reply_error(m, ERR_INVALID_FD);
-		return;
-	}
-
 	// TODO: Support for other file descriptors
 	if (newfd != STDOUT_FILENO && newfd != STDERR_FILENO) {
 		reply_error(m, ERR_INVALID_FD);
 		return;
 	}
 
-	if (newfd >= 0 && newfd < kernel::task::MAX_FDS_PER_PROCESS) {
-		t->fd_table[newfd] = *old_entry;
+	const error_t dup_err = kernel::fs::dup_process_fd(
+			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, oldfd, newfd);
+	if (IS_ERR(dup_err)) {
+		reply_error(m, dup_err);
+		return;
 	}
 
 	reply.result = OK;

--- a/kernel/fs/file_descriptor.cpp
+++ b/kernel/fs/file_descriptor.cpp
@@ -106,6 +106,25 @@ error_t release_process_fd(FileDescriptor* fd_table, size_t table_size, fd_t fd)
 	return OK;
 }
 
+error_t dup_process_fd(FileDescriptor* fd_table,
+					   size_t table_size,
+					   fd_t oldfd,
+					   fd_t newfd)
+{
+	FileDescriptor* old_entry = get_process_fd(fd_table, table_size, oldfd);
+	if (old_entry == nullptr) {
+		return ERR_INVALID_FD;
+	}
+
+	if (newfd < 0 || newfd >= table_size) {
+		return ERR_INVALID_FD;
+	}
+
+	fd_table[newfd] = *old_entry;
+
+	return OK;
+}
+
 error_t copy_fd_table(FileDescriptor* dest,
 					  const FileDescriptor* src,
 					  size_t table_size,

--- a/kernel/fs/file_descriptor.hpp
+++ b/kernel/fs/file_descriptor.hpp
@@ -115,6 +115,24 @@ FileDescriptor* get_process_fd(FileDescriptor* fd_table, size_t table_size, fd_t
 error_t release_process_fd(FileDescriptor* fd_table, size_t table_size, fd_t fd);
 
 /**
+ * @brief Duplicate oldfd's entry onto newfd (dup2 semantics)
+ *
+ * Overwrites newfd's entry with a copy of oldfd's; any previous state of
+ * newfd is discarded without being released (entries hold no resources).
+ *
+ * @param fd_table Process's file descriptor table
+ * @param table_size Size of the file descriptor table
+ * @param oldfd Descriptor to duplicate (must be in use)
+ * @param newfd Descriptor slot to overwrite
+ * @return error_t OK on success, ERR_INVALID_FD when oldfd is not in use or
+ * newfd is out of range
+ */
+error_t dup_process_fd(FileDescriptor* fd_table,
+					   size_t table_size,
+					   fd_t oldfd,
+					   fd_t newfd);
+
+/**
  * @brief Copy file descriptor table for process forking
  *
  * Creates a deep copy of the parent's file descriptor table for the child process.

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include "error.hpp"
 #include "fs/fat/fat.hpp"
+#include "fs/file_descriptor.hpp"
 #include "graphics/font.hpp"
 #include "graphics/screen.hpp"
 #include "log/log.hpp"
@@ -35,8 +36,9 @@ ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	kernel::task::Task* t = kernel::task::CURRENT_TASK;
 
 	// Validate file descriptor
-	if (fd < 0 || fd >= kernel::task::MAX_FDS_PER_PROCESS ||
-		t->fd_table[fd].is_unused()) {
+	if (kernel::fs::get_process_fd(t->fd_table.data(),
+								   kernel::task::MAX_FDS_PER_PROCESS,
+								   fd) == nullptr) {
 		return ERR_INVALID_FD;
 	}
 
@@ -59,8 +61,9 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 
 	kernel::task::Task* t = kernel::task::CURRENT_TASK;
 
-	if (fd < 0 || fd >= kernel::task::MAX_FDS_PER_PROCESS ||
-		t->fd_table[fd].is_unused()) {
+	kernel::fs::FileDescriptor* fd_entry = kernel::fs::get_process_fd(
+			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, fd);
+	if (fd_entry == nullptr) {
 		return ERR_INVALID_FD;
 	}
 
@@ -73,8 +76,7 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 	}
 
 	if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
-		if (t->fd_table[fd].has_name("stdout") ||
-			t->fd_table[fd].has_name("stderr")) {
+		if (fd_entry->has_name("stdout") || fd_entry->has_name("stderr")) {
 			// Standard output - send to terminal
 			Message m = { .type = MsgType::NOTIFY_WRITE, .sender = t->id };
 

--- a/kernel/tests/test_cases/fd_test.cpp
+++ b/kernel/tests/test_cases/fd_test.cpp
@@ -128,6 +128,40 @@ void test_fd_dup2()
 	ASSERT_EQ(redirected->size, src->size);
 }
 
+void test_dup_process_fd()
+{
+	// Create test FD table
+	fs::FileDescriptor fd_table[32];
+	fs::init_process_fd_table(fd_table, 32);
+
+	// Allocate a file descriptor
+	fd_t file_fd = fs::allocate_process_fd(fd_table, 32, "output.txt", 42,
+										   ProcessId::from_raw(1));
+	ASSERT_GT(file_fd, -1);
+
+	// Normal case: dup the file fd onto STDOUT_FILENO
+	error_t result = fs::dup_process_fd(fd_table, 32, file_fd, STDOUT_FILENO);
+	ASSERT_EQ(result, OK);
+
+	fs::FileDescriptor* src = fs::get_process_fd(fd_table, 32, file_fd);
+	fs::FileDescriptor* dup = fs::get_process_fd(fd_table, 32, STDOUT_FILENO);
+	ASSERT_NOT_NULL(src);
+	ASSERT_NOT_NULL(dup);
+	ASSERT_EQ(strcmp(dup->name, src->name), 0);
+	ASSERT_EQ(dup->size, src->size);
+
+	// Error case: oldfd is unused
+	result = fs::dup_process_fd(fd_table, 32, 20, STDOUT_FILENO);
+	ASSERT_EQ(result, ERR_INVALID_FD);
+
+	// Error case: newfd is out of range
+	result = fs::dup_process_fd(fd_table, 32, file_fd, -1);
+	ASSERT_EQ(result, ERR_INVALID_FD);
+
+	result = fs::dup_process_fd(fd_table, 32, file_fd, 32);
+	ASSERT_EQ(result, ERR_INVALID_FD);
+}
+
 void test_fd_limits()
 {
 	// Create small FD table
@@ -196,6 +230,7 @@ void register_fd_tests()
 	test_register("test_fd_release", test_fd_release);
 	test_register("test_fd_fork_copy", test_fd_fork_copy);
 	test_register("test_fd_dup2", test_fd_dup2);
+	test_register("test_dup_process_fd", test_dup_process_fd);
 	test_register("test_fd_limits", test_fd_limits);
 	test_register("test_release_all_fds", test_release_all_fds);
 }


### PR DESCRIPTION
## 概要

#315 前段リファクタの最終弾 PR-R3。fd_table への直接アクセスを全廃し、kernel/fs/file_descriptor.cpp の API を唯一の経路にする。これで #315-3b の「fd 管理を FS サーバへ移管」が散在アクセスの追跡ではなく 1 モジュールの差し替えになる。

事前の全数調査で判明した現状: task.cpp(fork コピー・exit 解放・初期化)は既に正規 API 経由、fs_path も directory.cpp の setter 4 つ+init_path に単一路化済み。残っていた直接アクセスは以下の 4 箇所のみで、これを潰した。

## 設計判断とその理由

1. **sys_read / sys_write の自前 fd 検証(handler.cpp:38-39, 62-63)→ `get_process_fd`**: 自前の「bounds + is_unused」チェックは API と完全同値の再実装だった。sys_write は取得した `FileDescriptor*` を stdout/stderr の名前判定(:76-77)にも再利用し、直接添字を全廃
2. **dup2 の直接書き込み(file.cpp)→ 新 API `dup_process_fd()`**: fd_table への「書き」の直接アクセスは全カーネルでここ 1 箇所だった。dup2 セマンティクスの API として file_descriptor に追加し、カーネルテスト付き(fd_test.cpp、正常系+oldfd 未使用+newfd 範囲外 2 種)
3. 捨てた代替案: API シグネチャを `(FileDescriptor*, size_t)` から `(Task&)` や ProcessId キーに変える案。それは 3b 本体(所有の移管)の仕事であり、本 PR は「経路の一本化」に限定

## 微小挙動変更(2 件)

- 無効 fd での sys_read/sys_write に `LOG_ERROR("fd %d is not in use")` が出るようになった(get_process_fd 内のログ。従来は無音で ERR_INVALID_FD)
- dup2 のチェック順が oldfd→newfd から newfd→oldfd に(両方無効時の応答コードは同じ ERR_INVALID_FD で外部から観測不能)。旧コードの「newfd 範囲外なら黙って何もせず OK を返す」到達不能分岐は、エラー返却に変更

## 危険だと思う箇所 top3

1. `kernel/syscall/handler.cpp` sys_write — fd_entry の取得を関数冒頭に移したため、以降のロジックが「fd_entry は非 null」という不変条件に依存する(旧コードは使用直前に添字アクセス)
2. `kernel/fs/file_descriptor.cpp` dup_process_fd — newfd の既存エントリを解放せず上書きする仕様(FileDescriptor はリソースを持たないため現状は正しいが、将来 fd がリソースを持ったら再考が必要。Doxygen に明記済み)
3. `kernel/fs/fat/file.cpp` handle_fs_dup2 — STDOUT/STDERR 制限チェックと dup の二重ガード。制限を外すとき dup_process_fd 側の bounds チェックだけになることを見落とさないこと

## 触れた危険地帯

**kernel/syscall/**(sys_read / sys_write の fd 検証部)。task/ の変更はなし

## 検証

- カーネルビルド緑 / clang-tidy 警告 0 / fd_test に dup_process_fd テスト追加(CI で実行される)
- syscall 側は CI のカーネルテストが通れば boot 経路は担保。dup2 経路(リダイレクト `echo hello > file.txt` 相当)は QEMU 確認を依頼

## 役割分担

設計・実装 = メイン、テスト追加 = Sonnet(裏取り済み)、事前の全数調査 = メイン(grep 4 系統)

🤖 Generated with [Claude Code](https://claude.com/claude-code)