### PR TITLE
feat(task): サービス起動 manifest のバイナリ名化 — ring3 サービスを汎用ブートストラップで起動(issue #315 3b-10a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,13 @@ jobs:
         export LDFLAGS="-L$GITHUB_WORKSPACE/x86_64-elf/lib"
         make -C userland/shell shell
         make -C userland/commands/echo echo
+        make -C userland/services/pongd pongd
 
     - name: Run kernel tests and ring-3 smoke test in QEMU
       run: |
         chmod +x ./scripts/run_kernel_tests.sh
         WORK_DIR=qemu-test \
-        SMOKE_BINS="userland/shell/shell userland/commands/echo/echo" \
+        SMOKE_BINS="userland/shell/shell userland/commands/echo/echo userland/services/pongd/pongd" \
         ./scripts/run_kernel_tests.sh
 
     - name: Upload serial log
@@ -110,6 +111,7 @@ jobs:
           build/UchosKernel
           userland/shell/shell
           userland/commands/echo/echo
+          userland/services/pongd/pongd
         if-no-files-found: ignore
 
     - name: Run clang-tidy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ uchos/
 │   ├── graphics/       # 画面描画・フォント・ログ
 │   └── tests/          # カーネル内部テストフレームワーク
 ├── UchLoaderPkg/       # UEFI ブートローダー(EDK2)
-├── userland/           # shell/ と commands/(ls, cat, echo, ping 等)
+├── userland/           # shell/、commands/(ls, cat, echo, ping 等)、services/(ring3 サービス)
 ├── libs/               # common(カーネル・ユーザー共通)/ user(ユーザーランドランタイム)
 ├── scripts/            # ビルド・ディスクイメージ作成・TAP 設定スクリプト
 └── x86_64-elf/         # クロスコンパイル用 newlib / libc++(編集禁止)

--- a/kernel/services.cpp
+++ b/kernel/services.cpp
@@ -141,6 +141,14 @@ void service_bootstrap()
 
 	CURRENT_TASK->is_initialized = true;
 	exec_elf(std::move(elf_buf), self->name, self->args);
+
+	// exec_elf only returns on failure (segment/stack/heap mapping). Falling
+	// off this function would run off a dead ring-0 stack frame into a
+	// garbage RIP and panic the whole system — park the task instead.
+	LOG_ERROR("exec failed for service binary: %s", self->binary);
+	while (true) {
+		__asm__("hlt");
+	}
 }
 
 } // namespace

--- a/kernel/services.cpp
+++ b/kernel/services.cpp
@@ -6,7 +6,8 @@
  * Extracted from kernel/task/task.cpp (issue #315): keeping the list here
  * cuts the scheduler's reverse dependencies on fs/, hardware/ and net/.
  * Phase 3b replaces entries with ring-3 launches one by one without the
- * task layer noticing.
+ * task layer noticing: an entry moves to ring 3 by swapping its function
+ * pointer for a binary name (issue #315 3b-10).
  */
 
 #include "services.hpp"
@@ -30,56 +31,36 @@
 namespace
 {
 
-/**
- * @brief Bootstrap of the user shell
- *
- * Runs as the SHELL task's ring-0 prologue: one synchronous FS_LOAD
- * returns a kernel-owned copy of the shell binary as an OOL move, then
- * exec_elf takes ownership and turns this task into the ring-3 shell.
- * Lives next to the manifest because it is boot wiring, not scheduler
- * code (issue #315).
- */
-void shell_service()
-{
-	Message m = { .type = MsgType::FS_LOAD, .sender = process_ids::SHELL };
-	char path[6] = "shell";
-	memcpy(m.data.fs.name, path, 6);
-
-	const error_t load_err = kernel::task::call(process_ids::FS_FAT32, &m);
-
-	// Take ownership before inspecting the result (mirrors sys_exec)
-	kernel::memory::unique_kbuf<> shell_elf{ reinterpret_cast<void*>(m.ool.addr) };
-	if (IS_ERR(load_err) || IS_ERR(m.result) || m.ool.size == 0 || !shell_elf) {
-		LOG_ERROR("failed to load shell binary");
-		while (true) {
-			__asm__("hlt");
-		}
-	}
-
-	CURRENT_TASK->is_initialized = true;
-#ifdef KERNEL_SMOKE_TEST_ENABLED
-	// argv[1] tells the shell to run one fork→exec→wait round-trip on its
-	// own and report the outcome to KERNEL (issue #374)
-	exec_elf(std::move(shell_elf), "shell", "-smoke");
-#else
-	exec_elf(std::move(shell_elf), "shell", nullptr);
-#endif
-}
+void service_bootstrap();
 
 using kernel::task::InitialTaskInfo;
 
-/// Every service the kernel starts at boot, in task-slot order. All still
-/// run ring 0 (KERNEL_CS kernel threads) for now; see issue #315 3b.
+/// argv tail of the shell's ring-3 launch. Smoke builds tell the shell to
+/// run one fork→exec→wait round-trip plus a pongd ping on its own and
+/// report the outcome to KERNEL (issues #374, #315 3b-10).
+#ifdef KERNEL_SMOKE_TEST_ENABLED
+constexpr const char* SHELL_ARGS = "-smoke";
+#else
+constexpr const char* SHELL_ARGS = nullptr;
+#endif
+
+/// Every service the kernel starts at boot, in task-slot order. Entries
+/// with a binary name boot through service_bootstrap() and run ring 3;
+/// the rest are still ring-0 kernel threads (issue #315 3b).
 constexpr InitialTaskInfo SERVICE_MANIFEST[] = {
-	{ SystemProcessId::XHCI, "usb_handler", &kernel::hw::usb_handler_service, true,
-	  true },
+	{ SystemProcessId::XHCI, "usb_handler", &kernel::hw::usb_handler_service,
+	  nullptr, nullptr, true, true },
 	{ SystemProcessId::VIRTIO_BLK, "virtio_blk",
-	  &kernel::hw::virtio::virtio_blk_service, true, false },
-	{ SystemProcessId::FS_FAT32, "fat32", &kernel::fs::fat32_service, true, true },
-	{ SystemProcessId::SHELL, "shell", &shell_service, true, false },
+	  &kernel::hw::virtio::virtio_blk_service, nullptr, nullptr, true, false },
+	{ SystemProcessId::FS_FAT32, "fat32", &kernel::fs::fat32_service, nullptr,
+	  nullptr, true, true },
+	{ SystemProcessId::SHELL, "shell", &service_bootstrap, "shell", SHELL_ARGS, true,
+	  false },
 	{ SystemProcessId::VIRTIO_NET, "virtio_net",
-	  &kernel::hw::virtio::virtio_net_service, true, false },
-	{ SystemProcessId::NET, "net", &kernel::net::packet_handler_service, true,
+	  &kernel::hw::virtio::virtio_net_service, nullptr, nullptr, true, false },
+	{ SystemProcessId::NET, "net", &kernel::net::packet_handler_service, nullptr,
+	  nullptr, true, false },
+	{ SystemProcessId::PONGD, "pongd", &service_bootstrap, "pongd", nullptr, true,
 	  false },
 };
 
@@ -102,6 +83,65 @@ constexpr bool manifest_matches_slots()
 static_assert(manifest_matches_slots(),
 			  "SERVICE_MANIFEST must start at XHCI and be ordered by "
 			  "SystemProcessId, gap-free");
+
+// service_bootstrap() finds its binary by scanning the manifest, so a
+// binary name without the bootstrap entry (or vice versa) is a dead field.
+constexpr bool ring3_entries_use_bootstrap()
+{
+	for (size_t i = 0; i < SERVICE_COUNT; ++i) {
+		if ((SERVICE_MANIFEST[i].binary != nullptr) !=
+			(SERVICE_MANIFEST[i].entry == &service_bootstrap)) {
+			return false;
+		}
+	}
+	return true;
+}
+static_assert(ring3_entries_use_bootstrap(),
+			  "manifest entries must set binary iff entry is "
+			  "service_bootstrap");
+
+/**
+ * @brief Generic ring-0 prologue of every ring-3 manifest service
+ *
+ * Runs as the service task's entry: looks up its own manifest row by task
+ * id, pulls the named binary with one synchronous FS_LOAD (a kernel-owned
+ * copy arrives as an OOL move), then exec_elf takes ownership and turns
+ * this task into the ring-3 service. Generalizes the former shell-only
+ * bootstrap (issue #315 3b-10); the FS migration (3b-11) reuses it as is.
+ */
+void service_bootstrap()
+{
+	const InitialTaskInfo* self = nullptr;
+	for (const auto& info : SERVICE_MANIFEST) {
+		if (CURRENT_TASK->id == info.id) {
+			self = &info;
+			break;
+		}
+	}
+	if (self == nullptr || self->binary == nullptr) {
+		LOG_ERROR("no manifest binary for task %d", CURRENT_TASK->id.raw());
+		while (true) {
+			__asm__("hlt");
+		}
+	}
+
+	Message m = { .type = MsgType::FS_LOAD, .sender = CURRENT_TASK->id };
+	strncpy(m.data.fs.name, self->binary, sizeof(m.data.fs.name) - 1);
+
+	const error_t load_err = kernel::task::call(process_ids::FS_FAT32, &m);
+
+	// Take ownership before inspecting the result (mirrors sys_exec)
+	kernel::memory::unique_kbuf<> elf_buf{ reinterpret_cast<void*>(m.ool.addr) };
+	if (IS_ERR(load_err) || IS_ERR(m.result) || m.ool.size == 0 || !elf_buf) {
+		LOG_ERROR("failed to load service binary: %s", self->binary);
+		while (true) {
+			__asm__("hlt");
+		}
+	}
+
+	CURRENT_TASK->is_initialized = true;
+	exec_elf(std::move(elf_buf), self->name, self->args);
+}
 
 } // namespace
 

--- a/kernel/task/task.cpp
+++ b/kernel/task/task.cpp
@@ -359,8 +359,8 @@ namespace
 // comes in through the manifest supplied to initialize() (issue #315:
 // this file must not know individual services).
 constexpr InitialTaskInfo SCHEDULER_TASKS[] = {
-	{ SystemProcessId::KERNEL, "main", nullptr, false, true },
-	{ SystemProcessId::IDLE, "idle", &idle_service, true, true },
+	{ SystemProcessId::KERNEL, "main", nullptr, nullptr, nullptr, false, true },
+	{ SystemProcessId::IDLE, "idle", &idle_service, nullptr, nullptr, true, true },
 };
 
 void spawn_initial_task(const InitialTaskInfo& info)

--- a/kernel/task/task.hpp
+++ b/kernel/task/task.hpp
@@ -176,6 +176,10 @@ struct InitialTaskInfo {
 	SystemProcessId id; ///< tasks[] slot this entry must land in (asserted)
 	const char* name;
 	void (*entry)(); ///< Service entry point, nullptr for the boot task
+	/// ELF name on the boot volume; non-null makes entry the generic
+	/// bootstrap that execs the task into ring 3 (issue #315 3b-10)
+	const char* binary;
+	const char* args; ///< argv tail of a ring-3 launch, usually nullptr
 	bool setup_context;
 	bool is_initialized;
 };

--- a/kernel/tests/test_cases/task_test.cpp
+++ b/kernel/tests/test_cases/task_test.cpp
@@ -221,9 +221,20 @@ void test_ipc_recv_returns_queued_message()
 	ASSERT_EQ(t->state, kernel::task::TASK_RUNNING);
 }
 
+void test_manifest_ring3_service_slot()
+{
+	// The boot manifest launches pongd through the generic ring-3
+	// bootstrap (issue #315 3b-10). Its declared slot must hold a task of
+	// that name, or every process_ids::PONGD send goes to a stranger.
+	Task* t = get_task(process_ids::PONGD);
+	ASSERT_NOT_NULL(t);
+	ASSERT_EQ(strcmp(t->name, "pongd"), 0);
+}
+
 void register_task_tests()
 {
 	test_register("task_creation_basic", test_task_creation_basic);
+	test_register("manifest_ring3_service_slot", test_manifest_ring3_service_slot);
 	test_register("task_id_management", test_task_id_management);
 	test_register("task_message_handling", test_task_message_handling);
 	test_register("task_copy", test_task_copy);

--- a/libs/common/message.hpp
+++ b/libs/common/message.hpp
@@ -90,6 +90,10 @@ enum class MsgType : int32_t {
 	FS_PWD,
 	FS_CHANGE_DIR,
 	FS_DUP2,
+	/// Ping the pongd reference service; the reply carries "pong" in
+	/// data.write.buf. Proves the manifest ring-3 service boot and the
+	/// user-side reply path (issue #315 3b-10).
+	PONGD_PING,
 	/// Ring-3 smoke result the shell sends to KERNEL in KERNEL_SMOKE_TEST
 	/// builds: one fork→exec→wait round-trip, judged by the kernel (#374)
 	SMOKE_REPORT,

--- a/libs/common/process_id.hpp
+++ b/libs/common/process_id.hpp
@@ -12,6 +12,7 @@ enum class SystemProcessId : pid_t {
 	SHELL = 5,
 	VIRTIO_NET = 6,
 	NET = 7,
+	PONGD = 8,
 	INTERRUPT = 100
 };
 
@@ -59,5 +60,6 @@ inline constexpr ProcessId FS_FAT32{ SystemProcessId::FS_FAT32 };
 inline constexpr ProcessId SHELL{ SystemProcessId::SHELL };
 inline constexpr ProcessId VIRTIO_NET{ SystemProcessId::VIRTIO_NET };
 inline constexpr ProcessId NET{ SystemProcessId::NET };
+inline constexpr ProcessId PONGD{ SystemProcessId::PONGD };
 inline constexpr ProcessId INTERRUPT{ SystemProcessId::INTERRUPT };
 } // namespace process_ids

--- a/libs/user/ipc.cpp
+++ b/libs/user/ipc.cpp
@@ -28,6 +28,15 @@ Message call(ProcessId dst, Message* msg)
 	return *msg;
 }
 
+error_t reply_message(const Message* req, Message* resp)
+{
+	// The server only echoes the pairing id; the kernel stamps the reply
+	// flag and the true sender at the syscall boundary (issue #315 3b-10)
+	resp->correlation = req->correlation;
+	return static_cast<error_t>(
+			sys_ipc(req->sender.raw(), resp->sender.raw(), resp, IPC_REPLY));
+}
+
 void initialize_task()
 {
 	Message m = make_request(MsgType::FS_REGISTER_PATH);

--- a/libs/user/ipc.hpp
+++ b/libs/user/ipc.hpp
@@ -29,6 +29,21 @@ Message make_request(MsgType type);
  */
 Message call(ProcessId dst, Message* msg);
 
+/**
+ * @brief Answer a received request (server side of an RPC, IPC_REPLY)
+ *
+ * Echoes the request's correlation so the kernel can pair the reply with
+ * the caller blocked in call(); the kernel stamps MSG_FLAG_REPLY and the
+ * true sender at the syscall boundary (issue #315 3b-10). A request with
+ * correlation 0 expects no reply and makes this a no-op. Put the
+ * server-side outcome in resp->result.
+ *
+ * @param req The request being answered
+ * @param resp Reply message (type/payload/result set by the caller)
+ * @return OK on delivery (or no-op), negative error_t otherwise
+ */
+error_t reply_message(const Message* req, Message* resp);
+
 void initialize_task();
 
 /**

--- a/scripts/build_kernel.sh
+++ b/scripts/build_kernel.sh
@@ -91,6 +91,21 @@ for MKF in $(ls $work_path/userland/commands/*/Makefile); do
     fi
 done
 
+# Ring-3 services launched from the boot manifest (issue #315 3b-10)
+for MKF in $(ls $work_path/userland/services/*/Makefile 2>/dev/null); do
+    APP_DIR=$(dirname $MKF)
+    APP=$(basename $APP_DIR)
+    printf "${YELLOW}Building service: $APP${NC}\n"
+    make ${MAKE_OPTS:-} -C $APP_DIR clean > /dev/null 2>&1
+    if ! make ${MAKE_OPTS:-} -C $APP_DIR $APP; then
+        printf "${RED}✗ Failed to build service: $APP${NC}\n"
+        BUILD_FAILED=1
+        FAILED_APPS+=("services/$APP")
+    else
+        printf "${GREEN}✓ Successfully built service: $APP${NC}\n"
+    fi
+done
+
 # Summary message at the end
 if [ $BUILD_FAILED -eq 1 ]; then
     printf "\n${RED}════════════════════════════════════════════════════════════════${NC}\n"
@@ -122,6 +137,14 @@ for COMMAND in $(ls $work_path/userland/commands); do
     if [ -f $work_path/userland/commands/$COMMAND/$COMMAND ]; then
         sudo cp $work_path/userland/commands/$COMMAND/$COMMAND $mount_point/
         sudo cp $work_path/userland/commands/$COMMAND/$COMMAND $storage_mount_point/
+    fi
+done
+
+# The boot manifest loads ring-3 services by name from the volume root
+for SERVICE in $(ls $work_path/userland/services 2>/dev/null); do
+    if [ -f $work_path/userland/services/$SERVICE/$SERVICE ]; then
+        sudo cp $work_path/userland/services/$SERVICE/$SERVICE $mount_point/
+        sudo cp $work_path/userland/services/$SERVICE/$SERVICE $storage_mount_point/
     fi
 done
 

--- a/scripts/replay_ci_run.sh
+++ b/scripts/replay_ci_run.sh
@@ -57,17 +57,22 @@ gh run download "$run_id" -n kernel-test-serial-log -D "$ci_logs_dir" ||
     echo "note: no kernel-test-serial-log artifact on this run"
 
 kernel_elf="$bins_dir/build/UchosKernel"
-shell_bin="$bins_dir/userland/shell/shell"
-echo_bin="$bins_dir/userland/commands/echo/echo"
 if [ ! -f "$kernel_elf" ]; then
     echo "error: artifact did not contain build/UchosKernel" >&2
     exit 1
 fi
 
+# Every userland binary the run uploaded goes onto the smoke disk: the
+# artifact list (ci.yml smoke-debug-binaries) is the single source of
+# truth, so a service added there never gets silently left off the replay
+# disk (a hardcoded shell+echo list once turned a missing-pongd artifact
+# into a bogus "fails locally" verdict).
 smoke_bins=""
-if [ -f "$shell_bin" ] && [ -f "$echo_bin" ]; then
-    smoke_bins="$shell_bin $echo_bin"
-else
+if [ -d "$bins_dir/userland" ]; then
+    smoke_bins="$(find "$bins_dir/userland" -type f | sort | tr '\n' ' ')"
+    smoke_bins="${smoke_bins% }"
+fi
+if [ -z "$smoke_bins" ]; then
     echo "note: userland binaries missing from the artifact; kernel tests only"
 fi
 

--- a/userland/services/pongd/Makefile
+++ b/userland/services/pongd/Makefile
@@ -1,0 +1,6 @@
+TARGET = pongd
+OBJS = main.o
+
+include ../../Makefile.elf
+
+INCLUDES = -I./../../../

--- a/userland/services/pongd/main.cpp
+++ b/userland/services/pongd/main.cpp
@@ -1,0 +1,32 @@
+/**
+ * @file main.cpp
+ * @brief pongd: minimal ring-3 reference service (issue #315 3b-10)
+ *
+ * The first service launched from the boot manifest as a plain ELF, and
+ * the template every later ring-3 service (the FS in 3b-11) follows:
+ * block in receive_message, answer each request with reply_message. The
+ * reply carries "pong" — a fixed transformation, so a lost reply can
+ * never look like a pass to the smoke test.
+ */
+#include <cstring>
+#include <libs/common/message.hpp>
+#include <libs/user/ipc.hpp>
+
+int main()
+{
+	Message msg;
+	while (true) {
+		receive_message(&msg);
+		if (msg.type != MsgType::PONGD_PING) {
+			continue;
+		}
+
+		Message resp = make_request(MsgType::PONGD_PING);
+		const char pong[] = "pong";
+		memcpy(resp.data.write.buf, pong, sizeof(pong));
+		resp.result = OK;
+		reply_message(&msg, &resp);
+	}
+
+	return 0;
+}

--- a/userland/shell/main.cpp
+++ b/userland/shell/main.cpp
@@ -24,8 +24,21 @@ void run_smoke_test(Shell* s, Terminal* term)
 	char command[] = "echo smoke";
 	const error_t status = s->process_input(command, *term);
 
+	// One ping to pongd, the first manifest-launched ring-3 service: covers
+	// the ELF service boot path and the user-side reply path (issue #315
+	// 3b-10). The service answers "pong" — a transformation, so a lost
+	// reply leaves the zeroed request buffer behind and cannot pass.
+	Message ping = make_request(MsgType::PONGD_PING);
+	const Message pong = call(process_ids::PONGD, &ping);
+	error_t svc_status = OK;
+	if (IS_ERR(pong.result)) {
+		svc_status = pong.result;
+	} else if (strcmp(pong.data.write.buf, "pong") != 0) {
+		svc_status = ERR_INVALID_ARG;
+	}
+
 	Message report = make_request(MsgType::SMOKE_REPORT);
-	report.data.smoke.status = status;
+	report.data.smoke.status = IS_ERR(status) ? status : svc_status;
 	send_message(process_ids::KERNEL, &report);
 }
 


### PR DESCRIPTION
issue #315 Stage 3b-10「ring3 サービス起動基盤」の第 1 弾(全 4 分割の 10a)。

## 何をしたか

- **manifest エントリのバイナリ名化**: `InitialTaskInfo` に `binary` / `args` を追加。バイナリ名を持つエントリは汎用プロローグ `service_bootstrap()`(自分の manifest 行を task id で引く → FS_LOAD → `exec_elf`)で ring3 に転生する。shell 専用だった `shell_service()` は削除され、shell は宣言的エントリ第 1 号に
- **`userland/services/` を新設**し、極小のリファレンスサービス **pongd**(PONGD_PING に "pong" を返すだけ)を manifest から起動。3b-11 で FS サービスが従うテンプレート
- **libs/user に `reply_message()`(IPC_REPLY ラッパ)を追加**。これまで ring3 プロセスは RPC に応答する手段がなかった(カーネル側は実装済みだった)
- **煙テスト拡張**: shell -smoke が fork→exec→wait に加えて pongd へ 1 往復 ping し、結果を合算して SMOKE_REPORT。ELF サービス起動経路と user 側 reply 経路が CI で毎回証明される
- カーネル内部テスト追加: manifest が宣言スロットに pongd を起動したことの検証(`manifest_ring3_service_slot`)

## 設計判断とその理由

1. **汎用ブートストラップは manifest の自己参照方式**(entry は引数なし関数のため、`CURRENT_TASK->id` で自分の行を検索)。捨てた代替: entry を引数付きにする ABI 変更(create_task の全呼び出し元に波及)
2. **pongd は素通しエコーではなく固定変換(→"pong")**。call() が失敗するとリクエストの Message がそのまま残るため、素通しだと「送った文字列が返ってきた」ように見える偽 PASS が構造的に起きる。変換なら失敗はゼロ埋めバッファとして必ず露見する
3. **binary ⇔ service_bootstrap の対応を static_assert で強制**(片方だけ設定された死にフィールドをコンパイル時に拒否)
4. **FS 自己ホスト問題(FS 自身の ring3 化時に誰が FS の ELF を読むか)は本 PR では解かない**。最終工程で UchLoaderPkg のブートモジュール方式(UEFI が FAT を読める)を導入予定。捨てた代替: カーネルに最小 FAT リーダ残置(「カーネルを薄く」に反する)
5. pongd は smoke ビルド限定にせず常時起動(#ifdef でスロット連番 static_assert が壊れる複雑さ > 常駐 1 タスクのコスト。リファレンス実装としての教材価値もある)

## 実装者として危険だと思う箇所 top3

1. `kernel/services.cpp:115`(service_bootstrap の manifest 検索)— spawn 時のスロット不一致は LOG_ERROR のみで続行するため、万一ズレると**別サービスのバイナリを load して exec する**。既存の挙動を踏襲したが、不一致時に hlt すべきかは論点
2. `userland/shell/main.cpp:32`(smoke の call(PONGD))— pongd がディスクに無い/起動失敗だと call が永久ブロックし、watchdog タイムアウトでしか検出されない(シリアルに原因ログは出る)
3. `libs/user/ipc.cpp:35`(reply_message)— 応答先は `req->sender` を信頼している。IPC_SEND が sender を刻印しない現状では偽装 sender に応答が飛び得る。**10c(sender 刻印 + kernel-forwarded フラグ)で塞ぐ既知の穴**

## 触れた危険地帯

- `kernel/task/`(task.hpp の InitialTaskInfo、task.cpp の SCHEDULER_TASKS 初期化子のみ。スケジューラ・IPC 本体は不変)

## 検証

- カーネルビルド: 通常構成 + CI と同じ SMOKE 構成の両方 green
- lint.sh: 警告ゼロ
- **ローカルヘッドレス E2E(QEMU 6.2)**: `TEST_SUMMARY: total=111 passed=111 result=PASS` + `SMOKE_TEST: ... status=0 ... result=PASS`(pongd 往復込み)
- CI(24.04 / QEMU 8.2)はこの PR の Actions run で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
