### PR TITLE
refactor(task): サービス起動を manifest 化し、スケジューラから個別サービスの知識を除去(issue #315 3b-6)

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCE_FILES
         elf.cpp
         list.cpp
         panic.cpp
+        services.cpp
 )
 
 # Build the kernel test suites and run them at boot. Left ON by default for

--- a/kernel/hardware/CMakeLists.txt
+++ b/kernel/hardware/CMakeLists.txt
@@ -2,6 +2,7 @@ set(HARDWARE_SOURCE_FILES
         keyboard.cpp
         pci.cpp
         serial.cpp
+        usb_service.cpp
         )
 
 add_library(UchosHardware ${HARDWARE_SOURCE_FILES})

--- a/kernel/hardware/usb_service.cpp
+++ b/kernel/hardware/usb_service.cpp
@@ -1,0 +1,35 @@
+#include "hardware/usb_service.hpp"
+#include <libs/common/message.hpp>
+#include "hardware/keyboard.hpp"
+#include "hardware/pci.hpp"
+#include "hardware/usb/xhci/xhci.hpp"
+#include "task/ipc.hpp"
+#include "task/task.hpp"
+
+namespace
+{
+void notify_xhci_handler(const Message& m)
+{
+	kernel::hw::usb::xhci::process_events();
+}
+} // namespace
+
+namespace kernel::hw
+{
+
+void usb_handler_service()
+{
+	kernel::task::Task* t = kernel::task::CURRENT_TASK;
+
+	pci::initialize();
+
+	usb::xhci::initialize();
+
+	initialize_keyboard();
+
+	t->add_msg_handler(MsgType::NOTIFY_XHCI, notify_xhci_handler);
+
+	kernel::task::process_messages(t);
+}
+
+} // namespace kernel::hw

--- a/kernel/hardware/usb_service.hpp
+++ b/kernel/hardware/usb_service.hpp
@@ -1,0 +1,23 @@
+/**
+ * @file usb_service.hpp
+ * @brief USB service task entry point
+ */
+
+#pragma once
+
+namespace kernel::hw
+{
+
+/**
+ * @brief USB service task: owns PCI/xHCI bring-up and USB event handling
+ *
+ * Initializes PCI, the xHCI controller and the keyboard observer, then
+ * serves NOTIFY_XHCI doorbells in a message loop. Lives in hardware/ so
+ * the task layer holds no USB knowledge (issue #315: the scheduler only
+ * learns about this service through the boot manifest).
+ *
+ * @note This function never returns
+ */
+void usb_handler_service();
+
+} // namespace kernel::hw

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -5,6 +5,7 @@
 #include "memory/bootstrap_allocator.hpp"
 #include "memory/paging.hpp"
 #include "memory/segment.hpp"
+#include "services.hpp"
 #include "syscall/syscall.hpp"
 #include "task/builtin.hpp"
 #include "task/task.hpp"
@@ -55,7 +56,10 @@ extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 
 	kernel::syscall::initialize();
 
-	kernel::task::initialize();
+	size_t num_services = 0;
+	const kernel::task::InitialTaskInfo* services =
+			kernel::service_manifest(&num_services);
+	kernel::task::initialize(services, num_services);
 
 	kernel::tests::run_main_stage_tests();
 

--- a/kernel/services.cpp
+++ b/kernel/services.cpp
@@ -1,0 +1,111 @@
+/**
+ * @file services.cpp
+ * @brief Boot-time service manifest: the single place that knows which
+ * services UCHos starts
+ *
+ * Extracted from kernel/task/task.cpp (issue #315): keeping the list here
+ * cuts the scheduler's reverse dependencies on fs/, hardware/ and net/.
+ * Phase 3b replaces entries with ring-3 launches one by one without the
+ * task layer noticing.
+ */
+
+#include "services.hpp"
+#include <cstddef>
+#include <cstring>
+#include <libs/common/message.hpp>
+#include <libs/common/process_id.hpp>
+#include <libs/common/types.hpp>
+#include <utility>
+#include "elf.hpp"
+#include "fs/fat/fat.hpp"
+#include "hardware/usb_service.hpp"
+#include "hardware/virtio/blk.hpp"
+#include "hardware/virtio/net.hpp"
+#include "log/log.hpp"
+#include "memory/slab.hpp"
+#include "net/packet_handler.hpp"
+#include "task/ipc.hpp"
+#include "task/task.hpp"
+
+namespace
+{
+
+/**
+ * @brief Bootstrap of the user shell
+ *
+ * Runs as the SHELL task's ring-0 prologue: one synchronous FS_LOAD
+ * returns a kernel-owned copy of the shell binary as an OOL move, then
+ * exec_elf takes ownership and turns this task into the ring-3 shell.
+ * Lives next to the manifest because it is boot wiring, not scheduler
+ * code (issue #315).
+ */
+void shell_service()
+{
+	Message m = { .type = MsgType::FS_LOAD, .sender = process_ids::SHELL };
+	char path[6] = "shell";
+	memcpy(m.data.fs.name, path, 6);
+
+	const error_t load_err = kernel::task::call(process_ids::FS_FAT32, &m);
+
+	// Take ownership before inspecting the result (mirrors sys_exec)
+	kernel::memory::unique_kbuf<> shell_elf{ reinterpret_cast<void*>(m.ool.addr) };
+	if (IS_ERR(load_err) || IS_ERR(m.result) || m.ool.size == 0 || !shell_elf) {
+		LOG_ERROR("failed to load shell binary");
+		while (true) {
+			__asm__("hlt");
+		}
+	}
+
+	CURRENT_TASK->is_initialized = true;
+	exec_elf(std::move(shell_elf), "shell", nullptr);
+}
+
+using kernel::task::InitialTaskInfo;
+
+/// Every service the kernel starts at boot, in task-slot order. All still
+/// run ring 0 (KERNEL_CS kernel threads) for now; see issue #315 3b.
+constexpr InitialTaskInfo SERVICE_MANIFEST[] = {
+	{ SystemProcessId::XHCI, "usb_handler", &kernel::hw::usb_handler_service, true,
+	  true },
+	{ SystemProcessId::VIRTIO_BLK, "virtio_blk",
+	  &kernel::hw::virtio::virtio_blk_service, true, false },
+	{ SystemProcessId::FS_FAT32, "fat32", &kernel::fs::fat32_service, true, true },
+	{ SystemProcessId::SHELL, "shell", &shell_service, true, false },
+	{ SystemProcessId::VIRTIO_NET, "virtio_net",
+	  &kernel::hw::virtio::virtio_net_service, true, false },
+	{ SystemProcessId::NET, "net", &kernel::net::packet_handler_service, true,
+	  false },
+};
+
+constexpr size_t SERVICE_COUNT =
+		sizeof(SERVICE_MANIFEST) / sizeof(SERVICE_MANIFEST[0]);
+
+// create_task() hands out slots in ascending order after the scheduler's
+// own KERNEL and IDLE tasks, so each entry's declared SystemProcessId only
+// holds if the manifest starts at XHCI and is ordered with no gap.
+constexpr bool manifest_matches_slots()
+{
+	for (size_t i = 0; i < SERVICE_COUNT; ++i) {
+		if (static_cast<pid_t>(SERVICE_MANIFEST[i].id) !=
+			static_cast<pid_t>(SystemProcessId::XHCI) + static_cast<pid_t>(i)) {
+			return false;
+		}
+	}
+	return true;
+}
+static_assert(manifest_matches_slots(),
+			  "SERVICE_MANIFEST must start at XHCI and be ordered by "
+			  "SystemProcessId, gap-free");
+
+} // namespace
+
+namespace kernel
+{
+
+const task::InitialTaskInfo* service_manifest(size_t* out_count)
+{
+	*out_count = SERVICE_COUNT;
+	return SERVICE_MANIFEST;
+}
+
+} // namespace kernel

--- a/kernel/services.hpp
+++ b/kernel/services.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file services.hpp
+ * @brief Boot-time service manifest access
+ */
+
+#pragma once
+
+#include <cstddef>
+#include "task/task.hpp"
+
+namespace kernel
+{
+
+/**
+ * @brief Get the boot-time service manifest
+ *
+ * The manifest is the single place that knows which services UCHos
+ * starts and in which task slots they live (issue #315): the scheduler
+ * (kernel/task) starts whatever list it is handed and knows no
+ * individual service.
+ *
+ * @param out_count Set to the number of manifest entries
+ * @return Pointer to the manifest array
+ */
+const task::InitialTaskInfo* service_manifest(size_t* out_count);
+
+} // namespace kernel

--- a/kernel/task/builtin.cpp
+++ b/kernel/task/builtin.cpp
@@ -1,29 +1,16 @@
 #include "task/builtin.hpp"
 #include <cstddef>
-#include <cstring>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 #include <utility>
-#include "elf.hpp"
-#include "fs/path.hpp"
-#include "hardware/keyboard.hpp"
 #include "hardware/pci.hpp"
-#include "hardware/usb/xhci/xhci.hpp"
-#include "hardware/virtio/pci.hpp"
-#include "log/log.hpp"
 #include "memory/page.hpp"
-#include "memory/slab.hpp"
 #include "task/ipc.hpp"
 #include "task/task.hpp"
 
 namespace
 {
-void notify_xhci_handler(const Message& m)
-{
-	kernel::hw::usb::xhci::process_events();
-}
-
 void handle_task_ready(const Message& m)
 {
 	Message send_m = { .type = MsgType::KERNEL_TASK_READY,
@@ -104,45 +91,6 @@ void kernel_service()
 	t->add_msg_handler(MsgType::KERNEL_TASK_READY, handle_task_ready);
 	t->add_msg_handler(MsgType::KERNEL_MEMORY_USAGE, handle_memory_usage);
 	t->add_msg_handler(MsgType::KERNEL_PCI_LIST, handle_pci);
-
-	kernel::task::process_messages(t);
-}
-
-void shell_service()
-{
-	// One synchronous FS_LOAD returns a kernel-owned copy of the binary as
-	// an OOL move; exec_elf takes ownership and frees it once the
-	// segments are loaded (issue #314 Stage C)
-	Message m = { .type = MsgType::FS_LOAD, .sender = process_ids::SHELL };
-	char path[6] = "shell";
-	memcpy(m.data.fs.name, path, 6);
-
-	const error_t load_err = kernel::task::call(process_ids::FS_FAT32, &m);
-
-	// Take ownership before inspecting the result (mirrors sys_exec)
-	kernel::memory::unique_kbuf<> shell_elf{ reinterpret_cast<void*>(m.ool.addr) };
-	if (IS_ERR(load_err) || IS_ERR(m.result) || m.ool.size == 0 || !shell_elf) {
-		LOG_ERROR("failed to load shell binary");
-		while (true) {
-			__asm__("hlt");
-		}
-	}
-
-	CURRENT_TASK->is_initialized = true;
-	exec_elf(std::move(shell_elf), "shell", nullptr);
-}
-
-void usb_handler_service()
-{
-	Task* t = kernel::task::CURRENT_TASK;
-
-	kernel::hw::pci::initialize();
-
-	kernel::hw::usb::xhci::initialize();
-
-	kernel::hw::initialize_keyboard();
-
-	t->add_msg_handler(MsgType::NOTIFY_XHCI, notify_xhci_handler);
 
 	kernel::task::process_messages(t);
 }

--- a/kernel/task/builtin.hpp
+++ b/kernel/task/builtin.hpp
@@ -29,22 +29,4 @@ namespace kernel::task
  */
 void kernel_service();
 
-/**
- * @brief Shell task for user interaction
- *
- * This task implements the command-line shell interface, allowing
- * users to interact with the system, execute commands, and manage
- * processes.
- */
-void shell_service();
-
-/**
- * @brief USB event handler task
- *
- * This task processes USB events and manages USB device communication.
- * It handles device enumeration, data transfers, and USB protocol
- * management for connected devices.
- */
-void usb_handler_service();
-
 } // namespace kernel::task

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -5,10 +5,7 @@
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
-#include "fs/fat/fat.hpp"
 #include "fs/path.hpp"
-#include "hardware/virtio/blk.hpp"
-#include "hardware/virtio/net.hpp"
 #include "interrupt/irq_guard.hpp"
 #include "interrupt/vector.hpp"
 #include "list.hpp"
@@ -18,7 +15,6 @@
 #include "memory/paging_utils.h"
 #include "memory/segment.hpp"
 #include "memory/slab.hpp"
-#include "net/packet_handler.hpp"
 #include "task/builtin.hpp"
 #include "task/context.hpp"
 #include "task/context_switch.h"
@@ -33,38 +29,6 @@ std::array<Task*, MAX_TASKS> tasks;
 
 Task* CURRENT_TASK = nullptr;
 Task* IDLE_TASK = nullptr;
-
-constexpr InitialTaskInfo INITIAL_TASKS[] = {
-	{ SystemProcessId::KERNEL, "main", nullptr, false, true },
-	{ SystemProcessId::IDLE, "idle", &kernel::task::idle_service, true, true },
-	{ SystemProcessId::XHCI, "usb_handler", &kernel::task::usb_handler_service, true,
-	  true },
-	{ SystemProcessId::VIRTIO_BLK, "virtio_blk",
-	  &kernel::hw::virtio::virtio_blk_service, true, false },
-	{ SystemProcessId::FS_FAT32, "fat32", &kernel::fs::fat32_service, true, true },
-	{ SystemProcessId::SHELL, "shell", &kernel::task::shell_service, true, false },
-	{ SystemProcessId::VIRTIO_NET, "virtio_net",
-	  &kernel::hw::virtio::virtio_net_service, true, false },
-	{ SystemProcessId::NET, "net", &kernel::net::packet_handler_service, true,
-	  false },
-};
-
-namespace
-{
-// create_task() hands out slots in ascending order, so each entry's declared
-// SystemProcessId only holds if the array is ordered by those ids with no gap.
-constexpr bool initial_tasks_match_their_slots()
-{
-	for (size_t i = 0; i < sizeof(INITIAL_TASKS) / sizeof(INITIAL_TASKS[0]); ++i) {
-		if (static_cast<pid_t>(INITIAL_TASKS[i].id) != static_cast<pid_t>(i)) {
-			return false;
-		}
-	}
-	return true;
-}
-static_assert(initial_tasks_match_their_slots(),
-			  "INITIAL_TASKS must be ordered by SystemProcessId, gap-free");
-} // namespace
 
 ProcessId get_available_task_id()
 {
@@ -390,18 +354,45 @@ void exit_task(int status)
 	}
 }
 
-void initialize()
+namespace
+{
+// The scheduler owns exactly two tasks of its own; every real service
+// comes in through the manifest supplied to initialize() (issue #315:
+// this file must not know individual services).
+constexpr InitialTaskInfo SCHEDULER_TASKS[] = {
+	{ SystemProcessId::KERNEL, "main", nullptr, false, true },
+	{ SystemProcessId::IDLE, "idle", &idle_service, true, true },
+};
+
+void spawn_initial_task(const InitialTaskInfo& info)
+{
+	Task* new_task = create_task(info.name, reinterpret_cast<uint64_t>(info.entry),
+								 info.setup_context, info.is_initialized);
+	if (new_task == nullptr) {
+		return;
+	}
+
+	// create_task hands out slots in ascending order; a mismatch means the
+	// caller's manifest is not ordered by SystemProcessId, gap-free
+	if (!(new_task->id == info.id)) {
+		LOG_ERROR("task %s landed in slot %d, expected %d", info.name,
+				  new_task->id.raw(), static_cast<pid_t>(info.id));
+	}
+
+	schedule_task(new_task->id);
+}
+} // namespace
+
+void initialize(const InitialTaskInfo* services, size_t num_services)
 {
 	tasks = std::array<Task*, MAX_TASKS>();
 	list_init(&run_queue);
 
-	for (const auto& t_info : INITIAL_TASKS) {
-		Task* new_task =
-				create_task(t_info.name, reinterpret_cast<uint64_t>(t_info.entry),
-							t_info.setup_context, t_info.is_initialized);
-		if (new_task != nullptr) {
-			schedule_task(new_task->id);
-		}
+	for (const auto& info : SCHEDULER_TASKS) {
+		spawn_initial_task(info);
+	}
+	for (size_t i = 0; i < num_services; ++i) {
+		spawn_initial_task(services[i]);
 	}
 
 	CURRENT_TASK = tasks[process_ids::KERNEL.raw()];

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -17,7 +17,21 @@
 namespace kernel::task
 {
 
-void initialize();
+struct InitialTaskInfo;
+
+/**
+ * @brief Initialize tasking and create the boot tasks
+ *
+ * Creates the scheduler's own tasks (KERNEL, IDLE) and then one task per
+ * manifest entry, in slot order. The scheduler knows no individual
+ * service: the manifest lives with the caller (kernel/services.cpp,
+ * issue #315).
+ *
+ * @param services Boot service manifest, ordered by SystemProcessId
+ * starting at the first slot after IDLE, with no gap
+ * @param num_services Number of manifest entries
+ */
+void initialize(const InitialTaskInfo* services, size_t num_services);
 
 /**
  * @brief Start preemptive scheduling by arming the switch-task timer


### PR DESCRIPTION
issue #315 Phase 3b の第 1 弾。構造分析コメントで「最優先の論点」とされた **task→fs/hardware/net 逆依存の根**(`INITIAL_TASKS`)を断つ。

## 変更内容

- **ブートサービス一覧を `kernel/services.cpp`(新規)の manifest へ外出し**。`task::initialize(services, count)` は渡された一覧を起動するだけになり、スケジューラが自前で知るタスクは KERNEL と IDLE の 2 つだけに
- `kernel/task/task.cpp` から `fs/fat/fat.hpp` / `hardware/virtio/{blk,net}.hpp` / `net/packet_handler.hpp` の include が消えた(逆依存の根の切除)
- **usb_handler_service を本来の家へ**: `hardware/usb_service.{cpp,hpp}` に移動(PCI/xHCI 起動と NOTIFY_XHCI ループはハードウェア層の仕事)
- **shell ブートストラップは manifest の隣へ**: FS_LOAD → exec_elf の起動配線は services.cpp 内の無名 namespace に(スケジューラのコードではなく「配線」)
- スロット順不変条件は **二重に強制**: manifest 記述地点の static_assert(XHCI 起点・SystemProcessId 順・隙間なし)+ 起動時の実スロット照合(不一致は LOG_ERROR)

## 設計判断と理由

- **manifest は「テーブル」であり「レジストリ」ではない**: 実行時登録 API(register_service 等)は作らなかった。ブートサービスは静的な集合であり、動的登録はエントリ関数ポインタの寿命・順序の問題を持ち込むだけ。3b でエントリが「ring3 バイナリのパス」に置き換わるときも、テーブルの形はそのまま使える
- **KERNEL / IDLE はスケジューラ側に残した**: この 2 つはサービスではなくスケジューラの構成要素(CURRENT_TASK / IDLE_TASK の初期配線に必要)。manifest に混ぜると「サービスとは何か」の境界が曖昧になる
- **捨てた代替案**: 各サブシステムが自分のサービスを登録しに来る分散登録方式。起動順(= タスクスロット)が well-known ID である現 ABI と両立せず、順序の決定権が散らばる

## 実装者として危険だと思う箇所 top3

1. `kernel/services.cpp:69-82` — スロット割当は「KERNEL, IDLE の後に manifest 順」という**暗黙の連番**に依存。static_assert と起動時照合で二重に守ったが、well-known ID(process_ids::FS_FAT32 等)前提の IPC が全域にあるため、ここが狂うと全サービス間通信が静かに誤配になる
2. `kernel/task/task.cpp:378-397`(initialize)— tests/runner.hpp は「task::initialize 後にテストが走る」前提。initialize のシグネチャ変更は main.cpp 1 箇所で吸収したが、将来テストから直接呼ぶ場合は manifest を渡す必要がある
3. `kernel/task/builtin.cpp`(kernel_service)— `handle_pci` が `pci::devices` を直接読む task→hardware 依存は**意図的に残置**(KERNEL_PCI_LIST の応答サーバ)。kernel_service の責務整理は本 PR の物語の外。次に task/ の依存を消す時はここが対象

## 触れた危険地帯

- `kernel/task/`(initialize の再構成・builtin の縮小。スケジューラ本体・IPC・コンテキストスイッチのロジックは無変更、移動と削除のみ)

## 確認

- `cmake -B build kernel && cmake --build build` ✅ / `./lint.sh` 警告 0 ✅(userland は非接触)
- 起動順・スロット割当は従来と完全一致(manifest の並びは旧 INITIAL_TASKS のまま)
- QEMU 確認推奨: 通常ブート(全サービス起動)+ コマンド実行 1 回

Refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)