### PR TITLE
refactor(syscall): fd をルーティングエントリ化し sys_write から名前判定・宛先ハードコードを除去(issue #315 3a-4)

### DIFF
--- a/kernel/fs/file_descriptor.cpp
+++ b/kernel/fs/file_descriptor.cpp
@@ -19,11 +19,15 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size)
 		fd_table[i].clear();
 	}
 
-	// Set up standard file descriptors
+	// Set up standard file descriptors. The console routing is decided
+	// HERE, at entry creation — the syscall layer just follows it (issue
+	// #315). This init moves to the user-side runtime in 3b.
 	// stdin
 	if (STDIN_FILENO < table_size) {
 		strncpy(fd_table[STDIN_FILENO].name, "stdin",
 				sizeof(fd_table[STDIN_FILENO].name) - 1);
+		fd_table[STDIN_FILENO].route = FdRoute::CONSOLE;
+		fd_table[STDIN_FILENO].dest = process_ids::SHELL;
 		fd_table[STDIN_FILENO].size = 0;
 		fd_table[STDIN_FILENO].offset = 0;
 	}
@@ -32,6 +36,8 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size)
 	if (STDOUT_FILENO < table_size) {
 		strncpy(fd_table[STDOUT_FILENO].name, "stdout",
 				sizeof(fd_table[STDOUT_FILENO].name) - 1);
+		fd_table[STDOUT_FILENO].route = FdRoute::CONSOLE;
+		fd_table[STDOUT_FILENO].dest = process_ids::SHELL;
 		fd_table[STDOUT_FILENO].size = 0;
 		fd_table[STDOUT_FILENO].offset = 0;
 	}
@@ -40,6 +46,8 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size)
 	if (STDERR_FILENO < table_size) {
 		strncpy(fd_table[STDERR_FILENO].name, "stderr",
 				sizeof(fd_table[STDERR_FILENO].name) - 1);
+		fd_table[STDERR_FILENO].route = FdRoute::CONSOLE;
+		fd_table[STDERR_FILENO].dest = process_ids::SHELL;
 		fd_table[STDERR_FILENO].size = 0;
 		fd_table[STDERR_FILENO].offset = 0;
 	}
@@ -59,6 +67,11 @@ fd_t allocate_process_fd(FileDescriptor* fd_table,
 	// Find first unused entry
 	for (size_t i = 0; i < table_size; ++i) {
 		if (fd_table[i].is_unused()) {
+			// This helper is FS-side code (it moves into the FS server in
+			// 3b), so entries it creates route to the FAT32 service; the
+			// syscall layer only ever reads this (issue #315)
+			fd_table[i].route = FdRoute::FS;
+			fd_table[i].dest = process_ids::FS_FAT32;
 			fd_table[i].size = size;
 			fd_table[i].offset = 0;
 			strncpy(fd_table[i].name, name, sizeof(fd_table[i].name) - 1);

--- a/kernel/fs/file_descriptor.hpp
+++ b/kernel/fs/file_descriptor.hpp
@@ -6,59 +6,18 @@
 #pragma once
 
 #include <cstddef>
-#include <cstring>
+#include <libs/common/file_descriptor.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 
 namespace kernel::fs
 {
 
-/**
- * @brief File descriptor structure
- *
- * Represents an open file handle for a process. Each file descriptor
- * tracks the file being accessed, the owning process, and the current
- * read/write position.
- */
-struct FileDescriptor {
-	char name[13]; ///< 8.3 file name: up to 12 characters plus null
-	size_t size;   ///< File size in bytes
-	size_t offset; ///< Current read/write position
-
-	/**
-	 * @brief Check if this file descriptor is unused
-	 * @return true if the descriptor is not in use (empty name)
-	 */
-	bool is_unused() const { return name[0] == '\0'; }
-
-	/**
-	 * @brief Check if this file descriptor is in use
-	 * @return true if the descriptor is in use (non-empty name)
-	 */
-	bool is_used() const { return name[0] != '\0'; }
-
-	/**
-	 * @brief Clear this file descriptor entry
-	 *
-	 * Resets all fields to their default values, marking the descriptor as unused.
-	 */
-	void clear()
-	{
-		name[0] = '\0';
-		size = 0;
-		offset = 0;
-	}
-
-	/**
-	 * @brief Check if this file descriptor has the specified name
-	 * @param target_name The name to compare against
-	 * @return true if the name matches, false otherwise
-	 */
-	bool has_name(const char* target_name) const
-	{
-		return strcmp(name, target_name) == 0;
-	}
-};
+/// The type itself now lives in libs/common (issue #315: the entry is part
+/// of the kernel/service contract and the FS server will manage it from
+/// user space in 3b). This alias keeps kernel call sites unchanged until
+/// the helpers below move out with it.
+using FileDescriptor = ::FileDescriptor;
 
 // Process-local file descriptor management functions
 

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -75,9 +75,12 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 		return ERR_OOL_LIMIT;
 	}
 
-	if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
-		if (fd_entry->has_name("stdout") || fd_entry->has_name("stderr")) {
-			// Standard output - send to terminal
+	// The entry says where and how this write goes (issue #315): no fd
+	// numerology, no "stdout" name matching, no well-known service ids.
+	// That policy now lives with whoever created the entry.
+	switch (fd_entry->route) {
+		case FdRoute::CONSOLE: {
+			// One-way console output to the routed task
 			Message m = { .type = MsgType::NOTIFY_WRITE, .sender = t->id };
 
 			if (count < sizeof(m.data.write.buf)) {
@@ -86,12 +89,12 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 				// message then carries an empty string)
 				copy_from_user(m.data.write.buf, buf, count);
 				m.data.write.buf[count] = '\0';
-				kernel::task::send_message(process_ids::SHELL, m);
+				kernel::task::send_message(fd_entry->dest, m);
 				return count;
 			}
 
-			// The 256B ceiling is gone (issue #314 Stage C): large stdout
-			// payloads travel OOL and are released by the shell
+			// The 256B ceiling is gone (issue #314 Stage C): large console
+			// payloads travel OOL and are released by the receiver
 			auto kbuf = kernel::task::make_ool_buffer(count + 1);
 			if (!kbuf) {
 				return ERR_NO_MEMORY;
@@ -101,51 +104,48 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 			m.ool.addr = reinterpret_cast<uint64_t>(kbuf.get());
 			m.ool.size = count + 1;
 
-			const error_t err = kernel::task::send_message(process_ids::SHELL, m);
+			const error_t err = kernel::task::send_message(fd_entry->dest, m);
 			if (IS_ERR(err)) {
 				return err;
 			}
-			static_cast<void>(kbuf.release()); // delivered: the shell owns it now
+			static_cast<void>(kbuf.release()); // delivered: the receiver owns it
 
 			return count;
 		}
-		// File output - fd contains actual file info after dup2. Any size
-		// goes through one OOL path (issue #314 Stage C).
-		Message req = { .type = MsgType::FS_WRITE, .sender = t->id };
-		req.data.fs.fd = fd;
-		req.data.fs.len = count;
+		case FdRoute::FS: {
+			// File write: any size goes through one OOL path (issue #314
+			// Stage C), correlation-matched so the reply cannot be confused
+			// with other FS_WRITE traffic (Stage B)
+			Message req = { .type = MsgType::FS_WRITE, .sender = t->id };
+			req.data.fs.fd = fd;
+			req.data.fs.len = count;
 
-		auto kbuf = kernel::task::make_ool_buffer(count);
-		if (!kbuf) {
-			return ERR_NO_MEMORY;
-		}
-		if (copy_from_user(kbuf.get(), buf, count) != count) {
-			return ERR_INVALID_ARG;
-		}
-		req.ool.addr = reinterpret_cast<uint64_t>(kbuf.get());
-		req.ool.size = count;
+			auto kbuf = kernel::task::make_ool_buffer(count);
+			if (!kbuf) {
+				return ERR_NO_MEMORY;
+			}
+			if (copy_from_user(kbuf.get(), buf, count) != count) {
+				return ERR_INVALID_ARG;
+			}
+			req.ool.addr = reinterpret_cast<uint64_t>(kbuf.get());
+			req.ool.size = count;
 
-		// Correlation-matched RPC: the reply cannot be confused with any
-		// other FS_WRITE traffic (issue #314 Stage B)
-		const error_t err = kernel::task::call(process_ids::FS_FAT32, &req);
-		if (IS_ERR(err)) {
-			// Never delivered; kbuf frees the payload on return
-			return err;
-		}
-		static_cast<void>(kbuf.release()); // consumed (and freed) by the FS task
-		if (IS_ERR(req.result)) {
-			return req.result;
-		}
+			const error_t err = kernel::task::call(fd_entry->dest, &req);
+			if (IS_ERR(err)) {
+				// Never delivered; kbuf frees the payload on return
+				return err;
+			}
+			static_cast<void>(kbuf.release()); // consumed (and freed) by the server
+			if (IS_ERR(req.result)) {
+				return req.result;
+			}
 
-		return req.data.fs.len;
+			return req.data.fs.len;
+		}
+		case FdRoute::NONE:
+			break;
 	}
 
-	// For file descriptors, the user process should use fs_write() through IPC
-	// The kernel doesn't directly handle file writes in Phase 2
-	// This allows proper IPC message handling in userland
-
-	// For now, return an error indicating the operation is not supported at syscall
-	// level User should use the file system API (fs_write) instead
 	return ERR_INVALID_FD;
 }
 

--- a/kernel/tests/test_cases/fd_test.cpp
+++ b/kernel/tests/test_cases/fd_test.cpp
@@ -192,6 +192,39 @@ void test_fd_limits()
 	ASSERT_EQ(new_fd, fds[0]); // Should reuse the freed slot
 }
 
+void test_fd_routing()
+{
+	// Create test FD table
+	fs::FileDescriptor fd_table[32];
+	fs::init_process_fd_table(fd_table, 32);
+
+	// Standard descriptors route console output to the shell task;
+	// sys_write follows this instead of matching "stdout" names (issue #315)
+	ASSERT_TRUE(fd_table[STDIN_FILENO].route == FdRoute::CONSOLE);
+	ASSERT_TRUE(fd_table[STDOUT_FILENO].route == FdRoute::CONSOLE);
+	ASSERT_TRUE(fd_table[STDOUT_FILENO].dest == process_ids::SHELL);
+	ASSERT_TRUE(fd_table[STDERR_FILENO].route == FdRoute::CONSOLE);
+	ASSERT_TRUE(fd_table[STDERR_FILENO].dest == process_ids::SHELL);
+
+	// FS-created entries route to the FAT32 service
+	fd_t fd = fs::allocate_process_fd(fd_table, 32, "routed.txt", 10,
+									  ProcessId::from_raw(1));
+	ASSERT_GT(fd, -1);
+	ASSERT_TRUE(fd_table[fd].route == FdRoute::FS);
+	ASSERT_TRUE(fd_table[fd].dest == process_ids::FS_FAT32);
+
+	// dup2 carries the routing with the entry: redirection is nothing but
+	// a routing swap now
+	error_t result = fs::dup_process_fd(fd_table, 32, fd, STDOUT_FILENO);
+	ASSERT_EQ(result, OK);
+	ASSERT_TRUE(fd_table[STDOUT_FILENO].route == FdRoute::FS);
+	ASSERT_TRUE(fd_table[STDOUT_FILENO].dest == process_ids::FS_FAT32);
+
+	// clear() drops the routing
+	fd_table[STDOUT_FILENO].clear();
+	ASSERT_TRUE(fd_table[STDOUT_FILENO].route == FdRoute::NONE);
+}
+
 void test_release_all_fds()
 {
 	// Create test FD table
@@ -232,5 +265,6 @@ void register_fd_tests()
 	test_register("test_fd_dup2", test_fd_dup2);
 	test_register("test_dup_process_fd", test_dup_process_fd);
 	test_register("test_fd_limits", test_fd_limits);
+	test_register("test_fd_routing", test_fd_routing);
 	test_register("test_release_all_fds", test_release_all_fds);
 }

--- a/libs/common/file_descriptor.hpp
+++ b/libs/common/file_descriptor.hpp
@@ -1,0 +1,80 @@
+/**
+ * @file file_descriptor.hpp
+ * @brief File descriptor entry: a per-process I/O routing record
+ *
+ * Lives in libs/common because the entry is part of the kernel/service
+ * contract (issue #315): the kernel only follows the routing stored here,
+ * and the services that create entries (FS server, future console server)
+ * will manage them from user space in Phase 3b.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include "process_id.hpp"
+
+/**
+ * @brief How I/O on a descriptor is routed
+ *
+ * The syscall layer follows this instead of interpreting fd numbers or
+ * name strings; whoever creates the entry decides the routing.
+ */
+enum class FdRoute : uint8_t {
+	NONE = 0, ///< No I/O possible through this entry
+	CONSOLE,  ///< write = one-way NOTIFY_WRITE to dest (console output)
+	FS,		  ///< read/write = correlation-matched FS_* RPC to dest
+};
+
+/**
+ * @brief File descriptor structure
+ *
+ * Represents an open I/O handle for a process: where operations on it are
+ * routed (route/dest) plus the file state the FS still keeps here until it
+ * owns fd management itself (issue #315 3b).
+ */
+struct FileDescriptor {
+	char name[13];	///< Label: 8.3 file name for FS fds, "stdout" etc. for std fds
+	FdRoute route;	///< Protocol the syscall layer uses for I/O on this fd
+	ProcessId dest; ///< Service task the I/O is sent to
+	size_t size;	///< File size in bytes
+	size_t offset;	///< Current read/write position
+
+	/**
+	 * @brief Check if this file descriptor is unused
+	 * @return true if the descriptor is not in use (empty name)
+	 */
+	bool is_unused() const { return name[0] == '\0'; }
+
+	/**
+	 * @brief Check if this file descriptor is in use
+	 * @return true if the descriptor is in use (non-empty name)
+	 */
+	bool is_used() const { return name[0] != '\0'; }
+
+	/**
+	 * @brief Clear this file descriptor entry
+	 *
+	 * Resets all fields to their default values, marking the descriptor as
+	 * unused.
+	 */
+	void clear()
+	{
+		name[0] = '\0';
+		route = FdRoute::NONE;
+		dest = process_ids::INVALID;
+		size = 0;
+		offset = 0;
+	}
+
+	/**
+	 * @brief Check if this file descriptor has the specified name
+	 * @param target_name The name to compare against
+	 * @return true if the name matches, false otherwise
+	 */
+	bool has_name(const char* target_name) const
+	{
+		return strcmp(name, target_name) == 0;
+	}
+};


### PR DESCRIPTION
issue #315 Phase 3a の第 4 弾。fd 所有権の設計決定「カーネルは fd → 宛先サービスの最小ルーティング表のみ持つ」を初めて実装に落とす。

## 変更内容

- **`FileDescriptor` を libs/common へ移動**(issue コメントで先行実施可と確認済みの項目)。カーネル側は `kernel::fs::FileDescriptor` エイリアスで既存呼び出し箇所を無傷に保つ(3b でヘルパごと移設したら消す)
- **エントリがルーティングを持つ**: `route`(`CONSOLE` = 一方向 NOTIFY_WRITE / `FS` = correlation 付き RPC)+ `dest`(宛先サービスの ProcessId)
- **sys_write はエントリに従うだけ**: `has_name("stdout")` の文字列判定、`fd == 1 || fd == 2` の番号占い、`process_ids::SHELL` / `FS_FAT32` のハードコードをすべて撤去
- **ルーティングの刻印は誕生地で**: fd 表初期化が std fd を CONSOLE→SHELL に、FS 側の allocate ヘルパがファイル fd を FS→FAT32 に刻む。dup2 / fork はエントリごと複製 → **リダイレクトは「ルーティングの差し替え」に還元**された
- 挙動改善: fd ≥ 3 のファイル fd への直接 sys_write が同じ経路で通るようになった(従来は dup2 済みの fd 1/2 以外 ERR_INVALID_FD)
- `test_fd_routing` 追加(init の刻印・allocate の刻印・dup2 での運搬・clear での消去)

## 設計判断と理由

- **CONSOLE / FS の 2 プロトコルは残す**(完全単一メッセージ化はしない): コンソール出力を RPC 化すると、ブート時テストが sys_write を呼ぶ時点で受け手が動いておらず `call()` がデッドロックする。fire-and-forget と RPC の違いは「サービス名の知識」ではなく「プロトコル種別」としてエントリに記録される
- **dest を enum でなく ProcessId にした理由**: 将来コンソールサーバや第 2 の FS が立っても、syscall 層は無変更でルーティング先だけが変わる(3b の布石)
- **捨てた代替案**: fd 表を丸ごと FS サーバへ移す案を先にやる順序。stdin/stdout は FS のものではないため、先にルーティング層を敷かないと console 経路が FS サーバ経由に歪む

## 実装者として危険だと思う箇所 top3

1. `kernel/syscall/handler.cpp:90-137`(FS route)— `call()` は応答までブロックする。**FS route の fd への書き込みをブート時テストから呼ぶと、FS タスクが回っていないためデッドロック**する(無効化中の redirection テスト群を再有効化するときの罠。CONSOLE route は send のみで安全)
2. `kernel/fs/file_descriptor.cpp:24-56` — SHELL を console 宛先として刻むのは fd 表 init。この init はまだカーネル内で全タスクに走るため、「シェル以外がコンソールを持つ」構成は 3b の ring3 サービス起動基盤までできない(現状の実挙動は従来と完全一致)
3. `libs/common/file_descriptor.hpp:66-72` — `clear()` が route/dest を落とすことに release_process_fd / 使い回しが依存。route を残したまま name だけ消すと、is_unused 判定(name 基準)とルーティングが食い違う。フィールド追加時は clear() への追加を忘れないこと

## 触れた危険地帯

- `kernel/syscall/`(sys_write の分岐再構成。IPC 送受・所有権移転の順序は既存パスをそのまま踏襲し、`.release()` 境界は移動していない)

## 確認

- `cmake -B build kernel && cmake --build build` ✅ / `userland/shell` 単体ビルド ✅ / `./lint.sh` 警告 0 ✅
- `test_fd_routing` 追加、既存 fd / stdio テストは無修正で通る(レイアウト変更はあるがテストはフィールド名でアクセス)
- QEMU 確認推奨: 通常コマンド出力、`echo foo > bar.txt` のリダイレクト、`cat bar.txt`

Refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)