### PR TITLE
scripts: CI 実行のバイナリをローカル再生する replay_ci_run.sh

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -31,5 +31,10 @@ paths:
 - 仕組み: テスト完走後もブートを継続 → シェルを `-smoke` 引数で exec → シェルが `echo smoke` を通常の fork→exec→wait 経路で 1 往復実行 → 結果を `SMOKE_REPORT` メッセージで KERNEL タスクへ報告 → カーネル(`kernel/tests/smoke.cpp`)が `SMOKE_TEST: ... result=PASS|FAIL` マーカーをシリアルに出して isa-debug-exit で終了(テスト結果との AND)。ハングは 60 秒のウォッチドッグが FAIL マーカー化する
 - `scripts/run_kernel_tests.sh` は `SMOKE_BINS="<shell> <echo>"` 指定時に virtio-blk ストレージディスクを組み立てて `SMOKE_TEST:` マーカーも判定する。マーカー形式を変える場合は両側を同期すること
 
+## CI 失敗の切り分け(replay-first)
+- CI 失敗の初手は `./scripts/replay_ci_run.sh <run-id>`(引数なし = 直近の失敗 run)。CI がブートした実バイナリ(smoke-debug-binaries アーティファクト)をローカル QEMU で再生し、「決定的なコードバグ」か「QEMU/OVMF の環境差」かを 1 実験で判定する。ローカル再ビルドでの再現試行はコンパイラ差で別バイナリになるため切り分けにならない
+- ローカルでも落ちる場合は `QEMU_DEBUG=int,cpu_reset,guest_errors` で例外トレースを取り、`llvm-addr2line -e <CI の ELF>` で行番号化する(手元の再ビルドではアドレスが合わないので必ず CI 実バイナリで解決する)
+- printf が死ぬ文脈(例外経路・沈黙死)の観測は `write_to_io_port8(0x3f8, c)` のシリアル直書きが安全(経緯: issue #383/#384)
+
 ## 注意
 - 既存テスト(memory / task / timer / virtio_blk / fs / fd / stdio)の書き方を踏襲すること

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,16 @@ gdb build/UchosKernel
 target remote :12345
 ```
 
+### 🔁 CI デバッグの初手は replay(replay-first)
+
+CI が落ちたら、ローカルで再ビルドして試す前に **CI がブートした実バイナリをそのままローカル QEMU で再生**する(ローカルビルドはコンパイラ差で別バイナリになり、切り分けにならない):
+
+```bash
+./scripts/replay_ci_run.sh <run-id>   # 省略時は直近の失敗 run
+```
+
+判定は二値: **ローカルでも落ちる** = 決定的なコードバグ(以降 CI 往復なしで手元デバッグ)/ **ローカルでは通る** = QEMU・OVMF の環境差を疑う。詳細・トレース取得(`QEMU_DEBUG=int,...`)はスクリプト冒頭のコメント参照。issue #383/#384 の切り分けを決めた手法(経緯は #383 のコメント)。
+
 ### 🩺 ヒープデバッグ(KERNEL_HEAP_DEBUG)
 
 slab アロケータに poison / redzone / 確保元トラッキングを仕込み、use-after-free・バッファオーバーフロー・二重 free・リークを **違反地点で** 検出する(実装: `kernel/memory/heap_debug.{hpp,cpp}`)。**既定 ON**(`KERNEL_TESTS` と同方針でローカル開発・対話ブートに常時稼働)。性能計測などで無効化する場合のみ `-DKERNEL_HEAP_DEBUG=OFF` を渡す(OFF ビルドはコード・性能とも従来と同一)。

--- a/scripts/replay_ci_run.sh
+++ b/scripts/replay_ci_run.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Replay a CI run's booted binaries on the local QEMU ("replay-first").
+#
+# When CI fails, the first question is "bad code or different environment?"
+# Rebuilding locally cannot answer it: the local toolchain produces a
+# different binary. This script downloads the EXACT kernel and userland
+# binaries the CI run booted (the smoke-debug-binaries artifact) and feeds
+# them to scripts/run_kernel_tests.sh unchanged, so the only remaining
+# variable is the environment (QEMU/OVMF):
+#   - fails locally too  -> deterministic code bug; debug locally, no CI loop
+#   - passes locally     -> the difference is the environment, not the code
+# (This one experiment is what pinned issue #384 down to the QEMU exception
+# delivery difference.)
+#
+# Usage:
+#   ./scripts/replay_ci_run.sh [run-id]
+#
+#   run-id     GitHub Actions run id (the number in the run's URL). When
+#              omitted, the most recent FAILED run is used.
+#
+# Environment overrides (all optional):
+#   LOADER_EFI / OVMF_CODE / OVMF_VARS  as in run_kernel_tests.sh; the
+#              loader is additionally searched in the local EDK2 build tree
+#   QEMU_DEBUG e.g. "int,cpu_reset,guest_errors" for an exception trace
+#   TIMEOUT_SEC / WORK_DIR              passed through
+#
+# Requires: gh (authenticated), plus run_kernel_tests.sh's own dependencies.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+run_id="${1:-}"
+
+if [ -z "$run_id" ]; then
+    run_id="$(gh api "repos/{owner}/{repo}/actions/runs?status=failure&per_page=1" \
+                  --jq '.workflow_runs[0].id')"
+    if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+        echo "error: no failed run found; pass a run id explicitly" >&2
+        exit 1
+    fi
+    echo "replaying the most recent failed run: $run_id"
+fi
+
+WORK_DIR="${WORK_DIR:-$(mktemp -d -t uchos-replay-XXXX)}"
+bins_dir="$WORK_DIR/ci-bins"
+ci_logs_dir="$WORK_DIR/ci-logs"
+
+echo "downloading artifacts of run $run_id into $WORK_DIR"
+gh run download "$run_id" -n smoke-debug-binaries -D "$bins_dir" || {
+    echo "error: run $run_id has no smoke-debug-binaries artifact" >&2
+    echo "(only runs that reached the build steps upload it)" >&2
+    exit 1
+}
+# The CI serial log rides along for comparing against the local replay.
+gh run download "$run_id" -n kernel-test-serial-log -D "$ci_logs_dir" ||
+    echo "note: no kernel-test-serial-log artifact on this run"
+
+kernel_elf="$bins_dir/build/UchosKernel"
+shell_bin="$bins_dir/userland/shell/shell"
+echo_bin="$bins_dir/userland/commands/echo/echo"
+if [ ! -f "$kernel_elf" ]; then
+    echo "error: artifact did not contain build/UchosKernel" >&2
+    exit 1
+fi
+
+smoke_bins=""
+if [ -f "$shell_bin" ] && [ -f "$echo_bin" ]; then
+    smoke_bins="$shell_bin $echo_bin"
+else
+    echo "note: userland binaries missing from the artifact; kernel tests only"
+fi
+
+# The loader is not part of the artifact (it is environment-neutral EFI and
+# rarely the suspect); fall back to the local EDK2 build tree.
+if [ -z "${LOADER_EFI:-}" ]; then
+    for candidate in "$repo_root/Loader.efi" \
+        "$HOME/edk2/Build/UchLoaderPkgX64/DEBUG_CLANG38/X64/UchLoaderPkg/Loader/OUTPUT/Loader.efi"; do
+        if [ -f "$candidate" ]; then
+            LOADER_EFI="$candidate"
+            break
+        fi
+    done
+fi
+
+echo "kernel : $kernel_elf"
+echo "smoke  : ${smoke_bins:-<none>}"
+echo "loader : ${LOADER_EFI:-<not found>}"
+
+cd "$repo_root"
+set +e
+KERNEL_ELF="$kernel_elf" \
+    LOADER_EFI="${LOADER_EFI:-}" \
+    SMOKE_BINS="$smoke_bins" \
+    WORK_DIR="$WORK_DIR/qemu" \
+    ./scripts/run_kernel_tests.sh
+status=$?
+set -e
+
+echo ""
+echo "== replay verdict =========================================="
+echo "local replay exit: $status (0 = the CI binaries PASS here)"
+if [ -f "$ci_logs_dir/serial.log" ]; then
+    echo "compare serial logs:"
+    echo "  CI    : $ci_logs_dir/serial.log"
+    echo "  local : $WORK_DIR/qemu/serial.log"
+fi
+if [ "$status" -eq 0 ]; then
+    echo "-> the exact CI binaries pass locally: suspect the ENVIRONMENT"
+    echo "   (QEMU/OVMF behaviour), not the code or the toolchain"
+else
+    echo "-> fails locally too: deterministic code bug, debug it here"
+    echo "   (rerun with QEMU_DEBUG=int,cpu_reset,guest_errors for a trace)"
+fi
+exit "$status"


### PR DESCRIPTION
## 概要

CI 失敗時の初手を 1 コマンド化する(#383/#384 デバッグの教訓「replay-first」の道具化):

```bash
./scripts/replay_ci_run.sh <run-id>   # 省略時は直近の失敗 run
```

やること: 該当 run の smoke-debug-binaries アーティファクト(CI が実際にブートしたカーネル・shell・echo)を取得し、そのまま `run_kernel_tests.sh` に食わせてローカル QEMU で起動。CI 側の serial.log も並置して比較できるようにする。

バイナリを固定するので判定は二値:
- **ローカルでも落ちる** → 決定的なコードバグ。以降 CI 往復なしで手元デバッグ(`QEMU_DEBUG=int,...` でトレース)
- **ローカルでは通る** → 差は QEMU/OVMF 環境

## 検証

#389 修正前の 24.04 トリプルフォールト run(30682087573)で実行し、「バイナリはローカル PASS → 環境を疑え」と #384 の結論どおりの判定が出ることを確認。

## 設計判断

- ローダーはアーティファクトに含まれない(環境中立な EFI で容疑者になりにくい)ため、ローカル EDK2 ビルドへのフォールバック探索にした
- 判定と次アクションの提示までをスクリプトの責務にし、解析(addr2line 等)はしない — シンプルさ優先

## 危険箇所 / 危険地帯

シェルスクリプト追加のみ。危険地帯: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)