### PR TITLE
fix(task): #371 が壊した fork の子復帰経路を修復(全コマンド fork failed の回帰)

### DIFF
--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -333,10 +333,20 @@ ProcessId sys_fork(void)
 	get_current_context(&current_ctx);
 
 	kernel::task::Task* t = kernel::task::CURRENT_TASK;
+
+	// A task waking up here on a stack copied by copy_task is the freshly
+	// created child re-entering sys_fork: fork returns 0 to it. This flag —
+	// not parent_id — is the child's return path (the old parent_id check
+	// served double duty, and repurposing it as a nested-fork error broke
+	// every fork: regression fixed here).
+	if (t->just_forked) {
+		t->just_forked = false;
+		return ProcessId::from_raw(0);
+	}
+
 	if (t->parent_id.raw() != -1) {
-		// Nested fork (a forked child forking again) is unsupported. Fail
-		// loudly (issue #315): the old silent 0 made the caller believe it
-		// was the child and run the child's code path in the parent.
+		// A genuine nested fork (a forked child forking again) is still
+		// unsupported: fail loudly instead of pretending (issue #315)
 		LOG_ERROR("fork depth > 1 is not supported (task %d)", t->id.raw());
 		return ProcessId::from_raw(ERR_FORK_FAILED);
 	}

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -207,6 +207,10 @@ Task* copy_task(Task* parent, Context* parent_ctx)
 	}
 	child->parent_id = parent->id;
 
+	// The child will wake up inside sys_fork on the copied stack below;
+	// this flag is what tells that resume apart from a real fork request
+	child->just_forked = true;
+
 	memcpy(&child->ctx, parent_ctx, sizeof(Context));
 
 	// Copy parent's file descriptor table
@@ -432,6 +436,7 @@ Task::Task(int raw_id,
 	  parent_id{ ProcessId::from_raw(-1) },
 	  priority{ 2 }, // TODO: Implement priority scheduling
 	  is_initialized{ is_initialized },
+	  just_forked{ false },
 	  state{ state },
 	  fs_path({ nullptr, nullptr, nullptr }),
 	  stack{ nullptr },

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -82,6 +82,11 @@ struct Task {
 	char name[32];
 	int priority;
 	bool is_initialized;
+	/// Set by copy_task, consumed once by sys_fork: the new child resumes
+	/// inside sys_fork on the copied kernel stack, and this flag is how that
+	/// resume is recognized so fork can return 0 to the child. parent_id
+	/// cannot serve here — it stays set for the child's whole life.
+	bool just_forked;
 	TaskState state;
 	Path fs_path;
 	uint64_t* stack;

--- a/kernel/tests/test_cases/task_test.cpp
+++ b/kernel/tests/test_cases/task_test.cpp
@@ -131,6 +131,9 @@ void test_task_copy()
 	// Verify child task properties
 	ASSERT_TRUE(child->parent_id == parent->id);
 	ASSERT_TRUE(child->has_parent());
+	// The child's fork-returns-0 path depends on this flag being set here
+	// (regression guard: issue #315 once turned every fork into an error)
+	ASSERT_TRUE(child->just_forked);
 	ASSERT_NOT_NULL(child->stack);
 	ASSERT_EQ(child->stack_size, parent->stack_size);
 	ASSERT_NOT_NULL(child->get_page_table());


### PR DESCRIPTION
## 何が起きたか(回帰の告白)

PR #371 で「fork の深さ 1 制限の明示エラー化」として書き換えた `sys_fork` の `parent_id != -1` 分岐は、実は**二役**を担っていた:

1. 入れ子 fork の抑止(issue #315 が名指しした役割)
2. **fork された子の正規の復帰経路**(誰も文書化していなかった役割)

UCHos の fork は `get_current_context` でカーネルスタックごとコンテキストを複製し、子は**スケジュール時に sys_fork の途中から目を覚ます**。`copy_task` は子の RAX に 0 を書かないので、子が「fork は 0 を返した」と見えるのは、再実行された `parent_id != -1` チェックが `return 0` していたから。#371 はこれを `ERR_FORK_FAILED` に変えたため、**すべての fork 子がエラー復帰し、シェルの全コマンド実行が「fork failed」になる**回帰を起こした(シリアルログの `fork depth > 1 is not supported (task 8)` がそれ)。

## 修正

`Task::just_forked` フラグで 2 つの意味を分離:

- `copy_task` が子に立てる → 子が sys_fork 内で目を覚ますと**フラグを消費して 0 を返す**(従来挙動の復元)
- フラグなしで parent 持ちのタスクが fork を呼んだ場合だけが**本物の入れ子 fork** → 従来どおり LOG_ERROR + `ERR_FORK_FAILED`(#371 の意図は維持)

`test_task_copy` に `child->just_forked` のアサーションを追加し、copy_task 側の前提をテストで固定した。

## 実装者として危険だと思う箇所 top3

1. `kernel/syscall/handler.cpp:344-352` — 子の復帰判定は「コピーされたスタックで sys_fork を途中再実行する」という暗黙のメカニズムに依存する。fork の実装方式(スタックコピー→文脈復帰)を変えるときはこのフラグ運用ごと見直しが必要
2. `kernel/task/task.cpp:copy_task` — `just_forked = true` は**コンテキスト捕獲より後・スケジュール前**に立てる必要がある(Task 構造体はスタックと独立なので現配置で安全だが、順序を動かすと壊れる)
3. sys_fork 全体が「戻り値 1 回の呼び出しから 2 回戻る」関数である事実そのもの。ring0 のテストでは再現できず(今回 104 テスト全パスのまま回帰した)、**検証は QEMU でのコマンド実行が唯一の手段**

## 触れた危険地帯

- `kernel/task/`(Task 構造体へのフラグ追加・copy_task)
- `kernel/syscall/`(sys_fork の分岐再構成)

## 確認

- `cmake -B build kernel && cmake --build build` ✅ / `./lint.sh` 警告 0 ✅
- `test_task_copy` に回帰ガード追加(CI で実行される)
- **マージ後、QEMU でコマンド実行(`ls` 等)が通ることの確認をお願いします**(ローカルに Loader.efi がなくヘッドレス実行不可のため)

## 教訓(このあと issue 化提案)

- 監査 issue の「黙って 0 を返す」という記述を鵜呑みにし、分岐の**全ての呼ばれ方**(子の復帰経路)を確認せずに書き換えた。fork/exec のような「2 回戻る」制御フローでは、分岐の意味をコードパスごとに検証する
- ring3 の fork→exec→wait を通す煙テストが CI に無いことが検出を遅らせた。ヘッドレス QEMU でシェルにコマンドを流す E2E テストを issue 化したい

Refs #315, #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)