### PR TITLE
feat(userland): ユーザーランドに本物のヒープを整備(sbrk 実装 + exec 時マップ、issue #315 3b-7)

### DIFF
--- a/kernel/elf.cpp
+++ b/kernel/elf.cpp
@@ -1,4 +1,5 @@
 #include "elf.hpp"
+#include <libs/common/memory_layout.h>
 #include <cstdint>
 #include <cstring>
 #include "asm_utils.h"
@@ -180,6 +181,17 @@ void exec_elf(kernel::memory::unique_kbuf<> buffer,
 			stack_addr, stack_size / kernel::memory::PAGE_SIZE, true);
 	if (IS_ERR(err)) {
 		LOG_ERROR("failed to setup stack page table: %s", name);
+		return;
+	}
+
+	// User heap (issue #315): mapped eagerly at the layout-contract address
+	// so sbrk/malloc work without a syscall (libs/common/memory_layout.h is
+	// the shared contract, libs/user/newlib_support.c the consumer)
+	const kernel::memory::vaddr_t heap_addr{ USER_HEAP_BASE };
+	err = kernel::memory::setup_page_tables(
+			heap_addr, USER_HEAP_SIZE / kernel::memory::PAGE_SIZE, true);
+	if (IS_ERR(err)) {
+		LOG_ERROR("failed to setup heap page table: %s", name);
 		return;
 	}
 

--- a/libs/common/memory_layout.h
+++ b/libs/common/memory_layout.h
@@ -1,0 +1,20 @@
+/**
+ * @file memory_layout.h
+ * @brief User-space virtual memory layout shared by the kernel loader and
+ * the user runtime
+ *
+ * Plain C header (macros, no C++) because libs/user/newlib_support.c
+ * consumes it. The kernel side of the contract is kernel/elf.cpp: exec
+ * maps the regions declared here before entering ring 3.
+ */
+
+#pragma once
+
+/// Base of the per-process user heap. exec maps it eagerly (no demand
+/// paging yet); sbrk() hands it out linearly from this address.
+#define USER_HEAP_BASE 0xffffa00000000000ULL
+
+/// Heap bytes mapped at exec: 1 MiB. Grow this constant when a process
+/// (the future user-space FS server, issue #315 3b) needs more; there is
+/// deliberately no brk/mmap syscall for now.
+#define USER_HEAP_SIZE (1024ULL * 1024ULL)

--- a/libs/user/newlib_support.c
+++ b/libs/user/newlib_support.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <libs/common/memory_layout.h>
 
 int close(int fd)
 {
@@ -35,11 +36,21 @@ ssize_t read(int fd, void* buf, size_t count)
 
 caddr_t sbrk(int incr)
 {
-	static uint8_t heap[4096];
-	static int index = 0;
-	int prev_index = index;
-	index += incr;
-	return (caddr_t)&heap[prev_index];
+	/* The heap region is mapped by the kernel loader at exec (see
+	 * kernel/elf.cpp); this hands it out linearly with bounds checks.
+	 * The old static 4 KiB array had none: overrunning it silently
+	 * corrupted whatever .bss happened to follow (issue #315). */
+	static uintptr_t brk = USER_HEAP_BASE;
+
+	uintptr_t next = brk + (intptr_t)incr;
+	if (next < USER_HEAP_BASE || next > USER_HEAP_BASE + USER_HEAP_SIZE) {
+		errno = ENOMEM;
+		return (caddr_t)-1;
+	}
+
+	uintptr_t prev = brk;
+	brk = next;
+	return (caddr_t)prev;
 }
 
 ssize_t write(int fd, const void* buf, size_t count)

--- a/userland/commands/heaptest/Makefile
+++ b/userland/commands/heaptest/Makefile
@@ -1,0 +1,5 @@
+TARGET = heaptest
+OBJS = main.o
+include ../../Makefile.elf
+
+INCLUDES = -I./../../../

--- a/userland/commands/heaptest/main.cpp
+++ b/userland/commands/heaptest/main.cpp
@@ -1,0 +1,66 @@
+#include <libs/common/memory_layout.h>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <libs/user/console.hpp>
+
+namespace
+{
+bool fill_and_check(uint8_t* p, size_t n, uint8_t v)
+{
+	memset(p, v, n);
+	for (size_t i = 0; i < n; ++i) {
+		if (p[i] != v) {
+			return false;
+		}
+	}
+	return true;
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+	// 1. Far beyond the old fixed 4 KiB sbrk array: proves malloc is backed
+	// by the real per-process heap now (issue #315)
+	constexpr size_t BIG = 64 * 1024;
+	auto* big = static_cast<uint8_t*>(malloc(BIG));
+	if (big == nullptr || !fill_and_check(big, BIG, 0xa5)) {
+		printu("heaptest: FAIL (64 KiB allocation)");
+		return 0;
+	}
+
+	// 2. Many small blocks with distinct patterns survive together
+	constexpr int COUNT = 32;
+	constexpr size_t SMALL = 1024;
+	uint8_t* blocks[COUNT];
+	for (int i = 0; i < COUNT; ++i) {
+		blocks[i] = static_cast<uint8_t*>(malloc(SMALL));
+		if (blocks[i] == nullptr ||
+			!fill_and_check(blocks[i], SMALL, static_cast<uint8_t>(i))) {
+			printu("heaptest: FAIL (small allocation %d)", i);
+			return 0;
+		}
+	}
+	for (int i = 0; i < COUNT; ++i) {
+		if (blocks[i][0] != static_cast<uint8_t>(i)) {
+			printu("heaptest: FAIL (block %d overwritten)", i);
+			return 0;
+		}
+		free(blocks[i]);
+	}
+	free(big);
+
+	// 3. Exhaustion fails cleanly: sbrk reports ENOMEM past USER_HEAP_SIZE
+	// and malloc turns that into nullptr instead of corrupting memory
+	void* too_big = malloc(USER_HEAP_SIZE);
+	if (too_big != nullptr) {
+		printu("heaptest: FAIL (oversize allocation did not fail)");
+		return 0;
+	}
+
+	printu("heaptest: PASS (64KiB + %dx1KiB + clean ENOMEM)", COUNT);
+
+	// The shell treats a nonzero exit status as "command not found", so
+	// results are reported above and the exit status stays 0
+	return 0;
+}


### PR DESCRIPTION
issue #315 Phase 3b の第 2 弾。計画の設計決定 3 で特定した**隠れブロッカー**の解消: FAT ドライバをユーザーランドへ移植するには動的確保が必須だが、`sbrk` は固定 4 KiB の static 配列だった。

## 変更内容

- **`libs/common/memory_layout.h`(新規、C 互換ヘッダ)**: `USER_HEAP_BASE`(0xffff'a000'0000'0000)と `USER_HEAP_SIZE`(1 MiB)。カーネルローダとユーザーランタイムが共有する「レイアウト契約」
- **`kernel/elf.cpp`**: exec 時に契約アドレスへヒープ領域を eager マップ(argv ページ・スタックと同じ `setup_page_tables` 経路)
- **`libs/user/newlib_support.c`**: `sbrk` を境界チェック付きの線形払い出しに書き換え。**旧実装は境界チェックがなく、4 KiB を超えた瞬間に後続の .bss を黙って破壊する地雷だった**。新実装は範囲外で `ENOMEM` を返し、newlib の malloc はそれを nullptr に変換する
- **`heaptest` コマンド(新規)**: 64 KiB 確保 + パターン検証、1 KiB × 32 の共存検証、超過確保が nullptr で綺麗に失敗することの 3 点を QEMU 上で確認できる

## 設計判断と理由

- **syscall を追加しない**: brk/mmap は作らず、exec 時に固定量を eager マップ。「システムコールは極力少なく」の方針どおり。ヒープが足りない未来のプロセス(ユーザーランド FS の file cache 等)には、まず定数の増量で応え、demand paging(ページフォルト処理)はその必要が実証されてから
- **固定アドレス契約(libs/common)方式**: ヒープ位置を argv/補助ベクタで渡す案は、受け渡しコードが両側に増えるだけで柔軟性の使い道がない。契約ヘッダ 1 枚が最小
- **fork との整合はタダで手に入る**: ヒープ領域は他のマッピングと同様 `copy_parent_page_table` の CoW クローン対象。sbrk のカーソル(`static brk`)も .bss ごと複製されるので、親子のヒープ観は一致する

## 実装者として危険だと思う箇所 top3

1. `libs/common/memory_layout.h` — `USER_HEAP_BASE` はプログラムイメージ(0xffff'8000'...)ともスタック(0xffff'ffff'...)とも十分離しているが、**衝突検査は静的にはされていない**。ELF が巨大化して 0xffff'a000'... に届くと exec 時のマップが上書き衝突する(現バイナリは数百 KiB で余裕 45 TiB)
2. `kernel/elf.cpp` — ヒープマップ失敗時は LOG_ERROR + return(exec 中断)だが、この時点で旧アドレス空間は既に破棄済みのため**プロセスは実質死ぬ**。既存の argv/スタック失敗パスと同じ既存問題で、この PR で悪化はしていない(3b の exec エラーパス整理で扱う候補)
3. `libs/user/newlib_support.c` — `static uintptr_t brk` は free されたメモリを再利用しない線形カーソル(newlib malloc が上でプール管理する前提)。sbrk へ負の incr が来た場合の縮小はサポートするが、newlib は実際にはほぼ呼ばない

## 触れた危険地帯

- なし(`kernel/elf.cpp` は危険地帯ディレクトリ外だが、アドレス空間構築に触れるため memory 隣接として精読推奨。task/ memory/ syscall/ interrupt/ は非接触)

## 確認

- `cmake -B build kernel && cmake --build build` ✅ / userland 全ターゲット(shell + commands/* + heaptest)ビルド ✅ / `./lint.sh` 警告 0 ✅
- **QEMU 確認**: `heaptest` を実行し `heaptest: PASS (64KiB + 32x1KiB + clean ENOMEM)` が出ること。既存コマンドの通常動作(ls / cat / echo リダイレクト)も一巡推奨

Refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)