### PR TITLE
fix(memory): slab/buddy/newlib-malloc をタスクプリエンプションから直列化する (issue #388)

### DIFF
--- a/kernel/memory/buddy_system.cpp
+++ b/kernel/memory/buddy_system.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include "bit_utils.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "log/log.hpp"
 #include "memory/page.hpp"
 
@@ -42,6 +43,11 @@ void BuddySystem::split_memory_block(int order)
 
 void* BuddySystem::allocate(size_t size)
 {
+	// free_lists_ and the page flags are shared by every task, and tasks are
+	// preempted mid-kernel; without this the slab grow path and a direct
+	// page allocation can interleave and corrupt the lists (issue #383)
+	kernel::interrupt::IrqGuard guard;
+
 	const int order = calculate_order(pages_for_bytes(size));
 	if (order == -1) {
 		LOG_ERROR("invalid size: %d", size);
@@ -86,6 +92,9 @@ void* BuddySystem::allocate(size_t size)
 
 void BuddySystem::free(void* addr, size_t size)
 {
+	// Same atomicity contract as allocate() (issue #383)
+	kernel::interrupt::IrqGuard guard;
+
 	auto* start_page = &pages[reinterpret_cast<uintptr_t>(addr) / PAGE_SIZE];
 	if (start_page->is_free()) {
 		LOG_ERROR("double free detected at address: %p", addr);

--- a/kernel/memory/slab.cpp
+++ b/kernel/memory/slab.cpp
@@ -10,6 +10,7 @@
 #include "bit_utils.hpp"
 #include "buddy_system.hpp"
 #include "heap_debug.hpp"
+#include "interrupt/irq_guard.hpp"
 #include "log/log.hpp"
 #include "page.hpp"
 
@@ -239,6 +240,12 @@ constexpr size_t MAX_ALLOC_SIZE = (1UL << MAX_ORDER) * PAGE_SIZE;
 
 void* alloc(size_t size, unsigned flags, int align)
 {
+	// Tasks are preempted mid-kernel (the timer switches even in syscall
+	// context), so every mutation of the cache/slab lists must be atomic
+	// against another task entering the allocator (issue #383): a lost
+	// free-list node surfaces later as "no free objects" on a partial slab.
+	kernel::interrupt::IrqGuard guard;
+
 	if (size == 0) {
 		LOG_ERROR("alloc: size must be non-zero");
 		return nullptr;
@@ -320,6 +327,9 @@ void free(void* addr)
 		return;
 	}
 
+	// Same atomicity contract as alloc() (issue #383)
+	kernel::interrupt::IrqGuard guard;
+
 #ifdef KERNEL_HEAP_DEBUG_ENABLED
 	// Validate the payload pointer, check its redzones, poison the object, and
 	// translate back to the raw slab object. A double/invalid free returns
@@ -367,6 +377,9 @@ bool is_slab_object_in_use(void* addr)
 	if (addr == nullptr) {
 		return false;
 	}
+
+	// Reads the same lists/tables the guarded alloc()/free() mutate
+	kernel::interrupt::IrqGuard guard;
 
 #ifdef KERNEL_HEAP_DEBUG_ENABLED
 	// A live payload pointer maps to its raw object; anything else falls

--- a/kernel/newlib_support.c
+++ b/kernel/newlib_support.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -7,6 +8,33 @@ void _exit(int status)
 	while (1) {
 		__asm__("hlt");
 	};
+}
+
+/*
+ * Newlib's malloc arena backs every std container node and printf buffer in
+ * the kernel, but tasks are preempted mid-kernel, so two tasks can interleave
+ * inside malloc/free and corrupt the arena (issue #383). Newlib serializes
+ * through these hooks (no-ops by default); on this single-processor kernel
+ * masking interrupts is the lock. The hooks may nest (newlib documents
+ * recursive acquisition), hence the depth counter.
+ */
+static int malloc_lock_depth;
+static int malloc_lock_if_was_set;
+
+void __malloc_lock(struct _reent* reent)
+{
+	uint64_t rflags;
+	__asm__ volatile("pushfq\n\tpopq %0\n\tcli" : "=r"(rflags) : : "memory");
+	if (malloc_lock_depth++ == 0) {
+		malloc_lock_if_was_set = (rflags & 0x200) != 0;
+	}
+}
+
+void __malloc_unlock(struct _reent* reent)
+{
+	if (--malloc_lock_depth == 0 && malloc_lock_if_was_set) {
+		__asm__ volatile("sti" : : : "memory");
+	}
 }
 
 caddr_t program_break, program_break_end;

--- a/kernel/tests/test_cases/memory_test.cpp
+++ b/kernel/tests/test_cases/memory_test.cpp
@@ -1,6 +1,7 @@
 #include "tests/test_cases/memory_test.hpp"
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <utility>
 #include "memory/bootstrap_allocator.hpp"
@@ -460,9 +461,62 @@ void test_unique_kbuf_null_is_safe()
 	ASSERT_FALSE(static_cast<bool>(empty));
 }
 
+namespace
+{
+uint64_t read_rflags()
+{
+	uint64_t rflags;
+	__asm__ volatile("pushfq\n\tpopq %0" : "=r"(rflags));
+	return rflags;
+}
+
+constexpr uint64_t RFLAGS_IF = 1UL << 9;
+} // namespace
+
+void test_heap_ops_preserve_interrupt_flag()
+{
+	// alloc()/free() and newlib malloc mask interrupts internally now
+	// (issue #388); the guards must RESTORE the caller's IF, never force
+	// it. A cli critical section that touches the heap would otherwise
+	// reopen an interrupt window in the middle of itself.
+	const bool entered_enabled = (read_rflags() & RFLAGS_IF) != 0;
+
+	__asm__ volatile("sti");
+	void* p = kernel::memory::alloc(64, kernel::memory::ALLOC_UNINITIALIZED);
+	const bool enabled_stays_enabled = (read_rflags() & RFLAGS_IF) != 0;
+	kernel::memory::free(p);
+	const bool enabled_after_free = (read_rflags() & RFLAGS_IF) != 0;
+
+	__asm__ volatile("cli");
+	void* q = kernel::memory::alloc(64, kernel::memory::ALLOC_UNINITIALIZED);
+	const bool masked_after_alloc = (read_rflags() & RFLAGS_IF) == 0;
+	kernel::memory::free(q);
+	const bool masked_after_free = (read_rflags() & RFLAGS_IF) == 0;
+	void* m = malloc(64);
+	const bool masked_after_malloc = (read_rflags() & RFLAGS_IF) == 0;
+	free(m);
+	const bool masked_after_libc_free = (read_rflags() & RFLAGS_IF) == 0;
+
+	if (entered_enabled) {
+		__asm__ volatile("sti");
+	}
+
+	ASSERT_NOT_NULL(p);
+	ASSERT_NOT_NULL(q);
+	ASSERT_NOT_NULL(m);
+	ASSERT_TRUE(enabled_stays_enabled);
+	ASSERT_TRUE(enabled_after_free);
+	ASSERT_TRUE(masked_after_alloc);
+	ASSERT_TRUE(masked_after_free);
+	ASSERT_TRUE(masked_after_malloc);
+	ASSERT_TRUE(masked_after_libc_free);
+}
+
 void register_slab_tests()
 {
 	test_register("slab_basic", test_slab_basic);
+	test_register("heap_ops_preserve_interrupt_flag",
+				  test_heap_ops_preserve_interrupt_flag);
 	test_register("cache_chain_walk_matches_size",
 				  test_cache_chain_walk_matches_size);
 	test_register("slab_list_invariants_across_burst",


### PR DESCRIPTION
issue #388 の修正。PR #392 の CI 失敗([run 30692908171](https://github.com/junyaU/uchos/actions/runs/30692908171))の根本原因で、#392 のブロッカー。

## 何が起きていたか(今回の実証)

- タイマー割り込みはカーネル/シスコール実行中のタスクも無条件に切り替えるが、slab の cache/slab リスト・buddy の free_lists・newlib malloc アリーナは**排他なしで全タスク共有**
- #392 の CI では、ブート時の確保バースト(shell の fork ページテーブル複製 + shell/pongd の ELF ロード + exec)が交錯し、**~1GB 空きがあるのに slab・ページテーブル割当が同時多発失敗** → fork 失敗・exec 失敗 → 暴走 panic
- **replay-first の判定**: CI の実バイナリはローカル QEMU 6.2 で PASS(コード・ツールチェーン無実、タイミング依存)。issue #388 の予言(「fork のページテーブル一括複製のような長い確保バーストの最中にタイマー切替 → リスト簿記の破壊」)と完全一致

## 何をしたか

- slab の `alloc()` / `free()` / `is_slab_object_in_use()` と buddy の `allocate()` / `free()` に `IrqGuard`([slab.cpp:247](kernel/memory/slab.cpp:247), [331](kernel/memory/slab.cpp:331), [382](kernel/memory/slab.cpp:382), [buddy_system.cpp:49](kernel/memory/buddy_system.cpp:49), [96](kernel/memory/buddy_system.cpp:96))
- `kernel/newlib_support.c` に `__malloc_lock` / `__malloc_unlock` を実装(cli ベースの再帰カウンタロック。newlib はこのフックで malloc を直列化する規約)
- 回帰テスト `heap_ops_preserve_interrupt_flag`: alloc/free/malloc/free が呼び出し元の IF 状態(有効・無効の両方)を正確に復元することを検証

パッチ本体は #383/#384 調査時に 24.04 スタックで動作確認済みのもの(検証ブランチの a5dd8b8)をそのまま採用。

## 設計判断とその理由

1. **単一プロセッサなので「割り込みマスク=ロック」**。スピンロック等は不要な複雑さ(捨てた代替案)。IrqGuard は既存・ネスト可・IF 復元保証
2. **newlib は独自ロックでなく規約フック(`__malloc_lock`)で直列化**。malloc 内部に触らない。再帰カウンタは newlib が再帰取得を規約上許すため必須
3. **決定的な再現テストは作れない**(単一 CPU でレースを決定的に再現する手段がない)。代わりに「ヒープ操作が IF を保存・復元する」という guard の存在証明をテスト化。実効の検証は #392 の CI 再走に委ねる

## 実装者として危険だと思う箇所 top3

1. [slab.cpp:247](kernel/memory/slab.cpp:247) — alloc の全経路(buddy grow 含む)が cli 区間になる。確保バースト中の割り込み遅延が伸びる(単一 CPU の短区間なので許容と判断)
2. [newlib_support.c:28](kernel/newlib_support.c:28) — `malloc_lock_depth` の再帰カウンタ。アンバランスな lock/unlock があると IF が復元されず沈黙死する(規約上 newlib が保証)
3. [buddy_system.cpp:96](kernel/memory/buddy_system.cpp:96) — free 側のガード。slab の free と入れ子になるが IrqGuard のネスト可設計で安全(復元は最外殻のみ)

## 触れた危険地帯

- `kernel/memory/`(slab・buddy 本体)

## 検証

- ローカルヘッドレス E2E(QEMU 6.2): `TEST_SUMMARY: total=111 passed=111 result=PASS`(新テスト込み)+ `SMOKE_TEST: result=PASS`
- lint 警告ゼロ
- マージ後、#392 の CI 再走で実環境(24.04)の実効を確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)