### PR TITLE
refactor(syscall): タイマー ABI から UI ポリシーを除去(issue #315 3a-1)

### DIFF
--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -184,17 +184,20 @@ error_t sys_fill_rect(uint64_t arg1,
 	return OK;
 }
 
-error_t sys_time(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4)
+error_t sys_time(uint64_t arg1, uint64_t arg2)
 {
 	const uint64_t ms = arg1;
 	const int is_periodic = arg2;
-	const TimeoutAction action = static_cast<TimeoutAction>(arg3);
-	const ProcessId task_id = ProcessId::from_raw(arg4);
+
+	// A timer can only ever target its own creator (issue #315): the expiry
+	// is a bare doorbell with no meaning attached, so letting a task arm
+	// timers on arbitrary victims would be an unauthenticated wakeup channel.
+	const ProcessId task_id = kernel::task::CURRENT_TASK->id;
 
 	if (is_periodic == 1) {
-		kernel::timers::ktimer->add_periodic_timer_event(ms, action, task_id);
+		kernel::timers::ktimer->add_periodic_timer_event(ms, task_id);
 	} else {
-		kernel::timers::ktimer->add_timer_event(ms, action, task_id);
+		kernel::timers::ktimer->add_timer_event(ms, task_id);
 	}
 
 	return OK;
@@ -475,7 +478,7 @@ extern "C" uint64_t handle_syscall(uint64_t arg1,
 			result = kernel::syscall::sys_fill_rect(arg1, arg2, arg3, arg4, arg5);
 			break;
 		case kernel::syscall::SYS_TIME:
-			result = kernel::syscall::sys_time(arg1, arg2, arg3, arg4);
+			result = kernel::syscall::sys_time(arg1, arg2);
 			break;
 		case kernel::syscall::SYS_IPC:
 			result = kernel::syscall::sys_ipc(arg1, arg2, arg3, arg4);

--- a/kernel/tests/test_cases/timer_test.cpp
+++ b/kernel/tests/test_cases/timer_test.cpp
@@ -1,6 +1,5 @@
 #include "tests/test_cases/timer_test.hpp"
 #include <cstdint>
-#include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 #include "tests/framework.hpp"
@@ -16,12 +15,12 @@ void test_add_timer_event()
 {
 	constexpr ProcessId test_task_id = ProcessId::from_raw(1);
 
-	const uint64_t event_id = kernel::timers::ktimer->add_timer_event(
-			1000, TimeoutAction::SWITCH_TASK, test_task_id);
+	const uint64_t event_id =
+			kernel::timers::ktimer->add_timer_event(1000, test_task_id);
 	ASSERT_NE(event_id, 0);
 
-	const uint64_t invalid_event_id = kernel::timers::ktimer->add_timer_event(
-			1000, TimeoutAction::SWITCH_TASK, ProcessId::from_raw(-1));
+	const uint64_t invalid_event_id =
+			kernel::timers::ktimer->add_timer_event(1000, ProcessId::from_raw(-1));
 	ASSERT_NE(invalid_event_id, 0);
 
 	// Leaving these queued would start task switching ~1s after the local
@@ -34,8 +33,8 @@ void test_remove_timer_event()
 {
 	constexpr ProcessId test_task_id = ProcessId::from_raw(1);
 
-	const uint64_t event_id = kernel::timers::ktimer->add_timer_event(
-			1000, TimeoutAction::SWITCH_TASK, test_task_id);
+	const uint64_t event_id =
+			kernel::timers::ktimer->add_timer_event(1000, test_task_id);
 	auto err = kernel::timers::ktimer->remove_timer_event(event_id);
 	ASSERT_EQ(err, OK);
 

--- a/kernel/timers/timer.cpp
+++ b/kernel/timers/timer.cpp
@@ -1,6 +1,5 @@
 #include "timers/timer.hpp"
 #include <cstdint>
-#include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 #include "log/log.hpp"
@@ -20,16 +19,13 @@ uint64_t KernelTimer::calculate_timeout_ticks(unsigned long millisec) const
 	return tick_ + (millisec * TIMER_FREQUENCY) / 1000;
 }
 
-uint64_t KernelTimer::add_timer_event(unsigned long millisec,
-									  TimeoutAction action,
-									  ProcessId task_id)
+uint64_t KernelTimer::add_timer_event(unsigned long millisec, ProcessId task_id)
 {
 	auto e = TimerEvent{
 		.id = last_id_++,
 		.task_id = task_id,
 		.timeout = calculate_timeout_ticks(millisec),
 		.period = static_cast<unsigned int>(millisec),
-		.action = action,
 	};
 
 	events_.push(e);
@@ -38,7 +34,6 @@ uint64_t KernelTimer::add_timer_event(unsigned long millisec,
 }
 
 uint64_t KernelTimer::add_periodic_timer_event(unsigned long millisec,
-											   TimeoutAction action,
 											   ProcessId task_id,
 											   uint64_t id)
 {
@@ -55,7 +50,6 @@ uint64_t KernelTimer::add_periodic_timer_event(unsigned long millisec,
 		.timeout = calculate_timeout_ticks(millisec),
 		.period = static_cast<unsigned int>(millisec),
 		.periodical = 1,
-		.action = action,
 	};
 
 	events_.push(e);
@@ -71,7 +65,7 @@ uint64_t KernelTimer::add_switch_task_event(unsigned long millisec)
 		.timeout = calculate_timeout_ticks(millisec),
 		.period = 0,
 		.periodical = 0,
-		.action = TimeoutAction::SWITCH_TASK,
+		.switch_task = true,
 	};
 	events_.push(e);
 
@@ -107,7 +101,7 @@ bool KernelTimer::increment_tick()
 			continue;
 		}
 
-		if (e.action == TimeoutAction::SWITCH_TASK) {
+		if (e.switch_task) {
 			need_switch_task = true;
 
 			e.timeout = calculate_timeout_ticks(SWITCH_TASK_MILLISEC);
@@ -119,8 +113,8 @@ bool KernelTimer::increment_tick()
 		// increment_tick runs in the timer interrupt, so the expiry is
 		// delivered as a doorbell bit: no allocation, and repeated
 		// expiries coalesce instead of overflowing the receiver's ring
-		// (issue #314 Stage A). The TimeoutAction payload is gone; the
-		// receiver knows what its own timer means (cursor blink).
+		// (issue #314 Stage A). The expiry carries no payload; the
+		// receiver knows what its own timer means (issue #315).
 		kernel::task::notify(e.task_id, kernel::task::NotifyType::TIMER);
 
 		if (e.periodical == 1) {

--- a/kernel/timers/timer.hpp
+++ b/kernel/timers/timer.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <cstdint>
-#include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 #include <queue>
@@ -27,7 +26,10 @@ struct TimerEvent {
 	uint64_t timeout;	 ///< Absolute tick count when timer expires
 	unsigned int period; ///< Period in milliseconds for periodic timers
 	int periodical; ///< Flag indicating if timer is periodic (1) or one-shot (0)
-	TimeoutAction action; ///< Action to perform when timer expires
+	/// Kernel-internal scheduler tick (issue #315): expiry triggers a task
+	/// switch instead of notifying task_id. Never exposed to user space; a
+	/// user timer only means "your timer fired" and the owner decides why.
+	bool switch_task;
 };
 
 /**
@@ -96,25 +98,20 @@ public:
 	 * @brief Add a one-shot timer event
 	 *
 	 * @param millisec Delay in milliseconds until timer expires
-	 * @param action Action to perform when timer expires
 	 * @param task_id Task to notify when timer expires
 	 * @return uint64_t Timer event ID for later removal
 	 */
-	uint64_t add_timer_event(unsigned long millisec,
-							 TimeoutAction action,
-							 ProcessId task_id);
+	uint64_t add_timer_event(unsigned long millisec, ProcessId task_id);
 
 	/**
 	 * @brief Add a periodic timer event
 	 *
 	 * @param millisec Period in milliseconds between timer events
-	 * @param action Action to perform on each timer expiration
 	 * @param task_id Task to notify on each timer expiration
 	 * @param id Optional timer ID (0 to auto-generate)
 	 * @return uint64_t Timer event ID for later removal
 	 */
 	uint64_t add_periodic_timer_event(unsigned long millisec,
-									  TimeoutAction action,
 									  ProcessId task_id,
 									  uint64_t id = 0);
 

--- a/libs/common/message.hpp
+++ b/libs/common/message.hpp
@@ -76,11 +76,6 @@ enum class MsgType : int32_t {
 constexpr int32_t TOTAL_MESSAGE_TYPES =
 		static_cast<int32_t>(MsgType::MAX_MESSAGE_TYPE);
 
-enum class TimeoutAction : uint8_t {
-	TERMINAL_CURSOR_BLINK,
-	SWITCH_TASK,
-};
-
 /**
  * @brief Descriptor of an out-of-line payload attached to a Message
  *
@@ -126,10 +121,6 @@ struct Message {
 			uint8_t ascii;
 			int press;
 		} key_input;
-
-		struct {
-			TimeoutAction action;
-		} timer;
 
 		/// Inline stdout payload (NOTIFY_WRITE); larger writes travel OOL
 		struct {

--- a/libs/user/syscall.hpp
+++ b/libs/user/syscall.hpp
@@ -13,7 +13,7 @@ void sys_exit(int exit_code);
 
 uint64_t sys_draw_text(const char* text, int x, int y, uint32_t color);
 uint64_t sys_fill_rect(int x, int y, int width, int height, uint32_t color);
-uint64_t sys_time(int ms, int is_periodic, uint8_t action, int task_id);
+uint64_t sys_time(int ms, int is_periodic);
 uint64_t sys_ipc(int dest, int src, const void* m, int flags);
 uint64_t sys_fork();
 uint64_t sys_exec(const char* path, const char* args);

--- a/libs/user/time.cpp
+++ b/libs/user/time.cpp
@@ -1,8 +1,7 @@
 #include "time.hpp"
 #include "syscall.hpp"
 
-void set_timer(int ms, bool is_periodic, TimeoutAction action, int task_id)
+void set_timer(int ms, bool is_periodic)
 {
-	sys_time(ms, static_cast<int>(is_periodic), static_cast<uint8_t>(action),
-			 task_id);
+	sys_time(ms, static_cast<int>(is_periodic));
 }

--- a/libs/user/time.hpp
+++ b/libs/user/time.hpp
@@ -2,4 +2,6 @@
 
 #include "ipc.hpp"
 
-void set_timer(int ms, bool is_periodic, TimeoutAction action, int task_id);
+/// Arm a timer for the calling task; the expiry arrives as a bare
+/// NOTIFY_TIMER_TIMEOUT and the caller decides what it means.
+void set_timer(int ms, bool is_periodic);

--- a/userland/shell/main.cpp
+++ b/userland/shell/main.cpp
@@ -38,13 +38,10 @@ int main(void)
 				}
 				break;
 			case MsgType::NOTIFY_TIMER_TIMEOUT:
-				switch (msg.data.timer.action) {
-					case TimeoutAction::TERMINAL_CURSOR_BLINK:
-						term->blink_cursor();
-						break;
-					default:
-						break;
-				};
+				// The only timer this task arms is the cursor-blink one
+				// (set_cursor_timer); the kernel no longer attaches a
+				// meaning to the expiry (issue #315)
+				term->blink_cursor();
 				break;
 			case MsgType::KERNEL_TASK_READY:
 				set_cursor_timer(500);

--- a/userland/shell/terminal.cpp
+++ b/userland/shell/terminal.cpp
@@ -209,8 +209,4 @@ void Terminal::register_current_dir(const char* name)
 	}
 }
 
-void set_cursor_timer(int ms)
-{
-	set_timer(ms, true, TimeoutAction::TERMINAL_CURSOR_BLINK,
-			  process_ids::SHELL.raw());
-}
+void set_cursor_timer(int ms) { set_timer(ms, true); }


### PR DESCRIPTION
issue #315 Phase 3a の第 1 弾。カーネルタイマー ABI からユーザーランド UI ポリシー(`TimeoutAction::TERMINAL_CURSOR_BLINK`)を排除する。

## 変更内容

- `libs/common/message.hpp`: `TimeoutAction` enum と `Message::data.timer` を削除。タイマー満了は既に #314 でペイロードなしのドアベル(`NOTIFY_TIMER_TIMEOUT`)になっており、この型は ABI 上の死荷重だった
- `sys_time`: 引数を `(ms, is_periodic)` に縮小。**宛先は常に発行者自身**(`CURRENT_TASK`)に固定し、任意タスクを起こせる無認可 wakeup チャネルを閉鎖
- `kernel/timers`: `TimerEvent::action` を kernel 内部専用の `bool switch_task` に置換。スケジューラ tick の概念はカーネルの外に出ない
- `userland/shell`: `NOTIFY_TIMER_TIMEOUT` を受けたら無条件にカーソル点滅(シェルが持つタイマーはそれだけ。自分のタイマーの意味は自分が知る)
- `libs/user`: `set_timer(ms, is_periodic)` に追従

## 設計判断と理由

- **タイマーの意味付けを完全に受信側へ移す**: カーネルは「いつ・誰を起こすか」だけを管理し、「なぜ」を知らない。マイクロカーネル方針(カーネルを薄く)の最小単位の実践
- **捨てた代替案①**: `TimeoutAction` を不透明トークンとしてカーネルが素通しで返す案。#314 のドアベル化で満了通知はペイロードを運べない(合体する)ため、トークン保管場所がカーネル側に必要になり本末転倒
- **捨てた代替案②**: タイマー ID を expiry に載せて受信側で照合する案。現状の用途(シェルの単一点滅タイマー)には過剰。複数タイマーを持つタスクが現れた時に再検討
- 宛先固定は issue 明記の要件(`handler.cpp:139-153` への監査指摘)

## 実装者として危険だと思う箇所 top3

1. `kernel/syscall/handler.cpp:187` — syscall ABI 変更(引数 4→2)。ディスクイメージ内の**旧ビルドのユーザーランドバイナリ**は旧 ABI で呼ぶが、余分なレジスタは無視され宛先は自タスクになるため、旧シェルの挙動は偶然一致で保たれる。イメージ再生成(`./run_qemu.sh` が再ビルド)を忘れると気づきにくい
2. `kernel/timers/timer.cpp:23-59` — `add_timer_event` / `add_periodic_timer_event` は指示初期化で `switch_task` を省略しており、ゼロ初期化(false)に依存。フィールド追加時に初期化漏れすると全タイマーがスケジューラ tick 化する
3. `userland/shell/main.cpp:40` — `NOTIFY_TIMER_TIMEOUT` を無条件で blink 扱い。シェルに 2 本目のタイマーを追加する場合はタイマー ID 照合(代替案②)の導入が前提になる

## 触れた危険地帯

- `kernel/syscall/`(`sys_time` の ABI 縮小と宛先固定のみ。IPC・メモリ経路には非接触)

## 確認

- `cmake -B build kernel && cmake --build build` ✅
- `userland/shell` 単体ビルド ✅
- `./lint.sh` 警告 0 ✅
- `kernel/tests/test_cases/timer_test.cpp` を新 API に追従

Refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)