### PR TITLE
fix(boot): .init_array を実行する — グローバルコンストラクタが一度も走っていなかった (#383)

### DIFF
--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -20,15 +20,41 @@
 struct FrameBufferConf;
 struct MemoryMap;
 
-// 1MiB　
+// 1MiB
 extern "C" {
 char kernel_stack[1024 * 1024];
 }
+
+// Bounds of .init_array, synthesized by lld. Nothing ran these before issue
+// #383: every global with a dynamic constructor (the slab cache_chain, fs
+// tables, IRQ routes, ...) was being used in its zeroed BSS state. A zeroed
+// std::vector happens to be a valid empty vector, but a zeroed std::list has
+// a null sentinel, so cache_chain grew a phantom node threaded through
+// physical page 0 — memory-map-dependent corruption.
+// NOLINTBEGIN(readability-identifier-naming): names are fixed by the linker
+extern "C" void (*__init_array_start[])();
+extern "C" void (*__init_array_end[])();
+// NOLINTEND(readability-identifier-naming)
+
+namespace
+{
+// Must run before anything touches a constructed global. Safe this early:
+// every constructor in this kernel default-constructs containers or stamps
+// plain values — no allocation, no hardware access.
+void run_global_constructors()
+{
+	for (void (**ctor)() = __init_array_start; ctor != __init_array_end; ++ctor) {
+		(*ctor)();
+	}
+}
+} // namespace
 
 extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 					 const MemoryMap& memory_map,
 					 const kernel::timers::acpi::RootSystemDescriptionPointer& rsdp)
 {
+	run_global_constructors();
+
 	kernel::hw::serial::initialize();
 
 	kernel::graphics::initialize(frame_buffer_conf, { 0, 0, 0 });

--- a/kernel/tests/test_cases/memory_test.cpp
+++ b/kernel/tests/test_cases/memory_test.cpp
@@ -148,8 +148,8 @@ void test_get_page_bounds()
 
 	// the last valid page resolves
 	const size_t num_pages = kernel::memory::pages.size();
-	void* last_page_addr = reinterpret_cast<void*>((num_pages - 1) *
-												   kernel::memory::PAGE_SIZE);
+	void* last_page_addr =
+			reinterpret_cast<void*>((num_pages - 1) * kernel::memory::PAGE_SIZE);
 	ASSERT_NOT_NULL(kernel::memory::get_page(last_page_addr));
 
 	// one page past the end must not resolve (used to be an off-by-one)
@@ -243,6 +243,82 @@ void test_slab_error_handling()
 	// Test allocation with size 0
 	ptr = kernel::memory::alloc(0, kernel::memory::ALLOC_UNINITIALIZED);
 	ASSERT_NULL(ptr);
+}
+
+namespace
+{
+
+// The slab list invariant issue #383's corruption violated: every slab sits
+// in the list matching its fill state, and each list walk agrees with its
+// size bookkeeping. Before the fix, global constructors never ran, so
+// cache_chain (a global std::list) had a null sentinel: the walk started at
+// a phantom node threaded through physical page 0 and this check failed on
+// the very first call.
+void check_all_cache_invariants()
+{
+	for (auto& cache : kernel::memory::cache_chain) {
+		for (auto& slab : cache->slabs_partial_) {
+			EXPECT_FALSE(slab->is_full());
+			EXPECT_FALSE(slab->is_empty());
+		}
+		for (auto& slab : cache->slabs_full_) {
+			EXPECT_TRUE(slab->is_full());
+		}
+		for (auto& slab : cache->slabs_free_) {
+			EXPECT_TRUE(slab->is_empty());
+		}
+	}
+}
+
+} // namespace
+
+// Walking cache_chain from the sentinel must yield exactly size() live
+// caches; the pre-fix zeroed sentinel yielded a phantom node with a null
+// MCache pointer first (issue #383)
+void test_cache_chain_walk_matches_size()
+{
+	size_t counted = 0;
+	for (auto& cache : kernel::memory::cache_chain) {
+		ASSERT_NOT_NULL(cache.get());
+		ASSERT_NE(cache->name()[0], '\0');
+		++counted;
+	}
+	ASSERT_EQ(counted, kernel::memory::cache_chain.size());
+}
+
+void test_slab_list_invariants_across_burst()
+{
+	check_all_cache_invariants();
+
+	// A fork-style burst: enough same-class objects to fill several slabs,
+	// with interleaved frees so slabs travel free -> partial -> full and
+	// back while the invariant is re-checked at every step
+	constexpr int num_ptrs = 24;
+	void* ptrs[num_ptrs] = {};
+
+	for (void*& ptr : ptrs) {
+		ptr = kernel::memory::alloc(512, kernel::memory::ALLOC_UNINITIALIZED);
+		ASSERT_NOT_NULL(ptr);
+	}
+	check_all_cache_invariants();
+
+	for (int i = 0; i < num_ptrs; i += 2) {
+		kernel::memory::free(ptrs[i]);
+		ptrs[i] = nullptr;
+	}
+	check_all_cache_invariants();
+
+	for (int i = 0; i < num_ptrs; i += 2) {
+		ptrs[i] = kernel::memory::alloc(512, kernel::memory::ALLOC_UNINITIALIZED);
+		ASSERT_NOT_NULL(ptrs[i]);
+	}
+	check_all_cache_invariants();
+
+	for (void*& ptr : ptrs) {
+		kernel::memory::free(ptr);
+		ptr = nullptr;
+	}
+	check_all_cache_invariants();
 }
 
 void test_slab_double_free_detected()
@@ -387,6 +463,10 @@ void test_unique_kbuf_null_is_safe()
 void register_slab_tests()
 {
 	test_register("slab_basic", test_slab_basic);
+	test_register("cache_chain_walk_matches_size",
+				  test_cache_chain_walk_matches_size);
+	test_register("slab_list_invariants_across_burst",
+				  test_slab_list_invariants_across_burst);
 	test_register("slab_cache_creation", test_slab_cache_creation);
 	test_register("slab_aligned_allocation", test_slab_aligned_allocation);
 	test_register("slab_zeroed_allocation", test_slab_zeroed_allocation);


### PR DESCRIPTION
Closes #383

## 概要

カーネルのエントリ(`KernelMain` → `Main`)が `.init_array` を一度も呼んでおらず、イメージ内の **9 個のグローバルコンストラクタが全て未実行**だった。動的初期化を持つグローバルはすべて BSS ゼロのまま使われていた。

これが #383(CI でのみ fork COW バースト中に slab が `no free objects`)の根本原因:

- ゼロの `std::vector` / `unordered_map` は libc++ では偶然「有効な空コンテナ」になるためブートは動いているように見えた
- しかし **ゼロの `std::list` は番兵が自己参照でなく null**。`cache_chain`(slab.cpp)がまさにそれで、初回 `push_back` が**物理ページ 0 を経由してチェーンを繋ぐ**壊れた構造を作っていた(走査すると先頭に null MCache の幽霊ノード、`size()` は走査より 1 少ない — テスト内ダンプで実測)
- ページ 0 付近が書き換わるかはファームウェアのメモリマップ依存 → ローカル(QEMU 6.2 / 旧 OVMF)では潜伏し、CI ランナー(QEMU 8.2 / 新 OVMF)でだけ崩壊が進行して #383 として観測された

## 設計判断とその理由

- **`Main()` の先頭で `__init_array_start..__init_array_end` を実行**(lld が自動定義するシンボル)。9 個のコンストラクタ全 TU(page/slab/heap_debug/routing/arp/keyboard/file_info/directory/open_files)を監査し、いずれもコンテナのデフォルト構築か値の代入のみ = **メモリ確保もハードウェア接触もない**ため、シリアル初期化より前でも安全
- **捨てた代替案 1: asm(KernelMain)側で呼ぶ** — C++ 側のループの方が可読で、リンカシンボルの extern 宣言も自然
- **捨てた代替案 2: cache_chain だけ initialize で再構築**(既存の `aligned_to_raw_addr_map` 方式の踏襲)— 症状の 1 つを塞ぐだけで、routing の `IrqRoute` 初期値や keyboard の focus 初期値(ゼロだと `pid=0`=KERNEL 扱い)など他の zeroed グローバルの静かな異常が残る。コンストラクタを正しく走らせるのが唯一の本修正
- 既存の `initialize_slab_allocator()` / `heap_debug::initialize()` 内の手動再代入(未実行コンストラクタの症状回避だったとみられる)は**そのまま残した**。正しく構築されたオブジェクトへの再代入として無害で、削除は別の機会でよい

## 検証

- **修正なしで新テストが確実に落ちる**ことを確認: `FAIL: cache_chain_walk_matches_size`(幽霊ノード検出)
- 修正ありでクリーンビルドから **110 テスト全 PASS**(ヒープデバッグのリークチェック込み)、`./lint.sh` 警告ゼロ
- cache_chain ダンプで幽霊ノード消滅(`size()` = 走査数、全キャッシュ実体)を実測
- 24.04 ランナー(発火環境)での煙テスト連結検証は後続コメントで報告予定

## 実装者として危険だと思う箇所 top3

1. `kernel/main.cpp:44`(`run_global_constructors`)— **今後グローバルコンストラクタで確保やハードウェアに触れるコードを書くと、ヒープ初期化前に走って死ぬ**。この前提(ctor はデフォルト構築のみ)はコメントに明記したが、コンパイラは強制してくれない
2. `kernel/main.cpp:30` — `__init_array_start/end` は lld の自動提供シンボルに依存。リンカや `-z` フラグ構成を変えると空になり得る(その場合は静かに未実行へ逆戻り)。テスト `cache_chain_walk_matches_size` が検出網
3. これまで「ゼロ初期化のまま動いていた」グローバル(routing の `IrqRoute`、keyboard の focus 等)の**初期値が本来のコンストラクタ値に変わる**。監査ではいずれも意図された初期値(INVALID=-1 等)に正される方向だが、ゼロ値に暗黙依存したコードが他にあれば挙動が変わる

## 触れた危険地帯

ディレクトリとしては なし(`kernel/main.cpp` と `kernel/tests/` のみ)。ただし**実質はメモリ管理の初期化契約の修正**なので、危険地帯 PR と同様に /tutor での理解確認を推奨します。

関連: #374(発見経緯)、#384(この破壊を隠蔽していた例外経路の問題・未修正)、#385(BAR 回避策・未修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)