### PR TITLE
feat(syscall): sys_read をルーティング準拠で実装 + FS ラッパのエラー潰し解消(issue #315 3a-5)

### DIFF
--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -30,26 +31,72 @@ namespace kernel::syscall
 ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 {
 	const fd_t fd = static_cast<fd_t>(arg1);
-	// void __user* buf = reinterpret_cast<void*>(arg2);
-	// const size_t count = static_cast<size_t>(arg3);
+	void __user* buf = reinterpret_cast<void*>(arg2);
+	const size_t count = static_cast<size_t>(arg3);
 
 	kernel::task::Task* t = kernel::task::CURRENT_TASK;
 
-	// Validate file descriptor
-	if (kernel::fs::get_process_fd(t->fd_table.data(),
-								   kernel::task::MAX_FDS_PER_PROCESS,
-								   fd) == nullptr) {
+	kernel::fs::FileDescriptor* fd_entry = kernel::fs::get_process_fd(
+			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, fd);
+	if (fd_entry == nullptr) {
 		return ERR_INVALID_FD;
 	}
 
-	// For now, only support stdin (fd 0)
-	if (fd == STDIN_FILENO) {
-		// TODO: Implement actual keyboard input via IPC
-		// For now, return 0 (no data available)
+	if (count == 0) {
 		return 0;
 	}
 
-	// Other file descriptors not yet supported
+	// Reads follow the fd's routing, mirroring sys_write (issue #315)
+	switch (fd_entry->route) {
+		case FdRoute::CONSOLE:
+			// Interactive stdin needs the console owner to serve reads, but
+			// the shell is blocked in sys_wait for the whole life of the
+			// command that would be reading (it could never answer the
+			// RPC). Until the shell loop goes async (issue #315 3b), stdin
+			// honestly reports EOF instead of pretending to be readable.
+			return 0;
+		case FdRoute::FS: {
+			// The FS's read contract is currently "reply with the whole
+			// file as one OOL copy" (kernel/fs/fat reply_file_data); the
+			// window [offset, offset+count) is cut out here so sequential
+			// read() loops terminate. Both move into the FS server in 3b.
+			Message req = { .type = MsgType::FS_READ, .sender = t->id };
+			req.data.fs.fd = fd;
+			req.data.fs.len = count;
+
+			const error_t err = kernel::task::call(fd_entry->dest, &req);
+			if (IS_ERR(err)) {
+				return err;
+			}
+
+			// Own the reply payload before inspecting the result so an
+			// error reply that still carries one cannot leak it (the
+			// buffer stays kernel-owned for in-kernel callers)
+			kernel::memory::unique_kbuf<> data{ reinterpret_cast<void*>(
+					req.ool.addr) };
+			if (IS_ERR(req.result)) {
+				return req.result;
+			}
+
+			const size_t file_size = req.data.fs.len;
+			if (!data || fd_entry->offset >= file_size) {
+				return 0; // EOF (or empty file: those replies carry no OOL)
+			}
+
+			const size_t n = std::min(count, file_size - fd_entry->offset);
+			if (copy_to_user(buf,
+							 static_cast<const char*>(data.get()) + fd_entry->offset,
+							 n) != n) {
+				return ERR_INVALID_ARG;
+			}
+			fd_entry->offset += n;
+
+			return n;
+		}
+		case FdRoute::NONE:
+			break;
+	}
+
 	return ERR_INVALID_FD;
 }
 

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -90,12 +90,13 @@ void test_read_from_stdin()
 
 	const ScopedCurrentTask scoped_task(t);
 
-	// Test reading from stdin (currently returns 0)
+	// stdin (CONSOLE route) reports EOF by design: the console owner
+	// cannot serve reads while it is blocked in sys_wait (issue #315;
+	// interactive stdin arrives with the async shell loop in 3b)
 	char buffer[128];
 	const ssize_t result = kernel::syscall::sys_read(
 			STDIN_FILENO, reinterpret_cast<uint64_t>(buffer), sizeof(buffer));
 
-	// Currently stdin returns 0 (no data available)
 	ASSERT_EQ(result, 0);
 }
 
@@ -123,6 +124,15 @@ void test_invalid_fd()
 	const ssize_t result3 = kernel::syscall::sys_write(
 			10, reinterpret_cast<uint64_t>(buffer), sizeof(buffer));
 	ASSERT_EQ(result3, ERR_INVALID_FD);
+
+	// sys_read validates through the same fd lookup (issue #315)
+	const ssize_t result4 = kernel::syscall::sys_read(
+			-1, reinterpret_cast<uint64_t>(buffer), sizeof(buffer));
+	ASSERT_EQ(result4, ERR_INVALID_FD);
+
+	const ssize_t result5 = kernel::syscall::sys_read(
+			10, reinterpret_cast<uint64_t>(buffer), sizeof(buffer));
+	ASSERT_EQ(result5, ERR_INVALID_FD);
 }
 
 void test_fd_inheritance()

--- a/libs/user/file.cpp
+++ b/libs/user/file.cpp
@@ -1,3 +1,4 @@
+#include <sys/types.h>
 #include <algorithm>
 #include <cstring>
 #include <libs/common/message.hpp>
@@ -14,18 +15,21 @@ fd_t fs_open(const char* path, int flags)
 
 	Message res = call(process_ids::FS_FAT32, &m);
 
-	return IS_ERR(res.result) ? -1 : res.data.fs.fd;
+	return IS_ERR(res.result) ? res.result : res.data.fs.fd;
 }
 
-size_t fs_read(fd_t fd, void* buf, size_t count)
+ssize_t fs_read(fd_t fd, void* buf, size_t count)
 {
 	Message m = make_request(MsgType::FS_READ);
 	m.data.fs.fd = fd;
 	m.data.fs.len = count;
 
 	Message res = call(process_ids::FS_FAT32, &m);
-	if (IS_ERR(res.result) || res.ool.size == 0) {
-		return 0;
+	if (IS_ERR(res.result)) {
+		return res.result;
+	}
+	if (res.ool.size == 0) {
+		return 0; // empty file: the reply carries no OOL payload
 	}
 
 	const size_t copy_len = std::min(count, static_cast<size_t>(res.ool.size));
@@ -51,26 +55,31 @@ fd_t fs_create(const char* path)
 
 	Message res = call(process_ids::FS_FAT32, &m);
 
-	return IS_ERR(res.result) ? -1 : res.data.fs.fd;
+	return IS_ERR(res.result) ? res.result : res.data.fs.fd;
 }
 
-void fs_pwd(char* buf, size_t size)
+error_t fs_pwd(char* buf, size_t size)
 {
 	Message m = make_request(MsgType::FS_PWD);
 
 	Message res = call(process_ids::FS_FAT32, &m);
 	if (IS_ERR(res.result)) {
 		buf[0] = '\0';
-		return;
+		return res.result;
 	}
 
 	memcpy(buf, res.data.fs.name, size);
+
+	return OK;
 }
 
-size_t fs_write(fd_t fd, const void* buf, size_t count)
+ssize_t fs_write(fd_t fd, const void* buf, size_t count)
 {
-	if (count == 0 || count > OOL_MAX_SIZE) {
+	if (count == 0) {
 		return 0;
+	}
+	if (count > OOL_MAX_SIZE) {
+		return ERR_OOL_LIMIT;
 	}
 
 	Message m = make_request(MsgType::FS_WRITE);
@@ -85,13 +94,13 @@ size_t fs_write(fd_t fd, const void* buf, size_t count)
 
 	Message res = call(process_ids::FS_FAT32, &m);
 	if (IS_ERR(res.result)) {
-		return 0;
+		return res.result;
 	}
 
 	return res.data.fs.len;
 }
 
-void fs_change_dir(char* buf, const char* path)
+error_t fs_change_dir(char* buf, const char* path)
 {
 	Message m = make_request(MsgType::FS_CHANGE_DIR);
 	memcpy(m.data.fs.name, path, strlen(path));
@@ -100,14 +109,16 @@ void fs_change_dir(char* buf, const char* path)
 	Message res = call(process_ids::FS_FAT32, &m);
 	if (IS_ERR(res.result)) {
 		buf[0] = '\0';
-		return;
+		return res.result;
 	}
 
 	memcpy(buf, res.data.fs.name, strlen(res.data.fs.name));
 	buf[strlen(res.data.fs.name)] = '\0';
+
+	return OK;
 }
 
-int fs_dup2(fd_t oldfd, fd_t newfd)
+fd_t fs_dup2(fd_t oldfd, fd_t newfd)
 {
 	Message m = make_request(MsgType::FS_DUP2);
 	m.data.fs.fd = oldfd;
@@ -115,5 +126,5 @@ int fs_dup2(fd_t oldfd, fd_t newfd)
 
 	Message res = call(process_ids::FS_FAT32, &m);
 
-	return IS_ERR(res.result) ? -1 : res.data.fs.fd;
+	return IS_ERR(res.result) ? res.result : res.data.fs.fd;
 }

--- a/libs/user/file.hpp
+++ b/libs/user/file.hpp
@@ -1,19 +1,31 @@
 #pragma once
 
+#include <sys/types.h>
 #include <libs/common/types.hpp>
 
+// FS wrappers propagate errors as negative error_t values (issue #356 /
+// #315-3a): no more crushing to -1 or 0. Check with IS_ERR / IS_OK, not
+// comparisons against specific negative values.
+
+/// @return The opened fd, or a negative error_t
 fd_t fs_open(const char* path, int flags);
 
-size_t fs_read(fd_t fd, void* buf, size_t count);
+/// @return Bytes read, or a negative error_t
+ssize_t fs_read(fd_t fd, void* buf, size_t count);
 
-size_t fs_write(fd_t fd, const void* buf, size_t count);
+/// @return Bytes written, or a negative error_t
+ssize_t fs_write(fd_t fd, const void* buf, size_t count);
 
 void fs_close(fd_t fd);
 
+/// @return The created file's fd, or a negative error_t
 fd_t fs_create(const char* path);
 
-void fs_pwd(char* buf, size_t size);
+/// @return OK on success (buf is filled), or a negative error_t (buf is "")
+error_t fs_pwd(char* buf, size_t size);
 
-void fs_change_dir(char* buf, const char* path);
+/// @return OK on success (buf holds the new cwd), or a negative error_t
+error_t fs_change_dir(char* buf, const char* path);
 
-int fs_dup2(fd_t oldfd, fd_t newfd);
+/// @return newfd on success, or a negative error_t
+fd_t fs_dup2(fd_t oldfd, fd_t newfd);

--- a/userland/commands/cat/main.cpp
+++ b/userland/commands/cat/main.cpp
@@ -13,19 +13,20 @@ int main(int argc, char** argv)
 	}
 
 	fd_t fd = fs_open(input, 0);
-	if (fd < 0) {
+	if (IS_ERR(fd)) {
 		printu("cat: No such file or directory");
 		return 0;
 	}
 
 	char buf[1024];
-	int result = fs_read(fd, buf, sizeof(buf) - 1); // Leave room for null terminator
-	if (result <= 0) {
-		printu("cat: Error reading file");
+	// Leave room for the null terminator
+	ssize_t result = fs_read(fd, buf, sizeof(buf) - 1);
+	if (IS_ERR(result)) {
+		printu("cat: failed to read %s (%d)", input, static_cast<int>(result));
 		return 0;
 	}
 
-	buf[result] = '\0'; // Add null terminator
+	buf[result] = '\0'; // Add null terminator (an empty file prints nothing)
 	printu(buf);
 
 	return 0;

--- a/userland/commands/cd/main.cpp
+++ b/userland/commands/cd/main.cpp
@@ -14,9 +14,7 @@ int main(int argc, char** argv)
 	char* target_dir = argv[1];
 	char new_path[256] = { 0 };
 
-	fs_change_dir(new_path, target_dir);
-
-	if (new_path[0] == '\0') {
+	if (IS_ERR(fs_change_dir(new_path, target_dir))) {
 		printu("cd: The directory %s does not exist", target_dir);
 		return 0;
 	}

--- a/userland/commands/pwd/main.cpp
+++ b/userland/commands/pwd/main.cpp
@@ -5,7 +5,11 @@ int main(int argc, char** argv)
 {
 	char name[20];
 
-	fs_pwd(name, 20);
+	const error_t err = fs_pwd(name, 20);
+	if (IS_ERR(err)) {
+		printu("pwd: failed (%d)", err);
+		return 0;
+	}
 
 	printu(name);
 

--- a/userland/commands/write/main.cpp
+++ b/userland/commands/write/main.cpp
@@ -14,32 +14,36 @@ int main(int argc, char** argv)
 
 	// Open or create file
 	fd_t fd = fs_open(filename, 0);
-	if (fd < 0) {
+	if (IS_ERR(fd)) {
 		// Try to create the file
 		fd = fs_create(filename);
-		if (fd < 0) {
-			printu("Failed to open or create file: %s", filename);
+		if (IS_ERR(fd)) {
+			printu("Failed to open or create file: %s (%d)", filename,
+				   static_cast<int>(fd));
 			return 0;
 		}
 	}
 
 	// Write text to file
 	size_t text_len = strlen(text);
-	size_t written = fs_write(fd, text, text_len);
+	ssize_t written = fs_write(fd, text, text_len);
 
-	if (written == 0) {
-		printu("Failed to write to file: %s", filename);
+	if (IS_ERR(written)) {
+		printu("Failed to write to file: %s (%d)", filename,
+			   static_cast<int>(written));
 		fs_close(fd);
 		return 0;
 	}
 
 	// Write newline
 	const char newline[] = "\n";
-	fs_write(fd, newline, 1);
+	if (IS_ERR(fs_write(fd, newline, 1))) {
+		printu("Failed to write newline to %s", filename);
+	}
 
 	fs_close(fd);
 
-	printu("Written %d bytes to %s", written + 1, filename);
+	printu("Written %d bytes to %s", static_cast<int>(written) + 1, filename);
 
 	return 0;
 }

--- a/userland/shell/shell.cpp
+++ b/userland/shell/shell.cpp
@@ -64,13 +64,14 @@ void Shell::process_input(char* input, Terminal& term)
 		if (redirect_file != nullptr && strlen(redirect_file) > 0) {
 			// Create or open the file
 			fd_t file_fd = fs_create(redirect_file);
-			if (file_fd < 0) {
+			if (IS_ERR(file_fd)) {
 				// Try opening existing file
 				file_fd = fs_open(redirect_file, 0);
 			}
 
-			if (file_fd >= 0) {
-				// Redirect stdout to file
+			if (IS_OK(file_fd)) {
+				// Redirect stdout to file; on failure the output just
+				// stays on the console, which the user will see anyway
 				fs_dup2(file_fd, STDOUT_FILENO);
 				fs_close(file_fd);
 			}


### PR DESCRIPTION
issue #315 Phase 3a の第 5 弾(3a 最終)。sys_read のスタブを #375 の fd ルーティングに乗せて実装し、userland ルールで予告済みだった libs/user/file.cpp のエラー潰し(-1/0 潰し)を #356 規約に揃える。

## 変更内容

**sys_read(kernel/syscall)**
- **FS route**: `FS_READ` RPC を `entry.dest` へ発行。FS の現契約は「ファイル全体を OOL 1 発で返す」なので、カーネル側で `[offset, offset+count)` の窓を切り出し、`fd_entry->offset` を進める。**逐次 read() ループが正しく EOF(0)で終端する**ようになった(newlib の `read()` は sys_read 直結なので実利あり)
- **CONSOLE route**: **意図的に EOF(0)を返す**。理由は下記の設計判断
- 検証は fd 表引きに一本化(`fd == 0` の特別扱い廃止)。`test_invalid_fd` に sys_read の検証を追加

**libs/user/file(エラー伝搬化)**
- `fs_open/fs_create/fs_dup2` → 失敗時は負の `error_t` を返す(-1 潰し廃止)
- `fs_read/fs_write` → `ssize_t` 化。失敗時は負の `error_t`(0 潰し廃止)
- `fs_pwd/fs_change_dir` → `error_t` を返す
- 呼び出し元(cat / write / pwd / cd / shell のリダイレクト)を `IS_ERR`/`IS_OK` 判定に追従。cat はエラー時にエラーコードを表示、空ファイルはエラー扱いせず空出力に(挙動修正)

## 設計判断と理由

- **対話 stdin は今回やらない(構造的ブロッカーの発見)**: コマンドが stdin を読む間、コンソール所有者であるシェルは `sys_wait` でブロックしており、stdin 要求 RPC に**原理的に応答できない**(子は call でブロック、親は wait でブロック = デッドロック)。解決にはシェルのイベントループ非同期化(子の exit をドアベル通知化 + 非ブロック wait)が必要で、これは 3b のコンソールサーバ検討と同じ設計判断に属する。**「読めるふり」をするより EOF を正直に返す**ことを選んだ(EOF なら read ループは正常終了する)
- **offset 窓切りをカーネルに置いた理由**: FS の「全ファイル返し」契約を変えると FS 側の改修が膨らみ 1 PR を超える。窓切り+offset は fd 状態の一部であり、3b-8 で fd 管理ごと FS サーバへ移る(移動先が既に計画にある一時配置)
- **fs_close は void のまま**: 応答のない一方向 send で、潰しているエラーが存在しない

## 実装者として危険だと思う箇所 top3

1. `kernel/syscall/handler.cpp`(sys_read FS route)— **毎 read でファイル全体を FS が複製**する O(file_size) 実装。大きいファイルの逐次読みは二乗コストになる。正しい修正は FS 契約の offset/len 対応で、3b の FS 移設時に併せて直す前提の暫定
2. `kernel/syscall/handler.cpp`(offset 進行)— offset はカーネル(fd 表)が進めるが、**userland の `fs_read`(IPC 直叩き)は offset を進めない**。sys_read 経由と fs_read 経由で読み位置の意味が違う二重経路が 3b までの間存在する(現状 fs_read 利用者は cat のみ・単発読みなので実害なし)
3. `libs/user/file.hpp` の ABI 変更 — 戻り値の型と意味が変わるため、**旧バイナリ混在は不可**。ディスクイメージ再生成必須(全コマンド再ビルドは確認済み)

## 触れた危険地帯

- `kernel/syscall/`(sys_read の実装。IPC 所有権は sys_exec と同じ「call 成功 → 即 unique_kbuf で受領 → result 検査」パターンを踏襲)

## 確認

- `cmake -B build kernel && cmake --build build` ✅ / userland 全ターゲット(shell + commands/*)ビルド ✅ / `./lint.sh` 警告 0 ✅
- `test_invalid_fd` に sys_read 検証を追加、`test_read_from_stdin` は「EOF は仕様」とコメント更新
- QEMU 確認推奨: `cat <file>`(既存動作)、`echo x > f && cat f`、`pwd` / `cd`

Refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)