### PR TITLE
refactor(fs): open file の状態を FS 所有の台帳(handle 方式)へ移管(issue #315 3b-8)

### DIFF
--- a/kernel/fs/fat/CMakeLists.txt
+++ b/kernel/fs/fat/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(UchosFAT32 STATIC
     init.cpp
     directory.cpp
     file.cpp
+    open_files.cpp
     utils.cpp
 )
 

--- a/kernel/fs/fat/file.cpp
+++ b/kernel/fs/fat/file.cpp
@@ -81,7 +81,7 @@ FileCache* load_file(const DirectoryEntry* entry, ProcessId requester)
 }
 
 /**
- * @brief Read a file and reply to the requester with its contents
+ * @brief Reply with a file's whole contents (FS_LOAD: exec images)
  */
 void reply_read_result(const Message& req, const DirectoryEntry* entry)
 {
@@ -101,47 +101,52 @@ void reply_read_result(const Message& req, const DirectoryEntry* entry)
 	reply_file_data(req, cache->buffer.data(), cache->total_size);
 }
 
-/// Fully resolved fd-based request. entry is non-null iff resolution
-/// succeeded; fd is only valid when entry is set.
-struct OpenFile {
-	FileDescriptor* fd;
-	DirectoryEntry* entry;
-};
+/**
+ * @brief Reply with the [offset, offset+count) window of an open file
+ *
+ * The offset is FS state now (issue #315 3b-8): it lives in the ledger
+ * record and advances here, so sequential reads terminate at EOF without
+ * the kernel ever interpreting file positions.
+ */
+void reply_read_window(const Message& req, OpenFileRecord* rec)
+{
+	const DirectoryEntry* entry = rec->entry;
+	const size_t count = req.data.fs.len;
+
+	// EOF and empty files answer with an empty payload, not an error
+	if (entry->file_size == 0 || entry->first_cluster() == 0 ||
+		rec->offset >= entry->file_size) {
+		reply_file_data(req, nullptr, 0);
+		return;
+	}
+
+	FileCache* cache = load_file(entry, req.sender);
+	if (cache == nullptr) {
+		reply_error(req, ERR_FAILED_READ_FROM_DEVICE);
+		return;
+	}
+
+	const size_t n = std::min(count, entry->file_size - rec->offset);
+	reply_file_data(req, cache->buffer.data() + rec->offset, n);
+	rec->offset += n;
+}
 
 /**
- * @brief Resolve sender task, file descriptor, and directory entry for an
- * fd-based FS request (FS_READ / FS_WRITE)
+ * @brief Resolve an fd-based request's handle to its ledger record
  *
- * On failure this logs and replies the matching error itself, except when
- * the requester task is already gone — then there is no one to reply to.
- *
- * @return OpenFile with entry != nullptr on success; entry == nullptr means
- * the error was already handled and the caller just returns
+ * On failure this replies ERR_INVALID_FD itself; the caller just returns.
  */
-OpenFile resolve_open_file(const Message& m)
+OpenFileRecord* resolve_record(const Message& m)
 {
-	kernel::task::Task* t = kernel::task::get_task(m.sender);
-	if (t == nullptr) {
-		LOG_ERROR("Task %d not found - likely already exited", m.sender.raw());
-		return {};
-	}
-
-	FileDescriptor* fd = kernel::fs::get_process_fd(
-			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, m.data.fs.fd);
-	if (fd == nullptr) {
-		LOG_ERROR("fd not found");
+	OpenFileRecord* rec = open_file_get(static_cast<uint32_t>(m.data.fs.fd));
+	if (rec == nullptr) {
+		LOG_ERROR("unknown open-file handle %d from task %d", m.data.fs.fd,
+				  m.sender.raw());
 		reply_error(m, ERR_INVALID_FD);
-		return {};
+		return nullptr;
 	}
 
-	DirectoryEntry* entry = find_dir_entry(ROOT_DIR, fd->name);
-	if (entry == nullptr) {
-		LOG_ERROR("entry not found");
-		reply_error(m, ERR_NO_FILE);
-		return {};
-	}
-
-	return { fd, entry };
+	return rec;
 }
 
 /**
@@ -371,10 +376,24 @@ void handle_fs_open(const Message& m)
 		return;
 	}
 
-	// Allocate a file descriptor in the process's FD table
+	// File state becomes an FS-owned ledger record; the client's routing
+	// entry only carries the handle (issue #315 3b-8)
+	const uint32_t handle = open_file_create(entry, name, m.sender);
+	if (handle == 0) {
+		req.result = ERR_NO_MEMORY;
+		kernel::task::reply(m, &req);
+		return;
+	}
+
+	// The ONE remaining touch on the client's task: installing the routing
+	// entry. Becomes a kernel-provided service API when the FS leaves
+	// ring 0 (issue #315 3b-10).
 	fd_t fd = kernel::fs::allocate_process_fd(t->fd_table.data(),
 											  kernel::task::MAX_FDS_PER_PROCESS,
-											  name, entry->file_size, m.sender);
+											  name, handle, m.sender);
+	if (fd < 0) {
+		open_file_release(handle);
+	}
 
 	req.data.fs.fd = fd;
 	req.result = fd < 0 ? ERR_INVALID_FD : OK;
@@ -383,12 +402,12 @@ void handle_fs_open(const Message& m)
 
 void handle_fs_read(const Message& m)
 {
-	const OpenFile of = resolve_open_file(m);
-	if (of.entry == nullptr) {
+	OpenFileRecord* rec = resolve_record(m);
+	if (rec == nullptr) {
 		return;
 	}
 
-	reply_read_result(m, of.entry);
+	reply_read_window(m, rec);
 }
 
 void handle_fs_close(const Message& m)
@@ -398,6 +417,13 @@ void handle_fs_close(const Message& m)
 		LOG_ERROR("Task %d not found in fs_close - likely already exited",
 				  m.sender.raw());
 		return;
+	}
+
+	// Drop the ledger reference before the routing entry disappears
+	kernel::fs::FileDescriptor* fd_entry = kernel::fs::get_process_fd(
+			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, m.data.fs.fd);
+	if (fd_entry != nullptr) {
+		open_file_release(fd_entry->handle);
 	}
 
 	error_t result = kernel::fs::release_process_fd(
@@ -421,14 +447,13 @@ void handle_fs_write(const Message& m)
 	// Never trust the inline length beyond the payload actually delivered
 	const size_t count = std::min(m.data.fs.len, static_cast<size_t>(m.ool.size));
 
-	const OpenFile of = resolve_open_file(m);
-	if (of.entry == nullptr) {
+	OpenFileRecord* rec = resolve_record(m);
+	if (rec == nullptr) {
 		return;
 	}
-	FileDescriptor* fd = of.fd;
-	DirectoryEntry* entry = of.entry;
+	DirectoryEntry* entry = rec->entry;
 
-	const size_t new_size = fd->offset + count;
+	const size_t new_size = rec->offset + count;
 
 	const error_t grow_err = grow_file_if_needed(entry, new_size);
 	if (IS_ERR(grow_err)) {
@@ -437,14 +462,14 @@ void handle_fs_write(const Message& m)
 	}
 
 	size_t write_len = 0;
-	const error_t write_err = write_file_cluster(entry, fd->offset, write_buf.get(),
+	const error_t write_err = write_file_cluster(entry, rec->offset, write_buf.get(),
 												 count, &write_len);
 	if (IS_ERR(write_err)) {
 		reply_error(m, write_err);
 		return;
 	}
 
-	fd->offset += write_len;
+	rec->offset += write_len;
 
 	if (new_size != entry->file_size) {
 		if (new_size < entry->file_size) {
@@ -452,7 +477,7 @@ void handle_fs_write(const Message& m)
 		}
 
 		entry->file_size = new_size;
-		persist_directory_entry(entry, fd->name);
+		persist_directory_entry(entry, rec->name);
 	}
 
 	Message reply = { .type = MsgType::FS_WRITE, .sender = process_ids::FS_FAT32 };
@@ -497,9 +522,19 @@ void handle_fs_mkfile(const Message& m)
 	entry->attribute = entry_attribute::ARCHIVE;
 	entry->file_size = 0;
 
+	const uint32_t handle = open_file_create(entry, name, m.sender);
+	if (handle == 0) {
+		reply.result = ERR_NO_MEMORY;
+		kernel::task::reply(m, &reply);
+		return;
+	}
+
 	fd_t fd = kernel::fs::allocate_process_fd(t->fd_table.data(),
 											  kernel::task::MAX_FDS_PER_PROCESS,
-											  name, 0, m.sender);
+											  name, handle, m.sender);
+	if (fd < 0) {
+		open_file_release(handle);
+	}
 
 	reply.data.fs.fd = fd;
 	reply.result = fd < 0 ? ERR_INVALID_FD : OK;
@@ -525,12 +560,27 @@ void handle_fs_dup2(const Message& m)
 		return;
 	}
 
+	// The routing-entry copy will share oldfd's ledger record (that IS the
+	// redirect); account the reference before overwriting newfd, and drop
+	// whatever FS object newfd may have referenced until now
+	kernel::fs::FileDescriptor* old_entry = kernel::fs::get_process_fd(
+			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, oldfd);
+	if (old_entry == nullptr) {
+		reply_error(m, ERR_INVALID_FD);
+		return;
+	}
+	const uint32_t replaced_handle =
+			t->fd_table[newfd].is_used() ? t->fd_table[newfd].handle : 0;
+
 	const error_t dup_err = kernel::fs::dup_process_fd(
 			t->fd_table.data(), kernel::task::MAX_FDS_PER_PROCESS, oldfd, newfd);
 	if (IS_ERR(dup_err)) {
 		reply_error(m, dup_err);
 		return;
 	}
+
+	open_file_addref(old_entry->handle);
+	open_file_release(replaced_handle);
 
 	reply.result = OK;
 	reply.data.fs.fd = newfd;

--- a/kernel/fs/fat/internal_common.hpp
+++ b/kernel/fs/fat/internal_common.hpp
@@ -29,6 +29,32 @@ constexpr size_t FAT_WRITE_CHUNK_SIZE = 65536; // 64KB chunks for batch writes
 /// Space character used to right-pad the 8.3 short file name fields.
 constexpr char SFN_PAD = 0x20;
 
+/**
+ * @brief One open file in the FS-owned ledger (issue #315 3b-8)
+ *
+ * Keyed by an opaque handle stored in the client's routing entry; the
+ * offset lives HERE, so routing-entry copies (fork, dup2) share it —
+ * POSIX open-file-description semantics.
+ */
+struct OpenFileRecord {
+	uint32_t handle; ///< 0 = slot free
+	ProcessId owner; ///< Creator; used only by the dead-owner sweep
+	kernel::fs::DirectoryEntry* entry;
+	size_t offset;
+	int refcount; ///< dup2 adds a reference, close drops one
+	char name[13];
+};
+
+constexpr int MAX_OPEN_FILES = 64;
+
+/// @return The new handle, or 0 when the ledger is full even after sweeping
+uint32_t open_file_create(kernel::fs::DirectoryEntry* entry,
+						  const char* name,
+						  ProcessId owner);
+OpenFileRecord* open_file_get(uint32_t handle);
+void open_file_addref(uint32_t handle);
+void open_file_release(uint32_t handle);
+
 // Common utility functions
 void read_dir_entry_name_raw(const kernel::fs::DirectoryEntry& entry, char* dest);
 void read_dir_entry_name(const kernel::fs::DirectoryEntry& entry, char* dest);

--- a/kernel/fs/fat/open_files.cpp
+++ b/kernel/fs/fat/open_files.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file open_files.cpp
+ * @brief FS-owned open-file ledger (issue #315 3b-8)
+ *
+ * The FS keeps every piece of per-open-file state here — directory entry,
+ * offset, name — keyed by an opaque handle it issues at open time. Clients
+ * never see this table; the kernel routing entry only stores the handle.
+ * This is exactly the state that used to live in each client's Task
+ * fd_table, which the FS had to reach into across the task boundary.
+ */
+
+#include <cstring>
+#include <libs/common/process_id.hpp>
+#include <libs/common/types.hpp>
+#include "internal_common.hpp"
+#include "log/log.hpp"
+#include "task/task.hpp"
+
+namespace kernel::fs::fat
+{
+
+namespace
+{
+OpenFileRecord open_files[MAX_OPEN_FILES];
+
+/// Monotonic handle source; 0 is never issued (it means "no handle").
+uint32_t next_handle = 1;
+
+/**
+ * @brief Free records whose owner task no longer exists
+ *
+ * Process exit does not notify the FS (that would recreate the reverse
+ * dependency issue #315 just removed), so records of dead owners linger
+ * until this sweep runs on allocation pressure. A record whose handle was
+ * fork-shared with a still-living child is swept too — a documented edge
+ * until ring-3 services bring real per-channel accounting (3b-10).
+ */
+void sweep_dead_owners()
+{
+	for (auto& r : open_files) {
+		if (r.handle != 0 && kernel::task::get_task(r.owner) == nullptr) {
+			r = OpenFileRecord{};
+		}
+	}
+}
+} // namespace
+
+uint32_t open_file_create(kernel::fs::DirectoryEntry* entry,
+						  const char* name,
+						  ProcessId owner)
+{
+	for (int attempt = 0; attempt < 2; ++attempt) {
+		for (auto& r : open_files) {
+			if (r.handle != 0) {
+				continue;
+			}
+
+			r.handle = next_handle++;
+			if (next_handle == 0) {
+				next_handle = 1; // skip the "no handle" value on wrap
+			}
+			r.owner = owner;
+			r.entry = entry;
+			r.offset = 0;
+			r.refcount = 1;
+			strncpy(r.name, name, sizeof(r.name) - 1);
+			r.name[sizeof(r.name) - 1] = '\0';
+
+			return r.handle;
+		}
+
+		sweep_dead_owners();
+	}
+
+	LOG_ERROR("open-file ledger full (owner %d, file %s)", owner.raw(), name);
+	return 0;
+}
+
+OpenFileRecord* open_file_get(uint32_t handle)
+{
+	if (handle == 0) {
+		return nullptr;
+	}
+
+	for (auto& r : open_files) {
+		if (r.handle == handle) {
+			return &r;
+		}
+	}
+
+	return nullptr;
+}
+
+void open_file_addref(uint32_t handle)
+{
+	OpenFileRecord* r = open_file_get(handle);
+	if (r != nullptr) {
+		++r->refcount;
+	}
+}
+
+void open_file_release(uint32_t handle)
+{
+	OpenFileRecord* r = open_file_get(handle);
+	if (r == nullptr) {
+		return;
+	}
+
+	if (--r->refcount <= 0) {
+		*r = OpenFileRecord{};
+	}
+}
+
+} // namespace kernel::fs::fat

--- a/kernel/fs/file_descriptor.cpp
+++ b/kernel/fs/file_descriptor.cpp
@@ -21,15 +21,14 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size)
 
 	// Set up standard file descriptors. The console routing is decided
 	// HERE, at entry creation — the syscall layer just follows it (issue
-	// #315). This init moves to the user-side runtime in 3b.
+	// #315). Console fds have no server-side object, so handle stays 0.
+	// This init moves to the user-side runtime in 3b.
 	// stdin
 	if (STDIN_FILENO < table_size) {
 		strncpy(fd_table[STDIN_FILENO].name, "stdin",
 				sizeof(fd_table[STDIN_FILENO].name) - 1);
 		fd_table[STDIN_FILENO].route = FdRoute::CONSOLE;
 		fd_table[STDIN_FILENO].dest = process_ids::SHELL;
-		fd_table[STDIN_FILENO].size = 0;
-		fd_table[STDIN_FILENO].offset = 0;
 	}
 
 	// stdout
@@ -38,8 +37,6 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size)
 				sizeof(fd_table[STDOUT_FILENO].name) - 1);
 		fd_table[STDOUT_FILENO].route = FdRoute::CONSOLE;
 		fd_table[STDOUT_FILENO].dest = process_ids::SHELL;
-		fd_table[STDOUT_FILENO].size = 0;
-		fd_table[STDOUT_FILENO].offset = 0;
 	}
 
 	// stderr
@@ -48,15 +45,13 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size)
 				sizeof(fd_table[STDERR_FILENO].name) - 1);
 		fd_table[STDERR_FILENO].route = FdRoute::CONSOLE;
 		fd_table[STDERR_FILENO].dest = process_ids::SHELL;
-		fd_table[STDERR_FILENO].size = 0;
-		fd_table[STDERR_FILENO].offset = 0;
 	}
 }
 
 fd_t allocate_process_fd(FileDescriptor* fd_table,
 						 size_t table_size,
 						 const char* name,
-						 size_t size,
+						 uint32_t handle,
 						 ProcessId pid)
 {
 	if (fd_table == nullptr || name == nullptr) {
@@ -69,11 +64,11 @@ fd_t allocate_process_fd(FileDescriptor* fd_table,
 		if (fd_table[i].is_unused()) {
 			// This helper is FS-side code (it moves into the FS server in
 			// 3b), so entries it creates route to the FAT32 service; the
-			// syscall layer only ever reads this (issue #315)
+			// syscall layer only ever reads this (issue #315). All file
+			// state lives behind the handle in the FS ledger.
 			fd_table[i].route = FdRoute::FS;
 			fd_table[i].dest = process_ids::FS_FAT32;
-			fd_table[i].size = size;
-			fd_table[i].offset = 0;
+			fd_table[i].handle = handle;
 			strncpy(fd_table[i].name, name, sizeof(fd_table[i].name) - 1);
 			fd_table[i].name[sizeof(fd_table[i].name) - 1] = '\0';
 			return i;

--- a/kernel/fs/file_descriptor.hpp
+++ b/kernel/fs/file_descriptor.hpp
@@ -40,15 +40,15 @@ void init_process_fd_table(FileDescriptor* fd_table, size_t table_size);
  *
  * @param fd_table Process's file descriptor table
  * @param table_size Size of the file descriptor table
- * @param name File name (max 12 characters for 8.3 format)
- * @param size File size in bytes
+ * @param name File name label (max 12 characters for 8.3 format)
+ * @param handle Server-side open-file object id stored in the entry
  * @param pid Process ID that owns this descriptor
  * @return fd_t The allocated file descriptor number, or NO_FD on failure
  */
 fd_t allocate_process_fd(FileDescriptor* fd_table,
 						 size_t table_size,
 						 const char* name,
-						 size_t size,
+						 uint32_t handle,
 						 ProcessId pid);
 
 /**

--- a/kernel/syscall/handler.cpp
+++ b/kernel/syscall/handler.cpp
@@ -56,12 +56,11 @@ ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 			// honestly reports EOF instead of pretending to be readable.
 			return 0;
 		case FdRoute::FS: {
-			// The FS's read contract is currently "reply with the whole
-			// file as one OOL copy" (kernel/fs/fat reply_file_data); the
-			// window [offset, offset+count) is cut out here so sequential
-			// read() loops terminate. Both move into the FS server in 3b.
+			// The reply is already the [offset, offset+count) window: the
+			// offset is FS state now (issue #315 3b-8) and the FS advances
+			// it. The kernel forwards the opaque handle and copies bytes.
 			Message req = { .type = MsgType::FS_READ, .sender = t->id };
-			req.data.fs.fd = fd;
+			req.data.fs.fd = static_cast<fd_t>(fd_entry->handle);
 			req.data.fs.len = count;
 
 			const error_t err = kernel::task::call(fd_entry->dest, &req);
@@ -78,18 +77,14 @@ ssize_t sys_read(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 				return req.result;
 			}
 
-			const size_t file_size = req.data.fs.len;
-			if (!data || fd_entry->offset >= file_size) {
-				return 0; // EOF (or empty file: those replies carry no OOL)
+			if (!data || req.data.fs.len == 0) {
+				return 0; // EOF or empty file: those replies carry no OOL
 			}
 
-			const size_t n = std::min(count, file_size - fd_entry->offset);
-			if (copy_to_user(buf,
-							 static_cast<const char*>(data.get()) + fd_entry->offset,
-							 n) != n) {
+			const size_t n = std::min(count, req.data.fs.len);
+			if (copy_to_user(buf, data.get(), n) != n) {
 				return ERR_INVALID_ARG;
 			}
-			fd_entry->offset += n;
 
 			return n;
 		}
@@ -164,7 +159,9 @@ ssize_t sys_write(uint64_t arg1, uint64_t arg2, uint64_t arg3)
 			// Stage C), correlation-matched so the reply cannot be confused
 			// with other FS_WRITE traffic (Stage B)
 			Message req = { .type = MsgType::FS_WRITE, .sender = t->id };
-			req.data.fs.fd = fd;
+			// The FS names the open file by the opaque handle, never by the
+			// client-local fd number (issue #315 3b-8)
+			req.data.fs.fd = static_cast<fd_t>(fd_entry->handle);
 			req.data.fs.len = count;
 
 			auto kbuf = kernel::task::make_ool_buffer(count);

--- a/kernel/tests/test_cases/fd_test.cpp
+++ b/kernel/tests/test_cases/fd_test.cpp
@@ -31,7 +31,7 @@ void test_fd_allocation()
 	ASSERT_NOT_NULL(entry);
 	ASSERT_TRUE(entry->is_used());
 	ASSERT_EQ(strcmp(entry->name, "test1.txt"), 0);
-	ASSERT_EQ(entry->size, 100);
+	ASSERT_EQ(entry->handle, 100);
 
 	// Test another allocation
 	fd_t fd2 = fs::allocate_process_fd(fd_table, 32, "test2.txt", 200,
@@ -90,14 +90,14 @@ void test_fd_fork_copy()
 	ASSERT_NOT_NULL(parent_entry1);
 	ASSERT_NOT_NULL(child_entry1);
 	ASSERT_EQ(strcmp(parent_entry1->name, child_entry1->name), 0);
-	ASSERT_EQ(parent_entry1->size, child_entry1->size);
+	ASSERT_EQ(parent_entry1->handle, child_entry1->handle);
 
 	fs::FileDescriptor* parent_entry2 = fs::get_process_fd(parent_table, 32, fd2);
 	fs::FileDescriptor* child_entry2 = fs::get_process_fd(child_table, 32, fd2);
 	ASSERT_NOT_NULL(parent_entry2);
 	ASSERT_NOT_NULL(child_entry2);
 	ASSERT_EQ(strcmp(parent_entry2->name, child_entry2->name), 0);
-	ASSERT_EQ(parent_entry2->size, child_entry2->size);
+	ASSERT_EQ(parent_entry2->handle, child_entry2->handle);
 
 	// Verify standard descriptors are also copied
 	ASSERT_TRUE(child_table[STDIN_FILENO].is_used());
@@ -125,7 +125,8 @@ void test_fd_dup2()
 	fs::FileDescriptor* redirected = fs::get_process_fd(fd_table, 32, STDOUT_FILENO);
 	ASSERT_NOT_NULL(redirected);
 	ASSERT_EQ(strcmp(redirected->name, "output.txt"), 0);
-	ASSERT_EQ(redirected->size, src->size);
+	// The copy shares the server-side object: same handle = same offset
+	ASSERT_EQ(redirected->handle, src->handle);
 }
 
 void test_dup_process_fd()
@@ -148,7 +149,7 @@ void test_dup_process_fd()
 	ASSERT_NOT_NULL(src);
 	ASSERT_NOT_NULL(dup);
 	ASSERT_EQ(strcmp(dup->name, src->name), 0);
-	ASSERT_EQ(dup->size, src->size);
+	ASSERT_EQ(dup->handle, src->handle);
 
 	// Error case: oldfd is unused
 	result = fs::dup_process_fd(fd_table, 32, 20, STDOUT_FILENO);

--- a/kernel/tests/test_cases/fs_test.cpp
+++ b/kernel/tests/test_cases/fs_test.cpp
@@ -17,7 +17,6 @@
 #include "tests/framework.hpp"
 #include "tests/macros.hpp"
 
-
 using namespace kernel::fs::fat;
 
 // 8.3 names are up to 12 characters ("ABCDEFGH.EXT") plus a null terminator;
@@ -196,10 +195,8 @@ void test_file_cache_eviction_terminates()
 
 	ASSERT_TRUE(all_created);
 	ASSERT_TRUE(local_caches.size() <= 50);
-	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "F0") ==
-				nullptr);
-	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "F59") !=
-				nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "F0") == nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "F59") != nullptr);
 }
 
 /**
@@ -217,19 +214,14 @@ void test_file_cache_lru_order()
 	}
 
 	// Touch the oldest entry so "L1" becomes the least recently used one
-	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L0") !=
-				nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L0") != nullptr);
 
 	// Cache is full: this create must evict exactly the LRU entry ("L1")
-	kernel::fs::create_file_cache(local_caches, "L50", 16,
-								  ProcessId::from_raw(1));
+	kernel::fs::create_file_cache(local_caches, "L50", 16, ProcessId::from_raw(1));
 
-	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L0") !=
-				nullptr);
-	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L1") ==
-				nullptr);
-	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L50") !=
-				nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L0") != nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L1") == nullptr);
+	ASSERT_TRUE(kernel::fs::find_file_cache_by_path(local_caches, "L50") != nullptr);
 }
 
 /**
@@ -323,6 +315,61 @@ void test_cluster_chain_disk_full()
 /**
  * @brief Register all file system test cases
  */
+void test_open_file_ledger_basic()
+{
+	using namespace kernel::fs::fat;
+
+	// The ledger stores the entry pointer opaquely; a dummy is enough
+	kernel::fs::DirectoryEntry dummy_entry = {};
+
+	const uint32_t h1 =
+			open_file_create(&dummy_entry, "LEDGER1", ProcessId::from_raw(1));
+	ASSERT_NE(h1, 0);
+	const uint32_t h2 =
+			open_file_create(&dummy_entry, "LEDGER2", ProcessId::from_raw(1));
+	ASSERT_NE(h2, 0);
+	ASSERT_NE(h1, h2);
+
+	OpenFileRecord* r = open_file_get(h1);
+	ASSERT_NOT_NULL(r);
+	ASSERT_EQ(r->offset, 0);
+	ASSERT_EQ(strcmp(r->name, "LEDGER1"), 0);
+
+	// dup2 semantics: an extra reference keeps the record alive across
+	// one close, and the record dies with the last reference
+	open_file_addref(h1);
+	open_file_release(h1);
+	ASSERT_NOT_NULL(open_file_get(h1));
+	open_file_release(h1);
+	ASSERT_NULL(open_file_get(h1));
+
+	open_file_release(h2);
+	ASSERT_NULL(open_file_get(h2));
+}
+
+void test_open_file_ledger_sweep()
+{
+	using namespace kernel::fs::fat;
+
+	kernel::fs::DirectoryEntry dummy_entry = {};
+
+	// Owner pid 90 has no task: these records are what the sweep reclaims
+	// (process exit does not notify the FS by design, issue #315 3b-8)
+	int created = 0;
+	for (int i = 0; i < MAX_OPEN_FILES; ++i) {
+		if (open_file_create(&dummy_entry, "DEAD", ProcessId::from_raw(90)) != 0) {
+			++created;
+		}
+	}
+	ASSERT_GT(created, 0);
+
+	// Allocation pressure must trigger the dead-owner sweep, not fail
+	const uint32_t h =
+			open_file_create(&dummy_entry, "ALIVE", ProcessId::from_raw(0));
+	ASSERT_NE(h, 0);
+	open_file_release(h);
+}
+
 void register_fs_tests()
 {
 	test_register("test_write_existing_file", test_write_existing_file);
@@ -339,4 +386,6 @@ void register_fs_tests()
 	test_register("test_read_dir_entry_name_boundary",
 				  test_read_dir_entry_name_boundary);
 	test_register("test_cluster_chain_disk_full", test_cluster_chain_disk_full);
+	test_register("test_open_file_ledger_basic", test_open_file_ledger_basic);
+	test_register("test_open_file_ledger_sweep", test_open_file_ledger_sweep);
 }

--- a/kernel/tests/test_cases/stdio_test.cpp
+++ b/kernel/tests/test_cases/stdio_test.cpp
@@ -163,7 +163,7 @@ void test_fd_inheritance()
 	// Check the allocated FD was also copied
 	ASSERT_TRUE(child->fd_table[fd].is_used());
 	ASSERT_EQ(strcmp(child->fd_table[fd].name, "test.txt"), 0);
-	ASSERT_EQ(child->fd_table[fd].size, 100);
+	ASSERT_EQ(child->fd_table[fd].handle, 100);
 }
 
 void test_stdout_redirection()

--- a/libs/common/file_descriptor.hpp
+++ b/libs/common/file_descriptor.hpp
@@ -28,18 +28,21 @@ enum class FdRoute : uint8_t {
 };
 
 /**
- * @brief File descriptor structure
+ * @brief File descriptor structure: a pure routing record
  *
- * Represents an open I/O handle for a process: where operations on it are
- * routed (route/dest) plus the file state the FS still keeps here until it
- * owns fd management itself (issue #315 3b).
+ * Holds only where operations on this fd go (route/dest) and which
+ * server-side object they name (handle). All file state — offset, size,
+ * name resolution — lives in the owning service's ledger (issue #315
+ * 3b-8); the kernel never interprets the handle.
  */
 struct FileDescriptor {
 	char name[13];	///< Label: 8.3 file name for FS fds, "stdout" etc. for std fds
 	FdRoute route;	///< Protocol the syscall layer uses for I/O on this fd
 	ProcessId dest; ///< Service task the I/O is sent to
-	size_t size;	///< File size in bytes
-	size_t offset;	///< Current read/write position
+	/// Server-side open-file object id, issued by dest and opaque here
+	/// (0 = none). fork/dup2 copy this record, so the copies SHARE the
+	/// server object — POSIX shared-offset semantics fall out for free.
+	uint32_t handle;
 
 	/**
 	 * @brief Check if this file descriptor is unused
@@ -64,8 +67,7 @@ struct FileDescriptor {
 		name[0] = '\0';
 		route = FdRoute::NONE;
 		dest = process_ids::INVALID;
-		size = 0;
-		offset = 0;
+		handle = 0;
 	}
 
 	/**

--- a/libs/user/file.cpp
+++ b/libs/user/file.cpp
@@ -1,11 +1,11 @@
 #include <sys/types.h>
-#include <algorithm>
 #include <cstring>
 #include <libs/common/message.hpp>
 #include <libs/common/process_id.hpp>
 #include <libs/common/types.hpp>
 #include <libs/user/file.hpp>
 #include <libs/user/ipc.hpp>
+#include <libs/user/syscall.hpp>
 
 fd_t fs_open(const char* path, int flags)
 {
@@ -20,24 +20,11 @@ fd_t fs_open(const char* path, int flags)
 
 ssize_t fs_read(fd_t fd, void* buf, size_t count)
 {
-	Message m = make_request(MsgType::FS_READ);
-	m.data.fs.fd = fd;
-	m.data.fs.len = count;
-
-	Message res = call(process_ids::FS_FAT32, &m);
-	if (IS_ERR(res.result)) {
-		return res.result;
-	}
-	if (res.ool.size == 0) {
-		return 0; // empty file: the reply carries no OOL payload
-	}
-
-	const size_t copy_len = std::min(count, static_cast<size_t>(res.ool.size));
-	memcpy(buf, reinterpret_cast<const void*>(res.ool.addr), copy_len);
-
-	ool_release(reinterpret_cast<const void*>(res.ool.addr));
-
-	return copy_len;
+	// One path only (issue #315 3b-8): the kernel resolves fd -> server
+	// handle and forwards. The old direct-IPC route sent the client-local
+	// fd number, which the FS no longer understands.
+	return static_cast<ssize_t>(
+			sys_read(fd, reinterpret_cast<uint64_t>(buf), count));
 }
 
 void fs_close(fd_t fd)
@@ -75,29 +62,10 @@ error_t fs_pwd(char* buf, size_t size)
 
 ssize_t fs_write(fd_t fd, const void* buf, size_t count)
 {
-	if (count == 0) {
-		return 0;
-	}
-	if (count > OOL_MAX_SIZE) {
-		return ERR_OOL_LIMIT;
-	}
-
-	Message m = make_request(MsgType::FS_WRITE);
-	m.data.fs.fd = fd;
-	m.data.fs.len = count;
-
-	// The payload rides OOL at any size: the kernel copies it in at the
-	// syscall boundary, so the old 256B inline ceiling is gone (issue #314
-	// Stage C)
-	m.ool.addr = reinterpret_cast<uint64_t>(buf);
-	m.ool.size = count;
-
-	Message res = call(process_ids::FS_FAT32, &m);
-	if (IS_ERR(res.result)) {
-		return res.result;
-	}
-
-	return res.data.fs.len;
+	// Same single path as fs_read: fd -> handle translation is the
+	// kernel's job (issue #315 3b-8)
+	return static_cast<ssize_t>(
+			sys_write(fd, reinterpret_cast<uint64_t>(buf), count));
 }
 
 error_t fs_change_dir(char* buf, const char* path)


### PR DESCRIPTION
issue #315 Phase 3b の第 3 弾(A 案 = 1 PR で合意済み)。FS が client の `Task.fd_table` からファイル状態を読み書きする越境アクセスを解消する。

## 変更内容

- **FS 所有の open-file 台帳を新設**(`kernel/fs/fat/open_files.cpp`): open/mkfile 時に FS が**不透明 handle** を発行し、entry ポインタ・offset・name を台帳レコードに保持。client のルーティングエントリは handle を運ぶだけになり、`FileDescriptor` から `size`/`offset` が消えた(純粋なルーティングレコード化が完成)
- **offset は FS の状態に**: `FS_READ` は「offset から count 分の窓を返して offset を進める」契約へ。PR #376 でカーネルに仮置きした窓切り + fd_table offset を削除。#376 で指摘した「sys_read と fs_read で読み位置の意味が違う二重経路」も消滅
- **handle 共有 = POSIX の open file description 意味論**: ルーティングエントリの複製(dup2 / fork)は同じ handle を共有 = offset 共有。dup2 は台帳の参照カウントを +1、close は −1(リダイレクトの `dup2 → close` 後もレコードが生きる)
- **libs/user の fs_read / fs_write を sys_read / sys_write 経由に一本化**(直叩き IPC は client ローカルの fd 番号を送るため FS がもう理解できない)
- テスト: 台帳の基本動作(発行・参照カウント・解放)と死亡所有者掃引を `fs_test` に追加、既存 fd/stdio テストを handle 方式に追従

## 設計判断と理由

- **handle キー((pid, fd) キーの否決)**: (pid, fd) キーだと fork のたびに FS へ複製通知が必要になり、#377 で切ったばかりの task→fs 依存が逆向きに復活する。handle 共有なら fork は FS の存在を知らずに済み、POSIX の offset 共有が自然に手に入る
- **exit 通知を作らない**: プロセス終了時に FS 台帳を掃除する通知は task→fs 依存の再導入。代わりに**割当圧時の死亡所有者掃引**(所有者タスク消滅済みのレコードを回収)で凌ぐ。厳密な参照管理は ring3 サービス基盤(3b-10)のチャネル会計で
- **残る唯一の越境**: open/mkfile/close/dup2 による client ルーティングエントリの設置・解放(`kernel/fs/file_descriptor.cpp` のヘルパ経由)。ここが 3b-10 で「サービス→カーネルの fd 設置 API」になる境界だとコメントで明示

## 実装者として危険だと思う箇所 top3

1. **handle に認可がない**(`file.cpp: resolve_record`)— handle は連番であり、悪意あるタスクが `sys_ipc` で FS_READ を直接送れば**他人の handle を推測して読める**。シングルユーザーの現段階で意図的に受け入れた穴(ring3 化で sender 検証を導入する前提)。/tutor で確認したい筆頭
2. **fork は参照カウントを増やせない**(設計上)— fork **前**に開いた fd は親子で handle を共有するが refcount は 1 のまま。**どちらかが close すると両方閉じる**。現 userland に fork 前 open をするコードは無い(リダイレクトは fork 後の子で open)が、将来の地雷として台帳とコミットログに明記
3. **死亡所有者掃引のエッジ**(`open_files.cpp: sweep_dead_owners`)— 開いた本人(owner)が死んだが fork 共有先の子が生きているレコードも掃引されうる。2 と同じく現実の利用者はいないが、pid スロット再利用と組み合わさると誤回収の理屈が成立する

## 触れた危険地帯

- `kernel/syscall/`(sys_read/sys_write の handle 転送化・窓切り削除。所有権パターンは従来どおり「call 成功 → 即 unique_kbuf → result 検査」)

## 確認

- `cmake -B build kernel && cmake --build build` ✅ / userland 全ターゲット ✅ / `./lint.sh` 警告 0 ✅
- 台帳テスト 2 本 + 既存 fd/stdio/fs テスト追従(CI で実行)
- **QEMU 確認推奨**: `cat <file>` / `echo x > f && cat f`(リダイレクト = dup2 + close 後の書き込みが台帳 refcount の実地検証)/ `write f テキスト` の追記系

Refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)