### PR TITLE
[検証用・マージ不可] #383 修正を 24.04 スタックで実証

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
         chmod +x ./scripts/run_kernel_tests.sh
         WORK_DIR=qemu-test \
         SMOKE_BINS="userland/shell/shell userland/commands/echo/echo" \
+        QEMU_DEBUG=int,cpu_reset,guest_errors \
         ./scripts/run_kernel_tests.sh
 
     - name: Upload serial log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     # the boot memory map enough to set off latent kernel bugs that are
     # tracked separately: #383 (slab), #384 (fault-path logging), #385
     # (PCI BARs above the identity map). Revisit once those are fixed.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest # TEMP: issue #383 fix verification on the 24.04 stack
 
     steps:
     - uses: actions/checkout@v4

--- a/kernel/interrupt/fault.hpp
+++ b/kernel/interrupt/fault.hpp
@@ -63,7 +63,8 @@ struct FaultHandler;
 // no error code
 template<uint64_t error_code>
 struct FaultHandler<error_code, false> {
-	static inline __attribute__((interrupt)) void handler(InterruptFrame* frame)
+	static inline __attribute__((interrupt, force_align_arg_pointer)) void
+	handler(InterruptFrame* frame)
 	{
 		const char* name = report_fault(error_code, frame);
 
@@ -74,8 +75,8 @@ struct FaultHandler<error_code, false> {
 // exisiting error code
 template<uint64_t error_code>
 struct FaultHandler<error_code, true> {
-	static inline __attribute__((interrupt)) void handler(InterruptFrame* frame,
-														  uint64_t code)
+	static inline __attribute__((interrupt, force_align_arg_pointer)) void
+	handler(InterruptFrame* frame, uint64_t code)
 	{
 		if (error_code == PAGE_FAULT) {
 			const uint64_t fault_addr = get_cr2();

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -20,15 +20,41 @@
 struct FrameBufferConf;
 struct MemoryMap;
 
-// 1MiB　
+// 1MiB
 extern "C" {
 char kernel_stack[1024 * 1024];
 }
+
+// Bounds of .init_array, synthesized by lld. Nothing ran these before issue
+// #383: every global with a dynamic constructor (the slab cache_chain, fs
+// tables, IRQ routes, ...) was being used in its zeroed BSS state. A zeroed
+// std::vector happens to be a valid empty vector, but a zeroed std::list has
+// a null sentinel, so cache_chain grew a phantom node threaded through
+// physical page 0 — memory-map-dependent corruption.
+// NOLINTBEGIN(readability-identifier-naming): names are fixed by the linker
+extern "C" void (*__init_array_start[])();
+extern "C" void (*__init_array_end[])();
+// NOLINTEND(readability-identifier-naming)
+
+namespace
+{
+// Must run before anything touches a constructed global. Safe this early:
+// every constructor in this kernel default-constructs containers or stamps
+// plain values — no allocation, no hardware access.
+void run_global_constructors()
+{
+	for (void (**ctor)() = __init_array_start; ctor != __init_array_end; ++ctor) {
+		(*ctor)();
+	}
+}
+} // namespace
 
 extern "C" void Main(const FrameBufferConf& frame_buffer_conf,
 					 const MemoryMap& memory_map,
 					 const kernel::timers::acpi::RootSystemDescriptionPointer& rsdp)
 {
+	run_global_constructors();
+
 	kernel::hw::serial::initialize();
 
 	kernel::graphics::initialize(frame_buffer_conf, { 0, 0, 0 });

--- a/kernel/memory/buddy_system.cpp
+++ b/kernel/memory/buddy_system.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include "bit_utils.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "log/log.hpp"
 #include "memory/page.hpp"
 
@@ -42,6 +43,11 @@ void BuddySystem::split_memory_block(int order)
 
 void* BuddySystem::allocate(size_t size)
 {
+	// free_lists_ and the page flags are shared by every task, and tasks are
+	// preempted mid-kernel; without this the slab grow path and a direct
+	// page allocation can interleave and corrupt the lists (issue #383)
+	kernel::interrupt::IrqGuard guard;
+
 	const int order = calculate_order(pages_for_bytes(size));
 	if (order == -1) {
 		LOG_ERROR("invalid size: %d", size);
@@ -86,6 +92,9 @@ void* BuddySystem::allocate(size_t size)
 
 void BuddySystem::free(void* addr, size_t size)
 {
+	// Same atomicity contract as allocate() (issue #383)
+	kernel::interrupt::IrqGuard guard;
+
 	auto* start_page = &pages[reinterpret_cast<uintptr_t>(addr) / PAGE_SIZE];
 	if (start_page->is_free()) {
 		LOG_ERROR("double free detected at address: %p", addr);

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -10,6 +10,7 @@
 #include "bit_utils.hpp"
 #include "buddy_system.hpp"
 #include "heap_debug.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "log/log.hpp"
 #include "page.hpp"
 
@@ -239,6 +240,12 @@ constexpr size_t MAX_ALLOC_SIZE = (1UL << MAX_ORDER) * PAGE_SIZE;
 
 void* alloc(size_t size, unsigned flags, int align)
 {
+	// Tasks are preempted mid-kernel (the timer switches even in syscall
+	// context), so every mutation of the cache/slab lists must be atomic
+	// against another task entering the allocator (issue #383): a lost
+	// free-list node surfaces later as "no free objects" on a partial slab.
+	kernel::interrupt::IrqGuard guard;
+
 	if (size == 0) {
 		LOG_ERROR("alloc: size must be non-zero");
 		return nullptr;
@@ -320,6 +327,9 @@ void free(void* addr)
 		return;
 	}
 
+	// Same atomicity contract as alloc() (issue #383)
+	kernel::interrupt::IrqGuard guard;
+
 #ifdef KERNEL_HEAP_DEBUG_ENABLED
 	// Validate the payload pointer, check its redzones, poison the object, and
 	// translate back to the raw slab object. A double/invalid free returns
@@ -367,6 +377,9 @@ bool is_slab_object_in_use(void* addr)
 	if (addr == nullptr) {
 		return false;
 	}
+
+	// Reads the same lists/tables the guarded alloc()/free() mutate
+	kernel::interrupt::IrqGuard guard;
 
 #ifdef KERNEL_HEAP_DEBUG_ENABLED
 	// A live payload pointer maps to its raw object; anything else falls

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -14,8 +14,35 @@
 #include "log/log.hpp"
 #include "page.hpp"
 
+#include "asm_utils.h"
+
 namespace kernel::memory
 {
+
+// ---- TEMP diagnostics for issue #383 (24.04-only alloc failure) ----
+// printf dies in the fault path (issue #384), so these write raw bytes to
+// COM1 directly: no formatting machinery, no SSE, no alignment hazard.
+namespace
+{
+void dbg_puts(const char* s)
+{
+	for (; *s != '\0'; ++s) {
+		write_to_io_port8(0x3f8, static_cast<uint8_t>(*s));
+	}
+}
+
+void dbg_hex(uint64_t v)
+{
+	dbg_puts("0x");
+	for (int shift = 60; shift >= 0; shift -= 4) {
+		const char c = "0123456789abcdef"[(v >> shift) & 0xf];
+		write_to_io_port8(0x3f8, static_cast<uint8_t>(c));
+	}
+}
+
+void dbg_dump_cache(MCache& cache);
+} // namespace
+// ---- END TEMP diagnostics ----
 
 MCache* get_cache_in_chain(const char* name)
 {
@@ -104,6 +131,45 @@ bool MCache::grow()
 	return true;
 }
 
+namespace
+{
+// TEMP (issue #383): printf-free dump of one cache's list state
+void dbg_dump_cache(MCache& cache)
+{
+	dbg_puts("SLABDBG cache=");
+	dbg_puts(cache.name());
+	dbg_puts(" obj_size=");
+	dbg_hex(cache.object_size());
+	dbg_puts("\r\n");
+
+	const struct {
+		const char* name;
+		std::list<std::unique_ptr<MSlab>>* list;
+	} lists[] = { { "free", &cache.slabs_free_ },
+				  { "partial", &cache.slabs_partial_ },
+				  { "full", &cache.slabs_full_ } };
+
+	for (const auto& entry : lists) {
+		dbg_puts("SLABDBG  ");
+		dbg_puts(entry.name);
+		dbg_puts(" size=");
+		dbg_hex(entry.list->size());
+		size_t walked = 0;
+		for (auto& slab : *entry.list) {
+			dbg_puts(" [st=");
+			dbg_hex(static_cast<uint64_t>(slab->status()));
+			dbg_puts(slab->is_full() ? ",F" : ",-");
+			dbg_puts(slab->is_empty() ? "E]" : "-]");
+			if (++walked > 8) {
+				dbg_puts(" ...");
+				break;
+			}
+		}
+		dbg_puts("\r\n");
+	}
+}
+} // namespace
+
 void* MCache::alloc()
 {
 	if (slabs_partial_.empty()) {
@@ -120,6 +186,7 @@ void* MCache::alloc()
 
 	void* addr = current_slab->alloc_object(object_size_);
 	if (addr == nullptr) {
+		dbg_dump_cache(*this); // TEMP (issue #383)
 		LOG_ERROR("failed to allocate object");
 		return nullptr;
 	}
@@ -285,6 +352,12 @@ void* alloc(size_t size, unsigned flags, int align)
 
 	void* addr = cache->alloc();
 	if (addr == nullptr) {
+		// TEMP (issue #383): name the failing call site without printf
+		dbg_puts("SLABDBG alloc-fail caller=");
+		dbg_hex(reinterpret_cast<uint64_t>(__builtin_return_address(0)));
+		dbg_puts(" size=");
+		dbg_hex(size);
+		dbg_puts("\r\n");
 		LOG_ERROR("failed to allocate memory");
 		return nullptr;
 	}

--- a/kernel/newlib_support.c
+++ b/kernel/newlib_support.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -7,6 +8,33 @@ void _exit(int status)
 	while (1) {
 		__asm__("hlt");
 	};
+}
+
+/*
+ * Newlib's malloc arena backs every std container node and printf buffer in
+ * the kernel, but tasks are preempted mid-kernel, so two tasks can interleave
+ * inside malloc/free and corrupt the arena (issue #383). Newlib serializes
+ * through these hooks (no-ops by default); on this single-processor kernel
+ * masking interrupts is the lock. The hooks may nest (newlib documents
+ * recursive acquisition), hence the depth counter.
+ */
+static int malloc_lock_depth;
+static int malloc_lock_if_was_set;
+
+void __malloc_lock(struct _reent* reent)
+{
+	uint64_t rflags;
+	__asm__ volatile("pushfq\n\tpopq %0\n\tcli" : "=r"(rflags) : : "memory");
+	if (malloc_lock_depth++ == 0) {
+		malloc_lock_if_was_set = (rflags & 0x200) != 0;
+	}
+}
+
+void __malloc_unlock(struct _reent* reent)
+{
+	if (--malloc_lock_depth == 0 && malloc_lock_if_was_set) {
+		__asm__ volatile("sti" : : : "memory");
+	}
 }
 
 caddr_t program_break, program_break_end;

--- a/kernel/tests/test_cases/memory_test.cpp
+++ b/kernel/tests/test_cases/memory_test.cpp
@@ -148,8 +148,8 @@ void test_get_page_bounds()
 
 	// the last valid page resolves
 	const size_t num_pages = kernel::memory::pages.size();
-	void* last_page_addr = reinterpret_cast<void*>((num_pages - 1) *
-												   kernel::memory::PAGE_SIZE);
+	void* last_page_addr =
+			reinterpret_cast<void*>((num_pages - 1) * kernel::memory::PAGE_SIZE);
 	ASSERT_NOT_NULL(kernel::memory::get_page(last_page_addr));
 
 	// one page past the end must not resolve (used to be an off-by-one)
@@ -243,6 +243,82 @@ void test_slab_error_handling()
 	// Test allocation with size 0
 	ptr = kernel::memory::alloc(0, kernel::memory::ALLOC_UNINITIALIZED);
 	ASSERT_NULL(ptr);
+}
+
+namespace
+{
+
+// The slab list invariant issue #383's corruption violated: every slab sits
+// in the list matching its fill state, and each list walk agrees with its
+// size bookkeeping. Before the fix, global constructors never ran, so
+// cache_chain (a global std::list) had a null sentinel: the walk started at
+// a phantom node threaded through physical page 0 and this check failed on
+// the very first call.
+void check_all_cache_invariants()
+{
+	for (auto& cache : kernel::memory::cache_chain) {
+		for (auto& slab : cache->slabs_partial_) {
+			EXPECT_FALSE(slab->is_full());
+			EXPECT_FALSE(slab->is_empty());
+		}
+		for (auto& slab : cache->slabs_full_) {
+			EXPECT_TRUE(slab->is_full());
+		}
+		for (auto& slab : cache->slabs_free_) {
+			EXPECT_TRUE(slab->is_empty());
+		}
+	}
+}
+
+} // namespace
+
+// Walking cache_chain from the sentinel must yield exactly size() live
+// caches; the pre-fix zeroed sentinel yielded a phantom node with a null
+// MCache pointer first (issue #383)
+void test_cache_chain_walk_matches_size()
+{
+	size_t counted = 0;
+	for (auto& cache : kernel::memory::cache_chain) {
+		ASSERT_NOT_NULL(cache.get());
+		ASSERT_NE(cache->name()[0], '\0');
+		++counted;
+	}
+	ASSERT_EQ(counted, kernel::memory::cache_chain.size());
+}
+
+void test_slab_list_invariants_across_burst()
+{
+	check_all_cache_invariants();
+
+	// A fork-style burst: enough same-class objects to fill several slabs,
+	// with interleaved frees so slabs travel free -> partial -> full and
+	// back while the invariant is re-checked at every step
+	constexpr int num_ptrs = 24;
+	void* ptrs[num_ptrs] = {};
+
+	for (void*& ptr : ptrs) {
+		ptr = kernel::memory::alloc(512, kernel::memory::ALLOC_UNINITIALIZED);
+		ASSERT_NOT_NULL(ptr);
+	}
+	check_all_cache_invariants();
+
+	for (int i = 0; i < num_ptrs; i += 2) {
+		kernel::memory::free(ptrs[i]);
+		ptrs[i] = nullptr;
+	}
+	check_all_cache_invariants();
+
+	for (int i = 0; i < num_ptrs; i += 2) {
+		ptrs[i] = kernel::memory::alloc(512, kernel::memory::ALLOC_UNINITIALIZED);
+		ASSERT_NOT_NULL(ptrs[i]);
+	}
+	check_all_cache_invariants();
+
+	for (void*& ptr : ptrs) {
+		kernel::memory::free(ptr);
+		ptr = nullptr;
+	}
+	check_all_cache_invariants();
 }
 
 void test_slab_double_free_detected()
@@ -387,6 +463,10 @@ void test_unique_kbuf_null_is_safe()
 void register_slab_tests()
 {
 	test_register("slab_basic", test_slab_basic);
+	test_register("cache_chain_walk_matches_size",
+				  test_cache_chain_walk_matches_size);
+	test_register("slab_list_invariants_across_burst",
+				  test_slab_list_invariants_across_burst);
 	test_register("slab_cache_creation", test_slab_cache_creation);
 	test_register("slab_aligned_allocation", test_slab_aligned_allocation);
 	test_register("slab_zeroed_allocation", test_slab_zeroed_allocation);


### PR DESCRIPTION
**マージしないでください** — PR #386(.init_array 修正)が、#383 が実際に発火していた ubuntu-24.04(QEMU 8.2 + 新 OVMF)で煙テストを green にすることを実証するための使い捨てブランチです(中身 = master + #386 + runner を ubuntu-latest に一時変更)。

修正前の同スタックでは fork COW バースト中の slab 破壊 → トリプルフォールトが 5/5 再現していました。結果確認後にクローズします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)