### PR TITLE
fix(interrupt): フォールトハンドラでスタックを再整列する (#384)

### DIFF
--- a/kernel/interrupt/fault.hpp
+++ b/kernel/interrupt/fault.hpp
@@ -60,10 +60,21 @@ __attribute__((no_caller_saved_registers)) const char* report_fault(
 template<uint64_t error_code, bool has_error_code>
 struct FaultHandler;
 
+// force_align_arg_pointer on both handlers (issue #384): the C call chain
+// below a fault handler must be ABI-aligned no matter what RSP parity the
+// exception delivery produced. Without it, clang's interrupt prologue can
+// leave every callee 8 bytes off, and the first function that spills an XMM
+// register to the stack (printf's movdqa) raises #GP — whose handler then
+// faults the same way, recursing into a triple fault. Delivery parity
+// differs between environments (QEMU 8.2 / real hardware align the frame
+// to 16 bytes; QEMU 6.2 does not), which is why the interactive setup
+// never showed this.
+
 // no error code
 template<uint64_t error_code>
 struct FaultHandler<error_code, false> {
-	static inline __attribute__((interrupt)) void handler(InterruptFrame* frame)
+	static inline __attribute__((interrupt, force_align_arg_pointer)) void handler(
+			InterruptFrame* frame)
 	{
 		const char* name = report_fault(error_code, frame);
 
@@ -74,8 +85,9 @@ struct FaultHandler<error_code, false> {
 // exisiting error code
 template<uint64_t error_code>
 struct FaultHandler<error_code, true> {
-	static inline __attribute__((interrupt)) void handler(InterruptFrame* frame,
-														  uint64_t code)
+	static inline __attribute__((interrupt, force_align_arg_pointer)) void handler(
+			InterruptFrame* frame,
+			uint64_t code)
 	{
 		if (error_code == PAGE_FAULT) {
 			const uint64_t fault_addr = get_cr2();


### PR DESCRIPTION
Closes #384

## 概要

フォールトハンドラ以下の C コールチェーンが、例外配送が作る RSP パリティ次第で **ABI 整列から 8 バイトずれたまま走る**問題の修正。ずれても SSE のスタック退避に到達するまで無症状で、最初の発火点(newlib printf の `movdqa`)で #GP → その報告経路(`get_fault_name` の `movaps`)も同じずれで #GP → 例外↔報告の無限再帰でスタックを食い潰し**サイレントなトリプルフォールト**になる。

これが CI 24.04 スタックで ring-3 煙テストを 6/6 で沈黙死させていた真因(#383 の調査で特定)。fork 子プロセスの最初の COW #PF 処理(`copy_target_page` → `alloc()` の `sprintf("cache-%d")`)が発火経路だった。

## 設計判断とその理由

- **`force_align_arg_pointer` を 2 つの `FaultHandler` テンプレートに追加**(実質の diff は属性 1 個 × 2 箇所 + 解説コメント)。プロローグに `and rsp,-16` が入り、ハンドラ以下の整列が**配送パリティ非依存**になる
- **なぜ環境差が出るか**: QEMU 8.2(および実ハードウェア)は例外フレームを 16B 境界に強制整列するが、基準環境の QEMU 6.2 はしない。clang のプロローグはどちらか一方のパリティでしか ABI を満たせず、**6.2 が偶然バグを隠していた**(= 実機でも発火し得た)
- **捨てた代替案 1: asm トランポリン**(各フォールトベクタで整列してから C へ)— 最も明示的だが、IDT 配線と例外フレーム受け渡しの書き換えが必要で diff が膨らむ。属性 1 個で同じ保証が得られる
- **捨てた代替案 2: ハンドラから呼ばれる関数側に個別対処**(`-mgeneral-regs-only` や個別属性)— printf を含む到達先全部が対象になりモグラ叩き。入口で一度整列する方が構造的
- #384 に書いた「フォールト報告経路の printf 非依存化」「#DF への IST」は、この修正後も**多層防御として有効**なので別途(この PR には含めない)

## 検証

- **発火環境での実証**: ubuntu-24.04 / QEMU 8.2(修正前 6/6 でトリプルフォールト)で **110 テスト + 煙テスト green**(クローズ済み検証 PR #387、run 30682585773)
- **基準環境の無退行**: QEMU 6.2 ローカルで 110 テスト + 煙テスト PASS、`./lint.sh` 警告ゼロ
- プロローグに `and rsp,-16` が入ることを逆アセンブルで確認済み
- **新規カーネルテストなし(理由明記)**: このずれは CI が現在走る QEMU 6.2 では原理的に誘発できない。回帰網はこの PR のマージ後に CI の 22.04 固定を解除して 24.04 スタックで煙テストを回すこと(フォローアップ PR 予定)

## 実装者として危険だと思う箇所 top3

1. `kernel/interrupt/fault.hpp:78` — ハンドラ**自身のプロローグの xmm 退避(rbp 相対 movaps)は依然パリティ依存**。`force_align_arg_pointer` の `and rsp,-16` は RBP 確立後に入るため、配送パリティが「8.2 型」の環境で守られているのは経験則(実測)であり構造保証ではない。完全化するなら asm トランポリン(#384 に記載の多層防御)
2. `kernel/interrupt/fault.hpp:60` のコメント前提 — 今後**新しい割り込み/例外ハンドラを追加するときに同じ属性を付け忘れる**と同型のバグが再導入される。`FaultHandler` 経由なら安全だが、直接 `__attribute__((interrupt))` を書く箇所は要注意(idt.cpp のデバイス割り込みは現状 C 呼び出しが浅く未発火)
3. 検証の非対称性 — 発火環境(24.04)は現在 CI から外れているため、**この修正の回帰は 22.04 固定を解除するまで検出できない**。解除のフォローアップを忘れると保護が絵に描いた餅になる

## 触れた危険地帯

**`kernel/interrupt/`**(fault.hpp のみ)。マージ前に /tutor での理解確認をお願いします。

関連: #383(発見経緯・調査ログ)、#387(発火環境での検証記録)、#385 / #388(未着手の残課題)

🤖 Generated with [Claude Code](https://claude.com/claude-code)